### PR TITLE
Add initial token server implementation in Go

### DIFF
--- a/cloud/token_server/main.go
+++ b/cloud/token_server/main.go
@@ -1,0 +1,145 @@
+// Copyright 2016 k8s-support Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//////////////////////////////////////////////////////////////////////////////
+
+// The token_server implements the epoxy extension API and provides a way for
+// machines booting with epoxy to allocate a k8s token, necessary for joining
+// the cluster.
+//
+// The
+//
+// To deploy the token_server, the ePoxy server must have an extension
+// registered that maps an operation name to this server, e.g.:
+//     "allocate_k8s_token" -> "http://localhost:8800/allocate_k8s_token"
+package main
+
+import (
+	"flag"
+	"log"
+	"math"
+	"net/http"
+	"os/exec"
+	"time"
+
+	"github.com/m-lab/epoxy/extension"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+)
+
+var (
+	fKubeadmCommand string
+
+	// requestDuration provides a histogram of processing times. The buckets should
+	// use periods that are intuitive for people.
+	//
+	// Provides metrics:
+	//   token_server_request_duration_seconds{code="...", le="..."}
+	//   ...
+	//   token_server_request_duration_seconds{code="..."}
+	//   token_server_request_duration_seconds{code="..."}
+	// Usage example:
+	requestDuration = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name: "token_server_request_duration_seconds",
+			Help: "Request status codes and execution times.",
+			Buckets: []float64{
+				0.001, 0.01, 0.1, 1.0, 5.0, 10.0, 30.0, 60.0, 120.0, 300.0, math.Inf(+1),
+			},
+		},
+		[]string{"method", "code"},
+	)
+
+	localGenerator tokenGenerator
+)
+
+func init() {
+	flag.StringVar(&fKubeadmCommand, "command", "/usr/bin/kubeadm",
+		"Absolute path to the kubeadm command used to create tokens")
+	prometheus.MustRegister(requestDuration)
+}
+
+// tokenGenerator defines the interface for creating tokens.
+type tokenGenerator interface {
+	Token(target string) ([]byte, error) // Generate a new token.
+}
+
+type k8sTokenGenerator struct {
+	Command string
+}
+
+// Token generates a new k8s token.
+func (g *k8sTokenGenerator) Token(target string) ([]byte, error) {
+	// Allocate the token for the given hostname.
+	cmd := exec.Command(
+		g.Command, "token", "create", "--ttl", "5m",
+		"--description", "Allow "+target+" to join the cluster")
+	return cmd.Output()
+}
+
+// allocateTokenHandler is an http.HandlerFunc for responding to an epoxy extension
+// Request.
+func allocateTokenHandler(w http.ResponseWriter, r *http.Request) {
+	// TODO: verify this is from a trusted source (admin or epoxy source)
+	// else return HTTP 401 (Unauthorized) and fire an alert (since this should never happen)
+
+	// Require requests to be POSTs.
+	if r.Method != http.MethodPost {
+		w.WriteHeader(http.StatusMethodNotAllowed)
+		// Write no response.
+		return
+	}
+
+	// Decode the extension request.
+	ext := &extension.Request{}
+	err := ext.Decode(r.Body)
+	if err != nil || ext.V1 == nil {
+		log.Println(err)
+		w.WriteHeader(http.StatusBadRequest)
+		// Write no response.
+		return
+	}
+	if time.Now().UTC().Sub(ext.V1.LastBoot) > 15*time.Minute {
+		// According to ePoxy the machine booted over 15 minutes ago, which is longer than we're willing to support.
+		w.WriteHeader(http.StatusRequestTimeout)
+		// Write no response.
+		return
+	}
+
+	log.Println("Request:", ext.Encode())
+
+	token, err := localGenerator.Token(ext.V1.Hostname)
+	if err != nil {
+		log.Println(err)
+		w.WriteHeader(http.StatusInternalServerError)
+		// Write no response.
+		return
+	}
+
+	// Write response to caller.
+	w.Header().Set("Content-Type", "text/plain; charset=us-ascii")
+	w.WriteHeader(http.StatusOK)
+	w.Write(token)
+}
+
+func main() {
+	flag.Parse()
+
+	localGenerator = &k8sTokenGenerator{fKubeadmCommand}
+
+	http.Handle("/metrics", promhttp.Handler())
+	http.HandleFunc("/allocate_k8s_token",
+		promhttp.InstrumentHandlerDuration(
+			requestDuration, http.HandlerFunc(allocateTokenHandler)))
+	log.Fatal(http.ListenAndServe(":8800", nil))
+}

