### PR TITLE
Fixes, enhancements and cleanups

### DIFF
--- a/apply_k8s.sh
+++ b/apply_k8s.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+USAGE="USAGE: $0 <google-cloud-project>"
+PROJECT=${1:?Please specify the google cloud project: $USAGE}
+
+# Apply Secrets
+#
+# TODO: figure out how to apply secrets automatically. For now these should be
+# applied manually before anything else.
+#
+# If you don't know where to find a copy of pusher.json, then you may need to go
+# into the pusher-dropbox-writer service account and generate a new JSON
+# authentication key.
+#
+# Ask an Ops person how to find the NDT TLS certificate and private key.  Once
+# in hand, you'll need to create a directory named ndt-tls/ and drop they key in
+# there as "key.pem" and the certificate as "cert.pem".
+# 
+# Commands:
+# 
+# $ kubectl create secret generic pusher-credentials --from-file pusher.json
+# $ kubectl create secret generic ndt-tls --from-file ndt-tls/
+
+# Apply RBAC configs
+kubectl apply -f k8s/roles/
+
+# Apply ConfigMaps
+kubectl create configmap pusher-dropbox --from-literal "bucket=dropbox-${PROJECT}"
+kubectl create configmap prometheus-config --from-file config/prometheus/prometheus.yml
+
+# Apply Deployments
+# 
+# NOTE: the Prometheus deployment will only schedule pods on nodes with both of the
+# following labels, and for now not more than a single node should have the
+# label prometheus-node=true:
+#     mlab/type=cloud
+#     prometheus-node=true
+kubectl apply -f k8s/deployments/prometheus.yml
+
+# Apply DaemonSets
+kubectl apply -f k8s/daemonsets/core/node-exporter.yml
+kubectl apply -f k8s/daemonsets/experiments/ndt-cloud-with-fast-sidestream.yml

--- a/k8s/daemonsets/experiments/ndt-cloud-with-fast-sidestream.yml
+++ b/k8s/daemonsets/experiments/ndt-cloud-with-fast-sidestream.yml
@@ -42,7 +42,7 @@ spec:
         - containerPort: 3010
         - containerPort: 9090
         volumeMounts:
-        - name: ndt-certificates
+        - name: ndt-tls
           mountPath: /certs
           readOnly: true
       - name: busybox
@@ -103,6 +103,6 @@ spec:
       - name: pusher-credentials
         secret:
           secretName: pusher-credentials
-      - name: ndt-certificates
+      - name: ndt-tls
         secret:
-          secretName: ndt-certificates
+          secretName: ndt-tls

--- a/manage-cluster/allocate_new_cloud_node.sh
+++ b/manage-cluster/allocate_new_cloud_node.sh
@@ -129,4 +129,19 @@ gcloud compute ssh "${K8S_MASTER}" "${GCE_ARGS[@]}" <<EOF
   for label in ${K8S_CLOUD_NODE_LABELS}; do
     kubectl label nodes ${NODE_NAME} \${label}
   done
+
+  # Work around a known issue with --cloud-provider=gce and CNI plugins.
+  # https://github.com/kubernetes/kubernetes/issues/44254
+  # Without the following action a node will have a node-condition of
+  # NetworkUnavailable=True, which has the result of a taint getting added to
+  # the node which may prevent some pods from getting scheduled on the node if
+  # they don't explicitly tolerate the taint.
+  kubectl proxy --port 8888 &> /dev/null &
+  # Give the proxy a couple seconds to start up.
+  sleep 2
+  curl http://localhost:8888/api/v1/nodes/${NODE_NAME}/status > a.json
+  cat a.json | tr -d '\n' | sed 's/{[^}]\+NetworkUnavailable[^}]\+}/{"type": "NetworkUnavailable","status": "False","reason": "RouteCreated","message": "Manually set through k8s API."}/g' > b.json
+  curl -X PUT http://localhost:8888/api/v1/nodes/${NODE_NAME}/status -H "Content-Type: application/json" -d @b.json
+  kill %1
 EOF
+

--- a/manage-cluster/allocate_new_cloud_node.sh
+++ b/manage-cluster/allocate_new_cloud_node.sh
@@ -17,7 +17,7 @@ PROJECT=${1:?Please specify the google cloud project: $USAGE}
 source k8s_deploy.conf
 
 GCE_REGION="GCE_REGION_${PROJECT/-/_}"
