### PR TITLE
Don't scrape port 3010 on ndt-cloud nodes + adds toleration to ndt-cloud DaemonSet

### DIFF
--- a/config/prometheus/prometheus.yml
+++ b/config/prometheus/prometheus.yml
@@ -53,6 +53,7 @@ scrape_configs:
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics
 
+
   # Scrape config for kubernetes pods.
   - job_name: 'kubernetes-pods'
     kubernetes_sd_configs:

--- a/config/prometheus/prometheus.yml
+++ b/config/prometheus/prometheus.yml
@@ -53,7 +53,6 @@ scrape_configs:
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics
 
-
   # Scrape config for kubernetes pods.
   - job_name: 'kubernetes-pods'
     kubernetes_sd_configs:
@@ -72,6 +71,11 @@ scrape_configs:
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
         action: keep
         regex: true
+
+      # Don't scrape port 3010 on ndt-cloud pods
+      - source_labels: [__meta_kubernetes_pod_container_port_number]
+        action: drop
+        regex: 3010
 
       # Only keep containers that have a declared container port.
       - source_labels: [__meta_kubernetes_pod_container_port_number]

--- a/config/prometheus/prometheus.yml
+++ b/config/prometheus/prometheus.yml
@@ -73,11 +73,6 @@ scrape_configs:
         action: keep
         regex: true
 
-      # Don't scrape port 3010 on ndt-cloud pods
-      - source_labels: [__meta_kubernetes_pod_container_port_number]
-        action: drop
-        regex: 3010
-
       # Only keep containers that have a declared container port.
       - source_labels: [__meta_kubernetes_pod_container_port_number]
         action: keep

--- a/k8s/daemonsets/experiments/ndt-cloud-with-fast-sidestream.yml
+++ b/k8s/daemonsets/experiments/ndt-cloud-with-fast-sidestream.yml
@@ -51,7 +51,6 @@ spec:
       - name: ndt-cloud
         image: measurementlab/ndt-cloud:v0.3
         ports:
-        - containerPort: 3010
         - containerPort: 9090
         volumeMounts:
         - name: ndt-tls

--- a/k8s/daemonsets/experiments/ndt-cloud-with-fast-sidestream.yml
+++ b/k8s/daemonsets/experiments/ndt-cloud-with-fast-sidestream.yml
@@ -32,6 +32,18 @@ spec:
       #
       # TODO: enable before receiving production traffic.
       # terminationGracePeriodSeconds: 150
+      #
+
+      # TODO (kinkade): Remove this toleration once we have discovered why
+      # the route_controller on platform nodes logs "FailedToCreateRoute [...]
+      # Could not create route [...]: instance not found". When this happens the
+      # route_controller set the NetworkUnavailable node condition to True,
+      # which adds this taint, which, without this toleration, causes the nodes
+      # to be unschedulable for the ndt-cloud pods.
+      tolerations:
+      - key: "node.kubernetes.io/network-unavailable"
+        operator: "Exists"
+        effect: "NoSchedule"
 
       nodeSelector:
         mlab/type: 'platform'


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/97)
<!-- Reviewable:end -->
