### PR TITLE
Fixes etcdctl configs in root's .bashrc file.

### DIFF
--- a/manage-cluster/bootstrap_k8s_master_cluster.sh
+++ b/manage-cluster/bootstrap_k8s_master_cluster.sh
@@ -811,10 +811,11 @@ EOF
     sudo cp -i /etc/kubernetes/admin.conf /root/.kube/config
     sudo chown $(id -u root):$(id -g root) /root/.kube/config
     sudo bash -c "(cat <<-EOF2
+        export ETCDCTL_API=3
 		export ETCDCTL_DIAL_TIMEOUT=3s
-		export ETCDCTL_CA_FILE=/etc/kubernetes/pki/etcd/ca.crt
-		export ETCDCTL_CERT_FILE=/etc/kubernetes/pki/etcd/peer.crt
-		export ETCDCTL_KEY_FILE=/etc/kubernetes/pki/etcd/peer.key
+		export ETCDCTL_CACERT=/etc/kubernetes/pki/etcd/ca.crt
+		export ETCDCTL_CERT=/etc/kubernetes/pki/etcd/peer.crt
+		export ETCDCTL_KEY=/etc/kubernetes/pki/etcd/peer.key
 		export ETCDCTL_ENDPOINTS=https://127.0.0.1:2379
 EOF2
 	) >> /root/.bashrc"

--- a/manage-cluster/bootstrap_k8s_master_cluster.sh
+++ b/manage-cluster/bootstrap_k8s_master_cluster.sh
@@ -811,7 +811,7 @@ EOF
     sudo cp -i /etc/kubernetes/admin.conf /root/.kube/config
     sudo chown $(id -u root):$(id -g root) /root/.kube/config
     sudo bash -c "(cat <<-EOF2
-        export ETCDCTL_API=3
+		export ETCDCTL_API=3
 		export ETCDCTL_DIAL_TIMEOUT=3s
 		export ETCDCTL_CACERT=/etc/kubernetes/pki/etcd/ca.crt
 		export ETCDCTL_CERT=/etc/kubernetes/pki/etcd/peer.crt


### PR DESCRIPTION
Previously, the environment variables were using v2 names, which changes with v3. Additionally, etcdctl will default to v2 api, so this must be explicitly set with `ETCDCTL_API=3`.

Thanks to @evfirerob for figuring this out.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/114)
<!-- Reviewable:end -->
