### PR TITLE
Multiple index2ip networks. Makes central config longer, eases the config burden on each experiment.

### DIFF
--- a/k8s/daemonsets/experiments/ndt-cloud-with-fast-sidestream.yml
+++ b/k8s/daemonsets/experiments/ndt-cloud-with-fast-sidestream.yml
@@ -1,7 +1,7 @@
 apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
-  name: ndt-cloud-index2
+  name: ndt-cloud
   namespace: default
 spec:
   selector:
@@ -15,7 +15,7 @@ spec:
         prometheus.io/scrape: 'true'
         networks: '[
           { "name": "flannel-conf" },
-          { "name": "index2ip-conf" } ]'
+          { "name": "index2ip-index-2-conf" } ]'
     spec:
 
       # The default grace period after k8s sends SIGTERM is 30s. We extend the
@@ -55,7 +55,7 @@ spec:
       - name: fast-sidestream
         image: measurementlab/tcp-info:prod-v0.0.1a
         args:
-         - -prom=9797
+        - -prom=9797
         volumeMounts:
         - name: fast-sidestream-data
           mountPath: /home
@@ -89,7 +89,8 @@ spec:
           readOnly: true
 
       initContainers:
-      # TODO: this is a hack. Remove the hack by fixing the content of resolv.conf
+      # TODO: this is a hack. Remove the hack by fixing the contents of
+      # resolv.conf
       - name: fix-resolv-conf
         image: busybox
         command: ['sh', '-c', 'echo "nameserver 8.8.8.8" > /etc/resolv.conf']

--- a/k8s/daemonsets/experiments/ndt-cloud.yml
+++ b/k8s/daemonsets/experiments/ndt-cloud.yml
@@ -1,7 +1,7 @@
 apiVersion: extensions/v1beta1
 kind: DaemonSet
 metadata:
-  name: ndt-cloud-index2
+  name: ndt-cloud
   namespace: default
 spec:
   selector:
@@ -15,7 +15,7 @@ spec:
         prometheus.io/scrape: 'true'
         networks: '[
           { "name": "flannel-conf" },
-          { "name": "index2ip-conf" } ]'
+          { "name": "index2ip-index-2-conf" } ]'
     spec:
 
       # The default grace period after k8s sends SIGTERM is 30s. We extend the

--- a/manage-cluster/network/common.yml
+++ b/manage-cluster/network/common.yml
@@ -112,8 +112,6 @@ data:
   # This file should not contain any index2ip stuff. It is the backup config
   # for when multus isn't working or a pod is not tagged with any network
   # stuff.
-  # TODO: remove index2ip after resolving
-  # https://github.com/m-lab/k8s-support/issues/69
   platform-node-cni-conf.json: |
     {
       "name": "multus-network",
@@ -127,14 +125,6 @@ data:
             "isDefaultGateway": false
           },
           "masterplugin": true
-        },
-        {
-           "name": "ipvlan",
-           "type": "ipvlan",
-           "master": "eth0",
-           "ipam": {
-             "type": "index2ip"
-           }
         }
       ]
     }

--- a/manage-cluster/network/multus.yml
+++ b/manage-cluster/network/multus.yml
@@ -16,13 +16,179 @@ args: '[ {
 apiVersion: "kubernetes.com/v1"
 kind: Network
 metadata:
