### PR TITLE
Adds a trailing space to the sed substitution.

### DIFF
--- a/node/setup_k8s.sh.template
+++ b/node/setup_k8s.sh.template
@@ -69,7 +69,7 @@ NODE_LABELS="mlab/machine=${MACHINE},mlab/site=${SITE},mlab/metro=${METRO},mlab/
 DYNAMIC_CONFIG_DIR="/var/lib/kubelet/dynamic-configs"
 mkdir -p /etc/systemd/system/kubelet.service.d
 curl --silent --show-error --location "https://raw.githubusercontent.com/kubernetes/kubernetes/${RELEASE}/build/debs/10-kubeadm.conf" \
-  | sed -e "s|KUBELET_KUBECONFIG_ARGS=|KUBELET_KUBECONFIG_ARGS=--node-labels=$NODE_LABELS --dynamic-config-dir=$DYNAMIC_CONFIG_DIR|g" \
+  | sed -e "s|KUBELET_KUBECONFIG_ARGS=|KUBELET_KUBECONFIG_ARGS=--node-labels=$NODE_LABELS --dynamic-config-dir=$DYNAMIC_CONFIG_DIR|g " \
   | sed -e 's|--cni-bin-dir=[^ "]*|--cni-bin-dir=/opt/shimcni/bin|' \
   > /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
 

--- a/node/setup_k8s.sh.template
+++ b/node/setup_k8s.sh.template
@@ -69,7 +69,7 @@ NODE_LABELS="mlab/machine=${MACHINE},mlab/site=${SITE},mlab/metro=${METRO},mlab/
 DYNAMIC_CONFIG_DIR="/var/lib/kubelet/dynamic-configs"
 mkdir -p /etc/systemd/system/kubelet.service.d
 curl --silent --show-error --location "https://raw.githubusercontent.com/kubernetes/kubernetes/${RELEASE}/build/debs/10-kubeadm.conf" \
-  | sed -e "s|KUBELET_KUBECONFIG_ARGS=|KUBELET_KUBECONFIG_ARGS=--node-labels=$NODE_LABELS --dynamic-config-dir=$DYNAMIC_CONFIG_DIR|g " \
+  | sed -e "s|KUBELET_KUBECONFIG_ARGS=|KUBELET_KUBECONFIG_ARGS=--node-labels=$NODE_LABELS --dynamic-config-dir=$DYNAMIC_CONFIG_DIR |g" \
   | sed -e 's|--cni-bin-dir=[^ "]*|--cni-bin-dir=/opt/shimcni/bin|' \
   > /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
 


### PR DESCRIPTION
Without  the trailing space these options are merged with the following flags, causing everything to break.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/120)
<!-- Reviewable:end -->
