### PR TITLE
Demo updates

### DIFF
--- a/k8s/daemonsets/experiments/ndt-cloud-with-fast-sidestream.yml
+++ b/k8s/daemonsets/experiments/ndt-cloud-with-fast-sidestream.yml
@@ -37,7 +37,7 @@ spec:
         mlab/type: 'platform'
       containers:
       - name: ndt-cloud
-        image: measurementlab/ndt-cloud:v0.2
+        image: measurementlab/ndt-cloud:v0.3
         ports:
         - containerPort: 3010
         - containerPort: 9090
@@ -58,18 +58,21 @@ spec:
         - name: fast-sidestream-data
           mountPath: /home
       - name: pusher
-        image: measurementlab/pusher:v1
+        image: measurementlab/pusher:v1.0
         env:
         - name: DIRECTORY
           value: /var/spool/fast-sidestream
         - name: GOOGLE_APPLICATION_CREDENTIALS
           value: /etc/credentials/pusher.json
         - name: BUCKET
-          value: dropbox-mlab-sandbox
+          valueFrom:
+            configMapKeyRef:
+              name: pusher-dropbox
+              key: bucket
         - name: EXPERIMENT
           value: fast-sidestream
         - name: ARCHIVE_SIZE_THRESHOLD
-          value: 1MB
+          value: 10MB
         # TODO: specify the node & site names using kubernetes magic.
         volumeMounts:
         - name: fast-sidestream-data

--- a/manage-cluster/network/common.yml
+++ b/manage-cluster/network/common.yml
@@ -112,6 +112,8 @@ data:
   # This file should not contain any index2ip stuff. It is the backup config
   # for when multus isn't working or a pod is not tagged with any network
   # stuff.
+  # TODO: remove index2ip after resolving
+  # https://github.com/m-lab/k8s-support/issues/69
   platform-node-cni-conf.json: |
     {
       "name": "multus-network",
@@ -125,6 +127,14 @@ data:
             "isDefaultGateway": false
           },
           "masterplugin": true
+        },
+        {
+           "name": "ipvlan",
+           "type": "ipvlan",
+           "master": "eth0",
+           "ipam": {
+             "type": "index2ip"
+           }
         }
       ]
     }


### PR DESCRIPTION
This change updates the experiment ndt-cloud-with-fast-sidestream.yml to use the lastest version of ndt-cloud as well as the reviewed version of pusher and supports deploying to multiple projects (e.g. mlab-sandbox or mlab-staging).

As well, the cluster network configuration now includes a delegate for index2ip to work around a functional regression in later versions of k8s after v1.10. -- `manage-cluster/network/common.yml` This change should be removed once https://github.com/m-lab/k8s-support/issues/69 is resolved.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/70)
<!-- Reviewable:end -->
