### PR TITLE
Add workaround to start kubelet.

### DIFF
--- a/node/setup_k8s.sh.template
+++ b/node/setup_k8s.sh.template
@@ -86,5 +86,12 @@ kubeadm join "${MASTER_NODE}:6443" \
   --token "${TOKEN}" \
   --discovery-token-ca-cert-hash sha256:{{CA_CERT_HASH}}
 
+systemctl daemon-reload
 systemctl enable kubelet
+systemctl start kubelet
+
+sleep 60
+
+systemctl stop kubelet
+sleep 10
 systemctl start kubelet


### PR DESCRIPTION
Apparently the configuration downloaded during the first run is not used until
kubelet is restarted. Without it, kubelet won't join the cluster.

This change makes sure that:
1. kubeadm join had time to run in full,
2. kubelet has downloaded the configuration files and, after a restart, is able
to join the cluster.

It is a workaround and in no way an optimal solution, but will allow us to
have working nodes and keep on debugging with a better understanding
of the problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/87)
<!-- Reviewable:end -->
