### PR TITLE
Add the k8s master to the epoxy-extension network by default

### DIFF
--- a/cloud/setup_cloud_k8s_master.sh
+++ b/cloud/setup_cloud_k8s_master.sh
@@ -43,6 +43,7 @@ gcloud compute instances create "${GCE_NAME}" \
   --boot-disk-size "10" \
   --boot-disk-type "pd-standard" \
   --boot-disk-device-name "${GCE_NAME}"  \
+  --network "epoxy-extension-private-network" \
   --tags "dmz" \
   --machine-type "n1-standard-2" \
   --address "${EXTERNAL_IP}"


### PR DESCRIPTION
In order for the epoxy server to contact the k8s token server over a private network, the k8s master VM must be placed on that network at creation time.

This change adds a new parameter to the k8s master VM creation that specifies the network name.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/35)
<!-- Reviewable:end -->
