### PR TITLE
Reenables flannel pod writing multus config to disk on initialization

### DIFF
--- a/manage-cluster/network/common.yml.template
+++ b/manage-cluster/network/common.yml.template
@@ -113,3 +113,24 @@ data:
         }
       ]
     }
+  # This is the CNI config needed for the platform nodes.
+  # This file should not contain any index2ip stuff. It is the backup config
+  # for when multus isn't working or a pod is not tagged with any network
+  # annotations.
+  platform-node-cni-conf.json: |
+    {
+      "name": "multus-network",
+      "type": "multus",
+      "kubeconfig": "/etc/kubernetes/kubelet.conf",
+      "delegates": [
+        {
+          "type": "flannel",
+          "delegate": {
+            "hairpinMode": true,
+            "isDefaultGateway": false,
+            "forceAddress": true
+          },
+          "masterplugin": true
+        }
+      ]
+    }

--- a/manage-cluster/network/platform.yml
+++ b/manage-cluster/network/platform.yml
@@ -31,6 +31,20 @@ spec:
       - operator: Exists
         effect: NoSchedule
       serviceAccountName: flannel
+      initContainers:
+      - name: install-cni
+        image: quay.io/coreos/flannel:v0.10.0-amd64
+        command:
+        - cp
+        args:
+        - -f
+        - /etc/kube-flannel/platform-node-cni-conf.json
+        - /etc/cni/net.d/multus-cni.conf
+        volumeMounts:
+        - name: cni
+          mountPath: /etc/cni/net.d
+        - name: flannel-cfg
+          mountPath: /etc/kube-flannel/
       containers:
       - name: kube-flannel
         image: quay.io/coreos/flannel:v0.10.0-amd64


### PR DESCRIPTION
Late last year nodes were having a hard time joining the cluster. It was determined that a likely culprit was some networking race condition, possibly due to the fact that multus config wasn't written to disk until  the flannel pod was initialized on the node, which occurred *after* the node had joined. So, the multus config was baked into the node boot images, and this seemed to help things. However, some fraction of nodes (10%) were still having problems joining in the same ways as before.

In the meantime we found and fixed some other k8s issues (primarily removing the `--cloud-provider=gce` flag from k8s components), and noticed that no nodes were having issues joining the cluster. We wonder whether the root of the issue had more to do with the `--cloud-provider` flag than the multus config file.

This PR reverts are earlier change in PR #113 in which we stopped flannel from writing out the multus config, since it was already baked into the node. Now, we have removed the multus config from the node images, and here we restore flannel writing the multus config to disk. Hopefully nodes have no problem joining now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/119)
<!-- Reviewable:end -->
