### PR TITLE
Enable dynamic kubelet configuration + set cache-control on setup_k8s.sh

### DIFF
--- a/manage-cluster/bootstrap_k8s_master_cluster.sh
+++ b/manage-cluster/bootstrap_k8s_master_cluster.sh
@@ -823,7 +823,8 @@ EOF
                    openssl rsa -pubin -outform der 2>/dev/null | \
                    openssl dgst -sha256 -hex | sed 's/^.* //'")
     sed -e "s/{{CA_CERT_HASH}}/${ca_cert_hash}/" ../node/setup_k8s.sh.template > setup_k8s.sh
-    gsutil cp setup_k8s.sh gs://${!GCS_BUCKET_EPOXY}/stage3_coreos/setup_k8s.sh
+    cache_control="Cache-Control:private, max-age=0, no-transform"
+    gsutil -h $cache_control cp setup_k8s.sh gs://${!GCS_BUCKET_EPOXY}/stage3_coreos/setup_k8s.sh
   fi
 
   # Evaluate the common.yml.template network config template file.

--- a/node/setup_k8s.sh.template
+++ b/node/setup_k8s.sh.template
@@ -66,9 +66,10 @@ popd
 # TODO: Add annotations to the node as well as labels. The annotations should
 #       contain most of /proc/cmdline as well as the args to this script.
 NODE_LABELS="mlab/machine=${MACHINE},mlab/site=${SITE},mlab/metro=${METRO},mlab/type=platform"
+DYNAMIC_CONFIG_DIR="/var/lib/kubelet/dynamic-configs"
 mkdir -p /etc/systemd/system/kubelet.service.d
 curl --silent --show-error --location "https://raw.githubusercontent.com/kubernetes/kubernetes/${RELEASE}/build/debs/10-kubeadm.conf" \
-  | sed -e "s|KUBELET_KUBECONFIG_ARGS=|KUBELET_KUBECONFIG_ARGS=--node-labels=$NODE_LABELS |g" \
+  | sed -e "s|KUBELET_KUBECONFIG_ARGS=|KUBELET_KUBECONFIG_ARGS=--node-labels=$NODE_LABELS --dynamic-config-dir=$DYNAMIC_CONFIG_DIR|g" \
   | sed -e 's|--cni-bin-dir=[^ "]*|--cni-bin-dir=/opt/shimcni/bin|' \
   > /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
 


### PR DESCRIPTION
It may be nice to have the ability to [modify node kubelet configurations on a dynamic basis](https://kubernetes.io/docs/tasks/administer-cluster/reconfigure-kubelet/), on live cluster nodes. This PR enables a necessary kubelet flag for this to be possible. *NOTE*: Enabling this flag doesn't automatically start dynamic configuration, but just sets up the necessary environment.

Previously, the bootstrap_k8s_master_cluster.sh script was not setting any cache-control headers on the setup_k8s.sh script when uploading it to GCS. GCS apparently caches for an hour if not told otherwise. This makes it difficult to test modifications to this file. Now the upload includes a directive to not cache the file at all.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/117)
<!-- Reviewable:end -->
