### PR TITLE
Add kube-state-metrics to core/daemonsets

### DIFF
--- a/k8s/daemonsets/core/README.md
+++ b/k8s/daemonsets/core/README.md
@@ -1,0 +1,15 @@
+# Deployment
+
+See the kube-state-metrics README for the most current deployment notes.
+https://github.com/kubernetes/kube-state-metrics/blob/master/README.md
+
+kube-state-metrics must run from a cloud node.
+
+If initial deployment fails for permissions, it may be necessary to create a
+role binding for your user. This also works for the GCE service account.
+
+```
+kubectl create clusterrolebinding cluster-admin-binding \
+   --clusterrole=cluster-admin \
+   --user=$(gcloud info --format='value(config.account)')
+```

--- a/k8s/daemonsets/core/kube-state-metrics.yml
+++ b/k8s/daemonsets/core/kube-state-metrics.yml
@@ -1,24 +1,68 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
+# Kubernetes version 1.8.x should use apps/v1beta2
+# Kubernetes versions before 1.8.0 should use apps/v1beta1 or extensions/v1beta1
 kind: Deployment
 metadata:
   name: kube-state-metrics
+  namespace: kube-system
 spec:
+  selector:
+    matchLabels:
+      k8s-app: kube-state-metrics
   replicas: 1
   template:
     metadata:
       labels:
-        run: kube-state-metrics
+        k8s-app: kube-state-metrics
       annotations:
         prometheus.io/scrape: 'true'
     spec:
       nodeSelector:
         mlab/type: cloud
+      serviceAccountName: kube-state-metrics
       containers:
       - name: kube-state-metrics
         image: quay.io/coreos/kube-state-metrics:v1.5.0
+        ports:
+        - name: http-metrics
+          containerPort: 8080
+        - name: telemetry
+          containerPort: 8081
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 5
+          timeoutSeconds: 5
         args: [
-          "--collectors=deployments,nodes,pods,services",
-          "--port=9999",
+          "--collectors=deployments,nodes,pods,services"
         ]
         ports:
-        - containerPort: 9999
+        - containerPort: 8080
+      - name: addon-resizer
+        image: k8s.gcr.io/addon-resizer:1.8.3
+        resources:
+          limits:
+            cpu: 150m
+            memory: 50Mi
+          requests:
+            cpu: 150m
+            memory: 50Mi
+        env:
+          - name: MY_POD_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
+          - name: MY_POD_NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+        command:
+          - /pod_nanny
+          - --container=kube-state-metrics
+          - --cpu=100m
+          - --extra-cpu=1m
+          - --memory=100Mi
+          - --extra-memory=2Mi
+          - --threshold=5
+          - --deployment=kube-state-metrics

--- a/k8s/daemonsets/core/kube-state-metrics.yml
+++ b/k8s/daemonsets/core/kube-state-metrics.yml
@@ -1,0 +1,24 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: kube-state-metrics
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        run: kube-state-metrics
+      annotations:
+        prometheus.io/scrape: 'true'
+    spec:
+      nodeSelector:
+        mlab/type: cloud
+      containers:
+      - name: kube-state-metrics
+        image: quay.io/coreos/kube-state-metrics:v1.5.0
+        args: [
+          "--collectors=deployments,nodes,pods,services",
+          "--port=9999",
+        ]
+        ports:
+        - containerPort: 9999

--- a/k8s/roles/kube-state-metrics.yaml
+++ b/k8s/roles/kube-state-metrics.yaml
@@ -1,0 +1,105 @@
+apiVersion: rbac.authorization.k8s.io/v1
+# kubernetes versions before 1.8.0 should use rbac.authorization.k8s.io/v1beta1
+kind: Role
+metadata:
+  namespace: kube-system
+  name: kube-state-metrics-resizer
+rules:
+- apiGroups: [""]
+  resources:
+  - pods
+  verbs: ["get"]
+- apiGroups: ["apps"]
+  resources:
+  - deployments
+  resourceNames: ["kube-state-metrics"]
+  verbs: ["get", "update"]
+- apiGroups: ["extensions"]
+  resources:
+  - deployments
+  resourceNames: ["kube-state-metrics"]
+  verbs: ["get", "update"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+# kubernetes versions before 1.8.0 should use rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: kube-state-metrics
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kube-state-metrics-resizer
+subjects:
+- kind: ServiceAccount
+  name: kube-state-metrics
+  namespace: kube-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-state-metrics
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+# kubernetes versions before 1.8.0 should use rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: kube-state-metrics
+rules:
+- apiGroups: [""]
+  resources:
+  - configmaps
+  - secrets
+  - nodes
+  - pods
+  - services
+  - resourcequotas
+  - replicationcontrollers
+  - limitranges
+  - persistentvolumeclaims
+  - persistentvolumes
+  - namespaces
+  - endpoints
+  verbs: ["list", "watch"]
+- apiGroups: ["extensions"]
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  - ingresses
+  verbs: ["list", "watch"]
+- apiGroups: ["apps"]
+  resources:
+  - daemonsets
+  - deployments
+  - replicasets
+  - statefulsets
+  verbs: ["list", "watch"]
+- apiGroups: ["batch"]
+  resources:
+  - cronjobs
+  - jobs
+  verbs: ["list", "watch"]
+- apiGroups: ["autoscaling"]
+  resources:
+  - horizontalpodautoscalers
+  verbs: ["list", "watch"]
+- apiGroups: ["policy"]
+  resources:
+  - poddisruptionbudgets
+  verbs: ["list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+# kubernetes versions before 1.8.0 should use rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: kube-state-metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-state-metrics
+subjects:
+- kind: ServiceAccount
+  name: kube-state-metrics
+  namespace: kube-system


### PR DESCRIPTION
This change adds a new single-pod deployment for the kube-state-metrics. This pod runs from a cloud node.

The configuration is a minor modification of the canonical configuration provided by the kube-state-metrics repo: https://github.com/kubernetes/kube-state-metrics/tree/master/kubernetes

Changes to that config include: consolidating all role related configs into a single file, removing the service definition, and adding explicit args and prometheus monitoring annotations for the kube-state-metrics deployment.

The existing steps in `bootstrap_k8s_workloads.sh` should be sufficient for this deployment. See README for possible one-time steps:
```
kubectl apply -f ../k8s/roles/
kubectl apply -f ../k8s/daemonsets/core/
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/110)
<!-- Reviewable:end -->