-GCE_ZONES="GCE_REGION_${PROJECT/-/_}"
+GCE_ZONES="GCE_ZONES_${PROJECT/-/_}"
 
 GCE_ZONE="${!GCE_REGION}-$(echo ${!GCE_ZONES} | awk '{print $1}')"
 GCP_ARGS=("--project=${PROJECT}" "--quiet")

--- a/manage-cluster/network/multus.yml
+++ b/manage-cluster/network/multus.yml
@@ -5,7 +5,7 @@ metadata:
  name: flannel-conf
 spec:
   config: '{
-    "cniVersion": "0.3.0",
+    "cniVersion": "0.2.0",
     "type": "flannel",
     "delegate": {
        "hairpinMode": true,
@@ -20,7 +20,7 @@ metadata:
  name: index2ip-index-1-conf
 spec:
   config: '{
-    "cniVersion": "0.3.0",
+    "cniVersion": "0.2.0",
     "name": "ipvlan-index-1",
     "type": "ipvlan",
     "master": "eth0",
@@ -36,7 +36,7 @@ metadata:
  name: index2ip-index-2-conf
 spec:
   config: '{
-    "cniVersion": "0.3.0",
+    "cniVersion": "0.2.0",
     "name": "ipvlan-index-2",
     "type": "ipvlan",
     "master": "eth0",
@@ -52,7 +52,7 @@ metadata:
  name: index2ip-index-4-conf
 spec:
   config: '{
-    "cniVersion": "0.3.0",
+    "cniVersion": "0.2.0",
     "name": "ipvlan-index-4",
     "type": "ipvlan",
     "master": "eth0",
@@ -68,7 +68,7 @@ metadata:
  name: index2ip-index-5-conf
 spec:
   config: '{
-    "cniVersion": "0.3.0",
+    "cniVersion": "0.2.0",
     "name": "ipvlan-index-5",
     "type": "ipvlan",
     "master": "eth0",
@@ -84,7 +84,7 @@ metadata:
  name: index2ip-index-6-conf
 spec:
   config: '{
-    "cniVersion": "0.3.0",
+    "cniVersion": "0.2.0",
     "name": "ipvlan-index-6,
     "type": "ipvlan",
     "master": "eth0",
@@ -100,7 +100,7 @@ metadata:
  name: index2ip-index-7-conf
 spec:
   config: '{
-    "cniVersion": "0.3.0",
+    "cniVersion": "0.2.0",
     "name": "ipvlan-index-7",
     "type": "ipvlan",
     "master": "eth0",
@@ -116,7 +116,7 @@ metadata:
  name: index2ip-index-8-conf
 spec:
   config: '{
-    "cniVersion": "0.3.0",
+    "cniVersion": "0.2.0",
     "name": "ipvlan-index-8",
     "type": "ipvlan",
     "master": "eth0",
@@ -132,7 +132,7 @@ metadata:
  name: index2ip-index-9-conf
 spec:
   config: '{
-    "cniVersion": "0.3.0",
+    "cniVersion": "0.2.0",
     "name": "ipvlan-index-9",
     "type": "ipvlan",
     "master": "eth0",
@@ -148,7 +148,7 @@ metadata:
  name: index2ip-index-10-conf
 spec:
   config: '{
-    "cniVersion": "0.3.0",
+    "cniVersion": "0.2.0",
     "name": "ipvlan-index-10",
     "type": "ipvlan",
     "master": "eth0",
@@ -164,7 +164,7 @@ metadata:
  name: index2ip-index-11-conf
 spec:
   config: '{
-    "cniVersion": "0.3.0",
+    "cniVersion": "0.2.0",
     "name": "ipvlan-index-11",
     "type": "ipvlan",
     "master": "eth0",
@@ -180,7 +180,7 @@ metadata:
  name: index2ip-index-12-conf
 spec:
   config: '{
-    "cniVersion": "0.3.0",
+    "cniVersion": "0.2.0",
     "name": "ipvlan-index-12",
     "type": "ipvlan",
     "master": "eth0",

--- a/manage-cluster/network/multus.yml
+++ b/manage-cluster/network/multus.yml
@@ -3,177 +3,189 @@ apiVersion: "k8s.cni.cncf.io/v1"
 kind: NetworkAttachmentDefinition
 metadata:
  name: flannel-conf
-args: '{
-         "cniVersion": "0.3.0",
-         "type": "flannel",
-         "delegate": {
-           "hairpinMode": true,
-           "isDefaultGateway": false
-         },
-         "masterplugin": true
-       }'
+spec:
+  config: '{
+    "cniVersion": "0.3.0",
+    "type": "flannel",
+    "delegate": {
+       "hairpinMode": true,
+       "isDefaultGateway": false
+    },
+    "masterplugin": true
+  }'
 ---
 apiVersion: "k8s.cni.cncf.io/v1"
 kind: NetworkAttachmentDefinition
 metadata:
  name: index2ip-index-1-conf
