### PR TITLE
Update k8s version to v1.12.3

### DIFF
--- a/manage-cluster/k8s_deploy.conf
+++ b/manage-cluster/k8s_deploy.conf
@@ -25,7 +25,7 @@ GCE_TYPE="n1-standard-4"
 # we learn more.
 GCE_API_SCOPES="cloud-platform"
 
-K8S_VERSION="1.12.0"
+K8S_VERSION="1.12.3"
 K8S_PKG_VERSION="00"
 K8S_CA_FILES="ca.crt ca.key sa.key sa.pub front-proxy-ca.crt front-proxy-ca.key etcd/ca.crt etcd/ca.key"
 K8S_PKI_DIR="/tmp/kubernetes-pki"


### PR DESCRIPTION
This change updates the default k8s version for the k8s cluster master to v1.12.3.

This change is expected to address some known vulnerabilities from https://github.com/m-lab/dev-tracker/issues/142

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/90)
<!-- Reviewable:end -->
