### PR TITLE
Removes configs for flannel pods to write out the multus config to disk

### DIFF
--- a/manage-cluster/network/common.yml.template
+++ b/manage-cluster/network/common.yml.template
@@ -101,7 +101,8 @@ data:
           "type": "flannel",
           "delegate": {
             "hairpinMode": true,
-            "isDefaultGateway": true
+            "isDefaultGateway": true,
+            "forceAddress": true
           }
         },
         {
@@ -109,26 +110,6 @@ data:
           "capabilities": {
             "portMappings": true
           }
-        }
-      ]
-    }
-  # This is the CNI config needed for the platform nodes.
-  # This file should not contain any index2ip stuff. It is the backup config
-  # for when multus isn't working or a pod is not tagged with any network
-  # annotations.
-  platform-node-cni-conf.json: |
-    {
-      "name": "multus-network",
-      "type": "multus",
-      "kubeconfig": "/etc/kubernetes/kubelet.conf",
-      "delegates": [
-        {
-          "type": "flannel",
-          "delegate": {
-            "hairpinMode": true,
-            "isDefaultGateway": false
-          },
-          "masterplugin": true
         }
       ]
     }

--- a/manage-cluster/network/platform.yml
+++ b/manage-cluster/network/platform.yml
@@ -31,20 +31,6 @@ spec:
       - operator: Exists
         effect: NoSchedule
       serviceAccountName: flannel
-      initContainers:
-      - name: install-cni
-        image: quay.io/coreos/flannel:v0.10.0-amd64
-        command:
-        - cp
-        args:
-        - -f
-        - /etc/kube-flannel/platform-node-cni-conf.json
-        - /etc/cni/net.d/multus-cni.conf
-        volumeMounts:
-        - name: cni
-          mountPath: /etc/cni/net.d
-        - name: flannel-cfg
-          mountPath: /etc/kube-flannel/
       containers:
       - name: kube-flannel
         image: quay.io/coreos/flannel:v0.10.0-amd64


### PR DESCRIPTION
The multus config file is now [baked into platform node images built by epoxy-images](https://github.com/m-lab/epoxy-images/blob/dev/configs/stage3_coreos/resources/multus-cni.conf) and no longer needs to be written to platform disks on initialization of the flannel pod on each node.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/113)
<!-- Reviewable:end -->