-args: '{
-         "cniVersion": "0.3.0",
-         "name": "ipvlan-index-1",
-         "type": "ipvlan",
-         "master": "eth0",
-         "ipam": {
-           "type": "index2ip",
-           "index": 1
-         }
-       }'
+spec:
+  config: '{
+    "cniVersion": "0.3.0",
+    "name": "ipvlan-index-1",
+    "type": "ipvlan",
+    "master": "eth0",
+    "ipam": {
+      "type": "index2ip",
+      "index": 1
+    }
+  }'
 ---
 apiVersion: "k8s.cni.cncf.io/v1"
 kind: NetworkAttachmentDefinition
 metadata:
  name: index2ip-index-2-conf
-args: '{
-         "cniVersion": "0.3.0",
-         "name": "ipvlan-index-3",
-         "type": "ipvlan",
-         "master": "eth0",
-         "ipam": {
-           "type": "index2ip",
-           "index": 3
-         }
-       }'
+spec:
+  config: '{
+    "cniVersion": "0.3.0",
+    "name": "ipvlan-index-2",
+    "type": "ipvlan",
+    "master": "eth0",
+    "ipam": {
+      "type": "index2ip",
+      "index": 2
+    }
+  }'
 ---
 apiVersion: "k8s.cni.cncf.io/v1"
 kind: NetworkAttachmentDefinition
 metadata:
  name: index2ip-index-4-conf
-args: '{
-         "cniVersion": "0.3.0",
-         "name": "ipvlan-index-4",
-         "type": "ipvlan",
-         "master": "eth0",
-         "ipam": {
-           "type": "index2ip",
-           "index": 4
-         }
-       }'
+spec:
+  config: '{
+    "cniVersion": "0.3.0",
+    "name": "ipvlan-index-4",
+    "type": "ipvlan",
+    "master": "eth0",
+    "ipam": {
+      "type": "index2ip",
+      "index": 4
+    }
+  }'
 ---
 apiVersion: "k8s.cni.cncf.io/v1"
 kind: NetworkAttachmentDefinition
 metadata:
  name: index2ip-index-5-conf
-args: '{
-         "cniVersion": "0.3.0",
-         "name": "ipvlan-index-5",
-         "type": "ipvlan",
-         "master": "eth0",
-         "ipam": {
-           "type": "index2ip",
-           "index": 5
-         }
-       }'
+spec:
+  config: '{
+    "cniVersion": "0.3.0",
+    "name": "ipvlan-index-5",
+    "type": "ipvlan",
+    "master": "eth0",
+    "ipam": {
+      "type": "index2ip",
+      "index": 5
+    }
+  }'
 ---
 apiVersion: "k8s.cni.cncf.io/v1"
 kind: NetworkAttachmentDefinition
 metadata:
  name: index2ip-index-6-conf
-args: '{
-         "cniVersion": "0.3.0",
-         "name": "ipvlan-index-6",
-         "type": "ipvlan",
-         "master": "eth0",
-         "ipam": {
-           "type": "index2ip",
-           "index": 6
-         }
-       }'
+spec:
+  config: '{
+    "cniVersion": "0.3.0",
+    "name": "ipvlan-index-6,
+    "type": "ipvlan",
+    "master": "eth0",
+    "ipam": {
+      "type": "index2ip",
+      "index": 6
+    }
+  }'
 ---
 apiVersion: "k8s.cni.cncf.io/v1"
 kind: NetworkAttachmentDefinition
 metadata:
  name: index2ip-index-7-conf