- name: index2ip-conf
-plugin: index2ip
+ name: index2ip-index-1-conf
+plugin: index2ip-index-1
 args: '[ {
            "name": "ipvlan",
            "type": "ipvlan",
            "master": "eth0",
            "ipam": {
-             "type": "index2ip"
+             "type": "index2ip",
+             "index": 1
+           }
+         } ]'
+---
+apiVersion: "kubernetes.com/v1"
+kind: Network
+metadata:
+ name: index2ip-index-2-conf
+plugin: index2ip-index-2
+args: '[ {
+           "name": "ipvlan",
+           "type": "ipvlan",
+           "master": "eth0",
+           "ipam": {
+             "type": "index2ip",
+             "index": 2
+           }
+         } ]'
+---
+apiVersion: "kubernetes.com/v1"
+kind: Network
+metadata:
+ name: index2ip-index-3-conf
+plugin: index2ip-index-3
+args: '[ {
+           "name": "ipvlan",
+           "type": "ipvlan",
+           "master": "eth0",
+           "ipam": {
+             "type": "index2ip",
+             "index": 3
+           }
+         } ]'
+---
+apiVersion: "kubernetes.com/v1"
+kind: Network
+metadata:
+ name: index2ip-index-4-conf
+plugin: index2ip-index-4
+args: '[ {
+           "name": "ipvlan",
+           "type": "ipvlan",
+           "master": "eth0",
+           "ipam": {
+             "type": "index2ip",
+             "index": 4
+           }
+         } ]'
+---
+apiVersion: "kubernetes.com/v1"
+kind: Network
+metadata:
+ name: index2ip-index-5-conf
+plugin: index2ip-index-5
+args: '[ {
+           "name": "ipvlan",
+           "type": "ipvlan",
+           "master": "eth0",
+           "ipam": {
+             "type": "index2ip",
+             "index": 5
+           }
+         } ]'
+---
+apiVersion: "kubernetes.com/v1"
+kind: Network
+metadata:
+ name: index2ip-index-6-conf
+plugin: index2ip-index-6
+args: '[ {
+           "name": "ipvlan",
+           "type": "ipvlan",
+           "master": "eth0",
+           "ipam": {
+             "type": "index2ip",
+             "index": 6
+           }
+         } ]'
+---
+apiVersion: "kubernetes.com/v1"
+kind: Network
+metadata:
+ name: index2ip-index-7-conf
+plugin: index2ip-index-7
+args: '[ {
+           "name": "ipvlan",
+           "type": "ipvlan",
+           "master": "eth0",
+           "ipam": {
+             "type": "index2ip",
+             "index": 7
+           }
+         } ]'
+---
+apiVersion: "kubernetes.com/v1"
+kind: Network
+metadata:
+ name: index2ip-index-8-conf
+plugin: index2ip-index-8
+args: '[ {
+           "name": "ipvlan",
+           "type": "ipvlan",
+           "master": "eth0",
+           "ipam": {
+             "type": "index2ip",
+             "index": 8
+           }
+         } ]'
+---
+apiVersion: "kubernetes.com/v1"
+kind: Network
+metadata:
+ name: index2ip-index-9-conf
+plugin: index2ip-index-9
+args: '[ {
+           "name": "ipvlan",
+           "type": "ipvlan",
+           "master": "eth0",
+           "ipam": {
+             "type": "index2ip",
+             "index": 9
+           }
+         } ]'
+---
+apiVersion: "kubernetes.com/v1"
+kind: Network
+metadata:
+ name: index2ip-index-10-conf
+plugin: index2ip-index-10
+args: '[ {
+           "name": "ipvlan",
+           "type": "ipvlan",
+           "master": "eth0",
+           "ipam": {
+             "type": "index2ip",
+             "index": 10
+           }
+         } ]'
+---
+apiVersion: "kubernetes.com/v1"
+kind: Network
+metadata:
+ name: index2ip-index-11-conf
+plugin: index2ip-index-11
+args: '[ {
+           "name": "ipvlan",
+           "type": "ipvlan",
+           "master": "eth0",
+           "ipam": {
+             "type": "index2ip",
+             "index": 11
+           }
+         } ]'
+---
+apiVersion: "kubernetes.com/v1"
+kind: Network
+metadata:
+ name: index2ip-index-12-conf
+plugin: index2ip-index-12
+args: '[ {
+           "name": "ipvlan",
+           "type": "ipvlan",
+           "master": "eth0",
+           "ipam": {
+             "type": "index2ip",
+             "index": 12
            }
          } ]'


### PR DESCRIPTION
Create multiple index2ip networks. Makes central config longer, eases the config burden on each experiment. Now to claim a particular IP, no arguments need to be passed to index2ip from the pod and the pod's name does not need to be special.

Updates the network declarations to create 12 networks.
Updates the dameonsets to use those new networks.
Remove index2ip from the default cni config. (Possible now that Nathan has addressed #69 )

Clean up a few YAML lint errors along the way.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/77)
<!-- Reviewable:end -->