--- a/cloud/token_server/main_test.go
+++ b/cloud/token_server/main_test.go
@@ -1,0 +1,141 @@
+// Copyright 2016 k8s-support Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//////////////////////////////////////////////////////////////////////////////
+
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/m-lab/epoxy/extension"
+)
+
+type fakeTokenGenerator struct {
+	token string
+}
+
+func (g *fakeTokenGenerator) Token(target string) ([]byte, error) {
+	if g.token == "" {
+		return nil, fmt.Errorf("Failing to generate token")
+	}
+	return []byte(g.token), nil
+}
+
+func Test_allocateTokenHandler(t *testing.T) {
+	tests := []struct {
+		name   string
+		method string
+		body   string
+		v1     *extension.V1
+		status int
+		token  string
+	}{
+		{
+			name:   "success",
+			method: "POST",
+			v1: &extension.V1{
+				Hostname:    "mlab1.foo01.measurement-lab.org",
+				IPv4Address: "192.168.1.1",
+				LastBoot:    time.Now().UTC().Add(-5 * time.Minute),
+			},
+			status: http.StatusOK,
+			token:  "012345.abcdefghijklmnop",
+		},
+		{
+			name:   "failure-bad-method",
+			method: "GET",
+			status: http.StatusMethodNotAllowed,
+		},
+		{
+			name:   "failure-bad-requested",
+			method: "POST",
+			v1:     nil,
+			status: http.StatusBadRequest,
+		},
+		{
+			name:   "failure-last-boot-too-old",
+			method: "POST",
+			v1: &extension.V1{
+				Hostname:    "mlab1.foo01.measurement-lab.org",
+				IPv4Address: "192.168.1.1",
+				LastBoot:    time.Now().UTC().Add(-16 * time.Minute),
+			},
+			status: http.StatusRequestTimeout,
+		},
+		{
+			name:   "failure-failure-to-generate-token",
+			method: "POST",
+			v1: &extension.V1{
+				Hostname:    "mlab1.foo01.measurement-lab.org",
+				IPv4Address: "192.168.1.1",
+				LastBoot:    time.Now().UTC().Add(-5 * time.Minute),
+			},
+			status: http.StatusInternalServerError,
+			token:  "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			localGenerator = &fakeTokenGenerator{token: tt.token}
+			ext := extension.Request{V1: tt.v1}
+			req := httptest.NewRequest(
+				tt.method, "/allocate_k8s_token", strings.NewReader(ext.Encode()))
+			rec := httptest.NewRecorder()
+
+			allocateTokenHandler(rec, req)
+
+			if tt.status != rec.Code {
+				t.Errorf("allocateTokenHandler() bad status code: got %d; want %d",
+					rec.Code, tt.status)
+			}
+			if rec.Body.String() != tt.token {
+				t.Errorf("allocateTokenHandler() bad token returned: got %q; want %q",
+					rec.Body.String(), tt.token)
+			}
+		})
+	}
+}
+
+func Test_k8sTokenGenerator_Token(t *testing.T) {
+	tests := []struct {
+		name     string
+		command  string
+		response string
+	}{
+		{
+			name:     "success",
+			command:  "/bin/echo",
+			response: "token create --ttl 5m --description Allow test to join the cluster\n",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := &k8sTokenGenerator{
+				Command: tt.command,
+			}
+			got, err := g.Token("test")
+			if err != nil {
+				t.Fatalf("k8sTokenGenerator.Token() = %q, want nil", err)
+			}
+			if string(got) != tt.response {
+				t.Errorf("k8sTokenGenerator.Token() = %q, want %q", got, tt.response)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This change adds an initial version of the k8s token server that supports the epoxy extension receiver API.

