### PR TITLE
Add Dockerfile to build token_server container

### DIFF
--- a/cloud/token_server/Dockerfile
+++ b/cloud/token_server/Dockerfile
@@ -1,0 +1,4 @@
+FROM golang:1.10
+ADD . /go/src/github.com/m-lab/k8s-support/cloud/token_server
+RUN go get -v github.com/m-lab/k8s-support/cloud/token_server
+ENTRYPOINT ["/go/bin/token_server"]


### PR DESCRIPTION
This change adds a simple Dockerfile to build the token_server as a container to run alongside the k8s master services.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/37)
<!-- Reviewable:end -->
