### PR TITLE
Start k8s-token-server when installing k8s master

### DIFF
--- a/cloud/setup_cloud_k8s_master.sh
+++ b/cloud/setup_cloud_k8s_master.sh
@@ -87,7 +87,7 @@ gcloud compute ssh "${GCE_NAME}" <<-\EOF
   # Run the k8s-token-server (supporting the ePoxy Extension API), such that:
   #
   #   1) the host root (/) is mounted read-only in the container as /ro
-  #   2) the host etc (/etc) is mounte read-only as the container's /etc
+  #   2) the host etc (/etc) is mounted read-only as the container's /etc
   #
   # The first gives access the kubeadm command.
   # The second gives kubeadm read access to /etc/kubernetes/admin.conf.

--- a/cloud/setup_cloud_k8s_master.sh
+++ b/cloud/setup_cloud_k8s_master.sh
@@ -15,8 +15,8 @@ set -euxo pipefail
 PROJECT=${GOOGLE_CLOUD_PROJECT:-mlab-sandbox}
 REGION=${GOOGLE_CLOUD_REGION:-us-central1}
 ZONE=${GOOGLE_CLOUD_ZONE:-us-central1-c}
-GCE_NAME=${K8S_GCE_MASTER:-soltesz-test-delete-after-2018-07}
-IP_NAME=${K8S_GCE_MASTER_IP:-soltesz-test-delete-after-2018-07-ip}
+GCE_NAME=${K8S_GCE_MASTER:-k8s-platform-master}
+IP_NAME=${K8S_GCE_MASTER_IP:-k8s-platform-master-ip}
 
 # Add gcloud to PATH.
 # Next line is a pragma directive telling the linter to skip path.bash.inc

--- a/cloud/token_server/main.go
+++ b/cloud/token_server/main.go
@@ -37,6 +37,7 @@ import (
 
 var (
 	fKubeadmCommand string
+	fPort           string
 
 	// requestDuration provides a histogram of processing times. The buckets should
 	// use periods that are intuitive for people.
@@ -64,6 +65,8 @@ var (
 func init() {
 	flag.StringVar(&fKubeadmCommand, "command", "/usr/bin/kubeadm",
 		"Absolute path to the kubeadm command used to create tokens")
+	flag.StringVar(&fPort, "port", "8800",
+		"Accept connection on this port.")
 	prometheus.MustRegister(requestDuration)
 }
 
@@ -140,5 +143,5 @@ func main() {
 	http.HandleFunc("/v1/allocate_k8s_token",
 		promhttp.InstrumentHandlerDuration(
 			requestDuration, http.HandlerFunc(allocateTokenHandler)))
-	log.Fatal(http.ListenAndServe(":8800", nil))
+	log.Fatal(http.ListenAndServe(":"+fPort, nil))
 }


### PR DESCRIPTION
This change adds a command to `setup_cloud_k8s_master.sh` that starts the k8s-token-server docker image such that it can run `kubeadm token create` commands.

This change also includes a simple change to the token server so the port can be specified as a command line parameter.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/38)
<!-- Reviewable:end -->
