### PR TITLE
Update pusher version to use nodeName, give tcp-info a monitoring port

### DIFF
--- a/k8s/daemonsets/experiments/ndt-cloud-with-fast-sidestream.yml
+++ b/k8s/daemonsets/experiments/ndt-cloud-with-fast-sidestream.yml
@@ -54,11 +54,14 @@ spec:
           readOnly: true
       - name: fast-sidestream
         image: measurementlab/tcp-info:latest
+        args:
+         - /usr/local/bin/tcp-info
+         - -prom=9797
         volumeMounts:
         - name: fast-sidestream-data
           mountPath: /home
       - name: pusher
-        image: measurementlab/pusher:v1.0
+        image: measurementlab/pusher:v1.1
         env:
         - name: DIRECTORY
           value: /var/spool/fast-sidestream
@@ -73,6 +76,11 @@ spec:
           value: fast-sidestream
         - name: ARCHIVE_SIZE_THRESHOLD
           value: 10MB
+        - name: MLAB_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+
         # TODO: specify the node & site names using kubernetes magic.
         volumeMounts:
         - name: fast-sidestream-data


### PR DESCRIPTION
This change updates the ndt-cloud-with-fast-sidestream.yml daemonset. Now pusher learns the node name from the local environment and tcp-info gets a new argument for prometheus monitoring.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/71)
<!-- Reviewable:end -->
