### PR TITLE
Various fixes and tweaks to k8s configs

### DIFF
--- a/k8s/daemonsets/core/prometheus.yml
+++ b/k8s/daemonsets/core/prometheus.yml
@@ -22,8 +22,17 @@ spec:
         node-role.kubernetes.io/master: ""
 
       tolerations:
-      - key: node-role.kubernetes.io/master
-        effect: NoSchedule
+      - key: "node-role.kubernetes.io/master"
+        operator: "Exists"
+        effect: "NoSchedule"
+      # The kube-controller-manager is launched with flag
+      # --configure-cloud-routes=false to avoid issues with the platform
+      # bare-metal nodes (which are not in the cloud), but this has the side
+      # effect of adding the following taint to all cloud nodes, which we
+      # tolerate here, since we need Prometheus running regardless.
+      - key: "node.kubernetes.io/network-unavailable"
+        operator: "Exists"
+        effect: "NoSchedule"
 
       containers:
       - name: prometheus

--- a/k8s/daemonsets/experiments/ndt-cloud-with-fast-sidestream.yml
+++ b/k8s/daemonsets/experiments/ndt-cloud-with-fast-sidestream.yml
@@ -34,17 +34,6 @@ spec:
       # terminationGracePeriodSeconds: 150
       #
 
-      # TODO (kinkade): Remove this toleration once we have discovered why
-      # the route_controller on platform nodes logs "FailedToCreateRoute [...]
-      # Could not create route [...]: instance not found". When this happens the
-      # route_controller set the NetworkUnavailable node condition to True,
-      # which adds this taint, which, without this toleration, causes the nodes
-      # to be unschedulable for the ndt-cloud pods.
-      tolerations:
-      - key: "node.kubernetes.io/network-unavailable"
-        operator: "Exists"
-        effect: "NoSchedule"
-
       nodeSelector:
         mlab/type: 'platform'
       containers:

--- a/manage-cluster/bootstrap_k8s_master_cluster.sh
+++ b/manage-cluster/bootstrap_k8s_master_cluster.sh
@@ -191,7 +191,7 @@ for zone in $GCE_ZONES; do
   GCE_ARGS=("--zone=${gce_zone}" "${GCP_ARGS[@]}")
 
   EXISTING_INSTANCE=$(gcloud compute instances list \
-      --filter "name=${gce_name} AND zone:${gce_zone}" \
+      --filter "name=${gce_name} AND zone:($gce_zone)" \
       --format "value(name)" \
       "${GCP_ARGS[@]}" || true)
   if [[ -n "${EXISTING_INSTANCE}" ]]; then
@@ -199,7 +199,7 @@ for zone in $GCE_ZONES; do
   fi
 
   EXISTING_INSTANCE_GROUP=$(gcloud compute instance-groups list \
-      --filter "name=${gce_name} AND zone:${gce_zone}" \
+      --filter "name=${gce_name} AND zone:($gce_zone)" \
       --format "value(name)" \
       "${GCP_ARGS[@]}" || true)
   if [[ -n "${EXISTING_INSTANCE_GROUP}" ]]; then
@@ -209,7 +209,7 @@ for zone in $GCE_ZONES; do
   fi
 
   EXISTING_CLUSTER_NODES=$(gcloud compute instances list \
-      --filter "name:k8s-platform-cluster-node AND zone:${gce_zone}" \
+      --filter "name:k8s-platform-cluster-node AND zone:($gce_zone)" \
       --format "value(name)" \
       "${GCP_ARGS[@]}" || true)
   if [[ -n "${EXISTING_CLUSTER_NODES}" ]]; then
@@ -578,7 +578,7 @@ for zone in $GCE_ZONES; do
 
   # Get the instances internal IP address.
   INTERNAL_IP=$(gcloud compute instances list \
-      --filter "name=${gce_name} AND zone:${gce_zone}" \
+      --filter "name=${gce_name} AND zone:(${gce_zone})" \
       --format "value(networkInterfaces[0].networkIP)" \
       "${GCP_ARGS[@]}" || true)
 

