### PR TITLE
Frankenstein PR

### DIFF
--- a/k8s/deployments/prometheus.yml
+++ b/k8s/deployments/prometheus.yml
@@ -20,6 +20,7 @@ spec:
       serviceAccountName: prometheus
       nodeSelector:
         mlab/type: cloud
+        prometheus-node: 'true'
       containers:
       - name: prometheus-server
         image: prom/prometheus:v2.4.2

--- a/k8s/deployments/prometheus.yml
+++ b/k8s/deployments/prometheus.yml
@@ -20,11 +20,10 @@ spec:
       serviceAccountName: prometheus
       nodeSelector:
         mlab/type: cloud
-        prometheus-node: 'true'
       containers:
       - name: prometheus-server
-        image: prom/prometheus:v2.3.1
-        args: ["--config.file=/etc/prometheus/prometheus-config.yml",
+        image: prom/prometheus:v2.4.2
+        args: ["--config.file=/etc/prometheus/prometheus.yml",
                "--web.enable-lifecycle"]
         ports:
         - containerPort: 9090

--- a/k8s/services/prometheus.yml
+++ b/k8s/services/prometheus.yml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus-service
+  namespace: default
+spec:
+  ports:
+  - port: 9090
+    protocol: TCP
+    targetPort: 9090
+  selector:
+    # Pods with labels matching this key/value pair will be publically
+    # accessible through the service IP and port.
+    run: prometheus-server
+  sessionAffinity: None
+  type: ClusterIP

--- a/manage-cluster/cloud-provider.conf.template
+++ b/manage-cluster/cloud-provider.conf.template
@@ -1,0 +1,61 @@
+# Configuration derived from:
+# https://github.com/kubernetes/kubernetes/blob/master/pkg/cloudprovider/providers/gce/gce.go#L162
+
+[global]
+
+# TokenURL string
+;token-url=
+
+# TokenBody string
+;token-body=
+
+# ProjectID and NetworkProjectID can either be the numeric or string-based
+# unique identifier that starts with [a-z].
+project-id={{PROJECT}}
+
+# NetworkProjectID refers to the project which owns the network being used.
+network-project-id={{PROJECT}}
+
+# NetworkName string
+network-name={{GCE_NETWORK}}
+
+# SubnetworkName string
+subnetwork-name={{GCE_SUBNET}}
+
+# SecondaryRangeName is the name of the secondary range to allocate IP
+# aliases. The secondary range must be present on the subnetwork the
+# cluster is attached to.
+;secondary-range-name=
+
+# NodeTags []string
+;node-tags=
+
+# NodeInstancePrefix string
+;node-instance-prefix=
+
+# Regional bool
+;regional=
+
+# Multizone bool
+;multizone=
+
+# ApiEndpoint is the GCE compute API endpoint to use. If this is blank,
+# then the default endpoint is used.
+# ApiEndpoint string
+;api-endpoint=
+
+# ContainerApiEndpoint is the GCE container API endpoint to use. If this is blank,
+# then the default endpoint is used.
+# ContainerApiEndpoint string
+;container-api-endpoint=
+
+# LocalZone specifies the GCE zone that gce cloud client instance is
+# located in (i.e. where the controller will be running). If this is
+# blank, then the local zone will be discovered via the metadata server.
+# LocalZone string
+;local-zone=
+
+# Default to none.
+# For example: MyFeatureFlag
+# AlphaFeatures []string
+;alpha-features=

--- a/manage-cluster/k8s_deploy.conf
+++ b/manage-cluster/k8s_deploy.conf
@@ -5,7 +5,9 @@ GCE_DISK_SIZE="100"
 GCE_DISK_TYPE="pd-standard"
 GCE_NETWORK="mlab-platform-network"
 GCE_K8S_SUBNET="kubernetes"
+GCE_K8S_SUBNET_RANGE="10.0.0.0/16"
 GCE_EPOXY_SUBNET="epoxy"
+GCE_EPOXY_SUBNET_RANGE="10.1.0.0/16"
 GCE_NET_TAGS="k8s-platform-master" # Comma separate list
 GCE_TYPE="n1-standard-4"
 

--- a/manage-cluster/kubeadm-config.yml.template
+++ b/manage-cluster/kubeadm-config.yml.template
@@ -11,7 +11,7 @@ nodeRegistration:
     key: node-role.kubernetes.io/master
   kubeletExtraArgs:
     cloud-provider: "gce"
-    cloud-config: "/etc/kubernetes/cloud.conf"
+    cloud-config: "/etc/kubernetes/cloud-provider.conf"
 ---
 apiVersion: kubeadm.k8s.io/v1alpha3
 kind: ClusterConfiguration
@@ -20,11 +20,11 @@ apiServerCertSANs:
 - {{LOAD_BALANCER_NAME}}.{{PROJECT}}.measurementlab.net
 apiServerExtraArgs:
   cloud-provider: "gce"
-  cloud-config: "/etc/kubernetes/cloud.conf"
+  cloud-config: "/etc/kubernetes/cloud-provider.conf"
 apiServerExtraVolumes:
 - name: cloud
-  hostPath: "/etc/kubernetes/cloud.conf"
-  mountPath: "/etc/kubernetes/cloud.conf"
+  hostPath: "/etc/kubernetes/cloud-provider.conf"
+  mountPath: "/etc/kubernetes/cloud-provider.conf"
 auditPolicy:
   logDir: /var/log/kubernetes/audit
   logMaxAge: 2
@@ -35,11 +35,11 @@ controlPlaneEndpoint: {{LOAD_BALANCER_NAME}}.{{PROJECT}}.measurementlab.net:6443
 controllerManagerExtraArgs:
   node-cidr-mask-size: "26"
   cloud-provider: "gce"
-  cloud-config: "/etc/kubernetes/cloud.conf"
+  cloud-config: "/etc/kubernetes/cloud-provider.conf"
 controllerManagerExtraVolumes:
 - name: cloud
-  hostPath: "/etc/kubernetes/cloud.conf"
-  mountPath: "/etc/kubernetes/cloud.conf"
+  hostPath: "/etc/kubernetes/cloud-provider.conf"
+  mountPath: "/etc/kubernetes/cloud-provider.conf"
 etcd:
   local:
     dataDir: /var/lib/etcd

--- a/manage-cluster/kubeadm-config.yml.template
+++ b/manage-cluster/kubeadm-config.yml.template
@@ -9,6 +9,9 @@ nodeRegistration:
   taints:
   - effect: NoSchedule
     key: node-role.kubernetes.io/master
+  kubeletExtraArgs:
+    cloud-provider: "gce"
+    cloud-config: "/etc/kubernetes/cloud.conf"
 ---
 apiVersion: kubeadm.k8s.io/v1alpha3
 kind: ClusterConfiguration

--- a/manage-cluster/kubeadm-config.yml.template
+++ b/manage-cluster/kubeadm-config.yml.template
@@ -18,6 +18,13 @@ kind: ClusterConfiguration
 kubernetesVersion: v{{K8S_VERSION}}
 apiServerCertSANs:
 - {{LOAD_BALANCER_NAME}}.{{PROJECT}}.measurementlab.net
+apiServerExtraArgs:
+  cloud-provider: "gce"
+  cloud-config: "/etc/kubernetes/cloud.conf"
+apiServerExtraVolumes:
+- name: cloud
+  hostPath: "/etc/kubernetes/cloud.conf"
+  mountPath: "/etc/kubernetes/cloud.conf"
 auditPolicy:
   logDir: /var/log/kubernetes/audit
   logMaxAge: 2
@@ -27,6 +34,12 @@ clusterName: kubernetes
 controlPlaneEndpoint: {{LOAD_BALANCER_NAME}}.{{PROJECT}}.measurementlab.net:6443
 controllerManagerExtraArgs:
   node-cidr-mask-size: "26"
+  cloud-provider: "gce"
+  cloud-config: "/etc/kubernetes/cloud.conf"
+controllerManagerExtraVolumes:
+- name: cloud
+  hostPath: "/etc/kubernetes/cloud.conf"
+  mountPath: "/etc/kubernetes/cloud.conf"
 etcd:
   local:
     dataDir: /var/lib/etcd

--- a/manage-cluster/setup_cloud_k8s_master.sh
+++ b/manage-cluster/setup_cloud_k8s_master.sh
@@ -62,7 +62,7 @@ fi
 GCP_ARGS=("--project=${PROJECT}" "--quiet")
 
 #
-# DELETE ANY EXISTING OBJECTS
+# DELETE ANY EXISTING GCP OBJECTS
 #
 # This script assumes you want to start totally fresh.
 
@@ -190,6 +190,32 @@ for zone in $GCE_ZONES; do
   fi
 done
 
+EXISTING_K8S_SUBNET=$(gcloud compute networks list \
+    --network "${GCE_NETWORK}" \
+    --filter "name=${GCE_K8S_SUBNET}" \
+    --format "value(name)" \
+    "${GCP_ARGS[@]}" || true)
+if [[ -n "${EXISTING_K8S_SUBNET}" ]]; then
+  gcloud compute networks subnets delete "${GCE_K8S_SUBNET}" "${GCP_ARGS[@]}"
+fi
+
+EXISTING_EPOXY_SUBNET=$(gcloud compute networks list \
+    --network "${GCE_NETWORK}" \
+    --filter "name=${GCE_EPOXY_SUBNET}" \
+    --format "value(name)" \
+    "${GCP_ARGS[@]}" || true)
+if [[ -n "${EXISTING_EPOXY_SUBNET}" ]]; then
+  gcloud compute networks subnets delete "${GCE_EPOXY_SUBNET}" "${GCP_ARGS[@]}"
+fi
+
+EXISTING_NETWORK=$(gcloud compute networks list \
+    --filter "name=${GCE_NETWORK}" \
+    --format "value(name)" \
+    "${GCP_ARGS[@]}" || true)
+if [[ -n "${EXISTING_NETWORK}" ]]; then
+  gcloud compute networks delete "${GCE_NETWORK}" "${GCP_ARGS[@]}"
+fi
+
 # If $DELETE_ONLY is set to "yes", then exit now.
 if [[ "${DELETE_ONLY}" == "yes" ]]; then
   echo "DELETE_ONLY set to 'yes'. All GCP objects deleted. Exiting."
@@ -199,6 +225,21 @@ fi
 #
 # CREATE NEW CLUSTER
 #
+
+# Create the VPC network and subnets.
+gcloud compute networks create "${GCE_NETWORK}" \
+    --subnet-mode custom \
+    "${GCP_ARGS[@]}"
+gcloud compute networks subnets create "${GCE_K8S_SUBNET}" \
+    --network "${GCE_NETWORK}" \
+    --range "${GCE_K8S_SUBNET_RANGE}" \
+    --region "${GCE_REGION}" \
+    "${GCP_ARGS[@]}"
+gcloud compute networks subnets create "${GCE_EPOXY_SUBNET}" \
+    --network "${GCE_NETWORK}" \
+    --range "${GCE_EPOXY_SUBNET_RANGE}" \
+    --region "${GCE_REGION}" \
+    "${GCP_ARGS[@]}"
 
 # EXTERNAL LOAD BALANCER
 #

--- a/manage-cluster/setup_cloud_k8s_master.sh
+++ b/manage-cluster/setup_cloud_k8s_master.sh
@@ -617,10 +617,6 @@ for zone in $GCE_ZONES; do
     # Create a suitable cloud-config file for the cloud provider.
     echo -e "[Global]\nproject-id = ${PROJECT}\n" > /etc/kubernetes/cloud.conf
 
-    # Sets the kubelet's cloud provider config to gce and points to a suitable config file.
-    echo 'KUBELET_EXTRA_ARGS="--cloud-provider=gce --cloud-config=/etc/kubernetes/cloud.conf"' > \
-        /etc/default/kubelet
-
     # We have run up against "no space left on device" errors, when clearly
     # there is plenty of free disk space. It seems this could likely be related
     # to this:

--- a/manage-cluster/setup_cloud_k8s_master.sh
+++ b/manage-cluster/setup_cloud_k8s_master.sh
@@ -630,6 +630,15 @@ for zone in $GCE_ZONES; do
     echo fs.inotify.max_user_watches=131072 >> /etc/sysctl.conf
     sysctl -p
 
+    # We have run up against "no space left on device" errors, when clearly
+    # there is plenty of free disk space. It seems this could likely be related
+    # to this:
+    # https://github.com/kubernetes/kubernetes/issues/7815#issuecomment-124566117
+    # To be sure we don't hit the limit of fs.inotify.max_user_watches, increase
+    # it from the default of 8192.
+    echo fs.inotify.max_user_watches=32768 >> /etc/sysctl.conf
+    sysctl -p
+
     systemctl daemon-reload
     systemctl restart kubelet
 EOF


### PR DESCRIPTION
* Adds a k8s service manifest for Prometheus. This will need changing once/if we figure out how to enable an external load-balancer.
* Bumps `fs.inotify.max_user_watches` to 32768.
* Deletes/creates platform VPC network and subnets.
* Bumps Prom version to 2.4.2.
* Adds a new cloud.conf template (as yet unused).
* Adds cloud provider configs to kubeadm configuration file.
* Adds variables for k8s and epoxy subnet CIDRs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/80)
<!-- Reviewable:end -->
