### PR TITLE
Update tcp-info calling convention

### DIFF
--- a/k8s/daemonsets/experiments/ndt-cloud-with-fast-sidestream.yml
+++ b/k8s/daemonsets/experiments/ndt-cloud-with-fast-sidestream.yml
@@ -55,7 +55,6 @@ spec:
       - name: fast-sidestream
         image: measurementlab/tcp-info:prod-v0.0.1a
         args:
-         - /usr/local/bin/tcp-info
          - -prom=9797
         volumeMounts:
         - name: fast-sidestream-data


### PR DESCRIPTION
The previous args list was necessary to start tcp-info with flags when the Dockerfile used `CMD`.

After the Dockerfile was updated to use `ENTRYPOINT` the first parameter causes flag parsing to fail and the subsequent flags to be ignored.

This change updates the tcp-info args to work with a container using `ENTRYPOINT`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/74)
<!-- Reviewable:end -->
