### PR TITLE
Enable/start kubelet after running kubeadm init.

### DIFF
--- a/node/setup_k8s.sh.template
+++ b/node/setup_k8s.sh.template
@@ -75,8 +75,6 @@ curl --silent --show-error --location "https://raw.githubusercontent.com/kuberne
 systemctl daemon-reload
 systemctl enable docker
 systemctl start docker
-systemctl enable kubelet
-systemctl start kubelet
 
 # Fetch k8s token via K8S_TOKEN_URL. Curl should report most errors to stderr.
 TOKEN=$( curl --fail --silent --show-error -XPOST --data-binary "{}" ${K8S_TOKEN_URL} )
@@ -87,3 +85,6 @@ export PATH=/sbin:/usr/sbin:/opt/bin:${PATH}
 kubeadm join "${MASTER_NODE}:6443" \
   --token "${TOKEN}" \
   --discovery-token-ca-cert-hash sha256:{{CA_CERT_HASH}}
+
+systemctl enable kubelet
+systemctl start kubelet


### PR DESCRIPTION
This might fix issue #85. Apparently, just restarting kubelet after
calling kubeadm init makes the node join the cluster correctly.

Also, since kubeadm wants kubelet to not be running to work correctly, this
seems to make a bit more sense.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/86)
<!-- Reviewable:end -->
