### PR TITLE
Update k8s platform master bootstrap

### DIFF
--- a/manage-cluster/bootstrap_k8s_master_cluster.sh
+++ b/manage-cluster/bootstrap_k8s_master_cluster.sh
@@ -228,9 +228,9 @@ if [[ -n "${EXISTING_K8S_SUBNET}" ]]; then
       "${GCP_ARGS[@]}"
 fi
 
-# If $DELETE_ONLY is set to "yes", then exit now.
-if [[ "${DELETE_ONLY}" == "yes" ]]; then
-  echo "DELETE_ONLY set to 'yes'. All GCP objects deleted. Exiting."
+# If $EXIT_AFTER_DELETE is set to "yes", then exit now.
+if [[ "${EXIT_AFTER_DELETE}" == "yes" ]]; then
+  echo "EXIT_AFTER_DELETE set to 'yes'. All GCP objects deleted. Exiting."
   exit 0
 fi
 
@@ -798,7 +798,7 @@ EOF
   # easily access kubectl as well as etcdctl.  As we productionize this process,
   # this code should be deleted.  For the next steps, we no longer want to be
   # root.
-  gcloud compute ssh "${gce_name}" "${GCE_ARGS[@]}" <<EOF
+  gcloud compute ssh "${gce_name}" "${GCE_ARGS[@]}" <<\EOF
     set -x
     mkdir -p $HOME/.kube
     sudo cp -i /etc/kubernetes/admin.conf $HOME/.kube/config

--- a/manage-cluster/k8s_deploy.conf
+++ b/manage-cluster/k8s_deploy.conf
@@ -39,10 +39,10 @@ TOKEN_SERVER_BASE_NAME="token-server"
 TOKEN_SERVER_PORT="8800"
 
 # Depending on the GCP project we may use different regions, zones, GSC buckets.
-# 
+#
 # Sandbox
-GCE_REGION_mlab_sandbox="us-central1"
-GCE_ZONES_mlab_sandbox="a b c"
+GCE_REGION_mlab_sandbox="us-east1"
+GCE_ZONES_mlab_sandbox="b c d"
 GCS_BUCKET_EPOXY_mlab_sandbox="epoxy-mlab-sandbox"
 GCS_BUCKET_K8S_mlab_sandbox="k8s-platform-master-mlab-sandbox"
 
@@ -53,8 +53,8 @@ GCS_BUCKET_EPOXY_mlab_staging="epoxy-mlab-staging"
 GCS_BUCKET_K8S_mlab_staging="k8s-platform-master-mlab-staging"
 
 # Production
-GCE_REGION_mlab_oti="us-central1"
-GCE_ZONES_mlab_oti="a b c"
+GCE_REGION_mlab_oti="us-east1"
+GCE_ZONES_mlab_oti="b c d"
 GCS_BUCKET_EPOXY_mlab_oti="epoxy-mlab-oti"
 GCS_BUCKET_K8S_mlab_oti="k8s-platform-master-mlab-oti"
 
@@ -68,4 +68,4 @@ GCS_BUCKET_K8S_mlab_oti="k8s-platform-master-mlab-oti"
 # project. One way to use this would be to set the following to "yes", run this
 # script, _then_ change any base object names, reset this to "no" and run this
 # script.
-DELETE_ONLY="no"
+EXIT_AFTER_DELETE="no"

--- a/node/setup_k8s.sh.template
+++ b/node/setup_k8s.sh.template
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-exec 2> /tmp/k8s_setup.log 1>&2
+exec 2> /tmp/setup_k8s.log 1>&2
 set -euxo pipefail
 
 # This script is intended to be called by epoxy as the action for the last stage

--- a/node/setup_k8s.sh.template
+++ b/node/setup_k8s.sh.template
@@ -95,3 +95,4 @@ sleep 300
 systemctl stop kubelet
 sleep 30
 systemctl start kubelet
+echo 'Success: everything we did appeared to work - good luck'


### PR DESCRIPTION
After discovering that internal loadbalancers only work within a single region, we must create the k8s masters in the same region that AppEngine is pinned to (for the epoxy boot-api server).

In practice this means that k8s must run in us-east1 for mlab-sandbox & mlab-oti and can remain in us-central1 or mlab-staging.

If we move epoxy out of app engine or adopt an alternative to internal loadbalancers for access to the token servers, then we can revisit this decision.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/89)
<!-- Reviewable:end -->