--- a/manage-cluster/bootstrap_prometheus.sh
+++ b/manage-cluster/bootstrap_prometheus.sh
@@ -211,6 +211,9 @@ for zone in $GCE_ZONES; do
     if ! mount /dev/sdb /mnt/local ; then
         mkfs.ext4 /dev/sdb
         mount /dev/sdb /mnt/local
+        # Add an entry to /etc/fstab so that this volume gets remounted when the
+        # VM reboots.
+        echo "/dev/sdb /mnt/local ext4 defaults 0 0" >> /etc/fstab
     fi
 
     if [[ ! -d /mnt/local/prometheus ]]; then

--- a/manage-cluster/bootstrap_prometheus.sh
+++ b/manage-cluster/bootstrap_prometheus.sh
@@ -117,6 +117,11 @@ gcloud compute target-pools delete "${PROM_BASE_NAME}" \
 # health checks
 gcloud compute http-health-checks delete "${PROM_BASE_NAME}" "${GCP_ARGS[@]}" || :
 
+# If $EXIT_AFTER_DELETE is set to "yes", then exit now.
+if [[ "${EXIT_AFTER_DELETE}" == "yes" ]]; then
+  echo "EXIT_AFTER_DELETE set to 'yes'. All GCP objects deleted. Exiting."
+  exit 0
+fi
 
 #######################################################
 # CREATE THINGS

--- a/manage-cluster/k8s_deploy.conf
+++ b/manage-cluster/k8s_deploy.conf
@@ -8,7 +8,7 @@ GCE_K8S_SUBNET="kubernetes"
 GCE_K8S_SUBNET_RANGE="10.0.0.0/16"
 GCE_EPOXY_SUBNET="epoxy"
 GCE_EPOXY_SUBNET_RANGE="10.1.0.0/16"
-GCE_NET_TAGS="k8s-platform-master" # Comma separate list
+GCE_NET_TAGS="k8s-platform-master" # Comma separated list
 GCE_TYPE="n1-standard-4"
 
 # Monitoring variables. Note: "prometheus" is reserved for other deployments.

--- a/manage-cluster/kubeadm-config.yml.template
+++ b/manage-cluster/kubeadm-config.yml.template
@@ -36,6 +36,7 @@ controllerManagerExtraArgs:
   node-cidr-mask-size: "26"
   cloud-provider: "gce"
   cloud-config: "/etc/kubernetes/cloud-provider.conf"
+  configure-cloud-routes: "false"
 controllerManagerExtraVolumes:
 - name: cloud
   hostPath: "/etc/kubernetes/cloud-provider.conf"

--- a/manage-cluster/network/platform.yml
+++ b/manage-cluster/network/platform.yml
@@ -56,10 +56,10 @@ spec:
         resources:
           requests:
             cpu: "100m"
-            memory: "50Mi"
+            memory: "128Mi"
           limits:
             cpu: "100m"
-            memory: "50Mi"
+            memory: "128Mi"
         securityContext:
           privileged: true
         env:


### PR DESCRIPTION
This PR contains a handful of small but important changes to our k8s configurations. A brief list of the important ones:

* Sets the Prometheus DaemonSet to tolerate the `network-unavailable` taint that results from turning of the configuration of "cloud routes". Turning them off does not affect networking in any way that we use it, so the condition/taint is benign in our case.
* Updates `--filter` syntax for filtering gcloud results by zone. It apparently changed recently and broke the script.
* Bumps the memory resource allocation for the flanneld pod from 50Mi to 128Mi to get around oom-killer issues that were chronic on all nodes when flannel only had 50Mi.
* The bootstrap_prometheus.sh script now honors the `EXIT_AFTER_DELETE` flag.
* The bootstrap_prometheus.sh script now sets up an entry in /etc/fstab so that the persistent volume where Prometheus writes its data gets remounted on reboots.
* A typo fix or two.