### PR TITLE
Copy multus-cni.conf from boot image.

### DIFF
--- a/manage-cluster/network/platform.yml
+++ b/manage-cluster/network/platform.yml
@@ -32,16 +32,6 @@ spec:
         effect: NoSchedule
       serviceAccountName: flannel
       initContainers:
-      - name: empty-cni-folder
-        image: quay.io/coreos/flannel:v0.10.0-amd64
-        command:
-        - mkdir
-        args:
-        - -p
-        - /etc/cni/net.d
-        volumeMounts:
-        - name: etc
-          mountPath: /etc
       - name: install-cni
         image: quay.io/coreos/flannel:v0.10.0-amd64
         command:
@@ -96,6 +86,3 @@ spec:
       - name: flannel-cfg
         configMap:
           name: kube-flannel-cfg
-      - name: etc
-        hostPath:
-          path: /etc

--- a/node/setup_k8s.sh.template
+++ b/node/setup_k8s.sh.template
@@ -72,6 +72,11 @@ curl --silent --show-error --location "https://raw.githubusercontent.com/kuberne
   | sed -e 's|--cni-bin-dir=[^ "]*|--cni-bin-dir=/opt/shimcni/bin|' \
   > /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
 
+# Copy the multus-cni configuration from the epoxy-image resources folder
+# to /etc/cni/net.d/ - this makes sure kubelet can find it on first run.
+mkdir -p /etc/cni/net.d
+cp /usr/share/oem/multus-cni.conf /etc/cni/net.d
+
 systemctl daemon-reload
 systemctl enable docker
 systemctl start docker
@@ -85,11 +90,6 @@ export PATH=/sbin:/usr/sbin:/opt/bin:${PATH}
 kubeadm join "${MASTER_NODE}:6443" \
   --token "${TOKEN}" \
   --discovery-token-ca-cert-hash sha256:{{CA_CERT_HASH}}
-
-# Copy the multus-cni configuration from the epoxy-image resources folder
-# to /etc/cni/net.d/ - this makes sure kubelet can find it on first run.
-mkdir -p /etc/cni/net.d
-cp /usr/share/oem/multus-cni.conf /etc/cni/net.d
 
 systemctl daemon-reload
 systemctl enable kubelet

--- a/node/setup_k8s.sh.template
+++ b/node/setup_k8s.sh.template
@@ -86,13 +86,13 @@ kubeadm join "${MASTER_NODE}:6443" \
   --token "${TOKEN}" \
   --discovery-token-ca-cert-hash sha256:{{CA_CERT_HASH}}
 
+# Copy the multus-cni configuration from the epoxy-image resources folder
+# to /etc/cni/net.d/ - this makes sure kubelet can find it on first run.
+mkdir -p /etc/cni/net.d
+cp /usr/share/oem/multus-cni.conf /etc/cni/net.d
+
 systemctl daemon-reload
 systemctl enable kubelet
 systemctl start kubelet
 
-sleep 300
-
-systemctl stop kubelet
-sleep 30
-systemctl start kubelet
 echo 'Success: everything we did appeared to work - good luck'


### PR DESCRIPTION
This changes how the multus-cni configuration is received by the node. Instead of relying on a DaemonSet providing the file as part of its initialization, `multus-cni.conf` is included in the boot image and copied in the right location by the k8s setup script before bootstrapping the cluster.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/92)
<!-- Reviewable:end -->