-args: '{
-         "cniVersion": "0.3.0",
-         "name": "ipvlan-index-7",
-         "type": "ipvlan",
-         "master": "eth0",
-         "ipam": {
-           "type": "index2ip",
-           "index": 7
-         }
-       }'
+spec:
+  config: '{
+    "cniVersion": "0.3.0",
+    "name": "ipvlan-index-7",
+    "type": "ipvlan",
+    "master": "eth0",
+    "ipam": {
+      "type": "index2ip",
+      "index": 7
+    }
+  }'
 ---
 apiVersion: "k8s.cni.cncf.io/v1"
 kind: NetworkAttachmentDefinition
 metadata:
  name: index2ip-index-8-conf
-args: '{
-         "cniVersion": "0.3.0",
-         "name": "ipvlan-index-8",
-         "type": "ipvlan",
-         "master": "eth0",
-         "ipam": {
-           "type": "index2ip",
-           "index": 8
-         }
-       }'
+spec:
+  config: '{
+    "cniVersion": "0.3.0",
+    "name": "ipvlan-index-8",
+    "type": "ipvlan",
+    "master": "eth0",
+    "ipam": {
+      "type": "index2ip",
+      "index": 8
+    }
+  }'
 ---
 apiVersion: "k8s.cni.cncf.io/v1"
 kind: NetworkAttachmentDefinition
 metadata:
  name: index2ip-index-9-conf
-args: '{
-         "cniVersion": "0.3.0",
-         "name": "ipvlan-index-9",
-         "type": "ipvlan",
-         "master": "eth0",
-         "ipam": {
-           "type": "index2ip",
-           "index": 9
-         }
-       }'
+spec:
+  config: '{
+    "cniVersion": "0.3.0",
+    "name": "ipvlan-index-9",
+    "type": "ipvlan",
+    "master": "eth0",
+    "ipam": {
+      "type": "index2ip",
+      "index": 9
+    }
+  }'
 ---
 apiVersion: "k8s.cni.cncf.io/v1"
 kind: NetworkAttachmentDefinition
 metadata:
  name: index2ip-index-10-conf
-args: '{
-         "cniVersion": "0.3.0",
-         "name": "ipvlan-index-10",
-         "type": "ipvlan",
-         "master": "eth0",
-         "ipam": {
-           "type": "index2ip",
-           "index": 10
-         }
-       }'
+spec:
+  config: '{
+    "cniVersion": "0.3.0",
+    "name": "ipvlan-index-10",
+    "type": "ipvlan",
+    "master": "eth0",
+    "ipam": {
+      "type": "index2ip",
+      "index": 10
+    }
+  }'
 ---
 apiVersion: "k8s.cni.cncf.io/v1"
 kind: NetworkAttachmentDefinition
 metadata:
  name: index2ip-index-11-conf
-args: '{
-         "cniVersion": "0.3.0",
-         "name": "ipvlan-index-11",
-         "type": "ipvlan",
-         "master": "eth0",
-         "ipam": {
-           "type": "index2ip",
-           "index": 11
-         }
-       }'
+spec:
+  config: '{
+    "cniVersion": "0.3.0",
+    "name": "ipvlan-index-11",
+    "type": "ipvlan",
+    "master": "eth0",
+    "ipam": {
+      "type": "index2ip",
+      "index": 11
+    }
+  }'
 ---
 apiVersion: "k8s.cni.cncf.io/v1"
 kind: NetworkAttachmentDefinition
 metadata:
  name: index2ip-index-12-conf
-args: '{
-         "cniVersion": "0.3.0",
-         "name": "ipvlan-index-12",
-         "type": "ipvlan",
-         "master": "eth0",
-         "ipam": {
-           "type": "index2ip",
-           "index": 12
-         }
-       }'
+spec:
+  config: '{
+    "cniVersion": "0.3.0",
+    "name": "ipvlan-index-12",
+    "type": "ipvlan",
+    "master": "eth0",
+    "ipam": {
+      "type": "index2ip",
+      "index": 12
+    }
+  }'


### PR DESCRIPTION
This is another PR without any cohesion between its commits. Notable:

* Fixes multus-cni configs.
* Adds a new script to help ease deploying k8s resources.
* Applies the "NetworkUnavailable=True" workaround to cluster nodes too.
* Renames configmap `ndt-certificates` to `ndt-tls`.