### PR TITLE
Adds a sidecar container kube-rbac-proxy to the node-exporter pods.

### DIFF
--- a/config/prometheus/prometheus.yml
+++ b/config/prometheus/prometheus.yml
@@ -59,6 +59,8 @@ scrape_configs:
     kubernetes_sd_configs:
       - role: pod
 
+    bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+
     relabel_configs:
       # For inventory, record whether a pod is ready. This helps distinguish
       # between: missing from inventory, not ready and failing, ready but

--- a/config/prometheus/prometheus.yml
+++ b/config/prometheus/prometheus.yml
@@ -59,9 +59,12 @@ scrape_configs:
     kubernetes_sd_configs:
       - role: pod
 
-    bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
-
     relabel_configs:
+      # node-exporter is scraped in a separate job.
+      - source_labels: [__meta_kubernetes_pod_label_app]
+        regex: node-exporter
+        action: drop
+
       # For inventory, record whether a pod is ready. This helps distinguish
       # between: missing from inventory, not ready and failing, ready but
       # failing, ready and working.
@@ -167,3 +170,83 @@ scrape_configs:
       - source_labels: [__meta_kubernetes_service_name]
         action: replace
         target_label: kubernetes_name
+
+
+  - job_name: 'node-exporter'
+    kubernetes_sd_configs:
+      - role: pod
+
+    scheme: https
+    tls_config:
+      ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      insecure_skip_verify: true
+    bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+
+    relabel_configs:
+      - source_labels: [__meta_kubernetes_pod_label_app]
+        regex: node-exporter
+        action: keep
+
+      # For inventory, record whether a pod is ready. This helps distinguish
+      # between: missing from inventory, not ready and failing, ready but
+      # failing, ready and working.
+      # and working.
+      - source_labels: [__meta_kubernetes_pod_ready]
+        action: replace
+        target_label: ready
+
+      # Check for the prometheus.io/scrape=true annotation.
+      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+        action: keep
+        regex: true
+
+      # Only keep containers that have a declared container port.
+      - source_labels: [__meta_kubernetes_pod_container_port_number]
+        action: keep
+        regex: (\d+)
+
+      # Copy all pod labels from kubernetes to the Prometheus metrics.
+      - action: labelmap
+        regex: __meta_kubernetes_pod_label_(.+)
+
+      # Add the kubernetes namespace as a Prometheus label.
+      - source_labels: [__meta_kubernetes_namespace]
+        action: replace
+        target_label: namespace
+
+      # Add the GKE node name.
+      - source_labels: [__meta_kubernetes_pod_node_name]
+        action: replace
+        target_label: node
+
+      # Identify the deployment name for replica set or daemon set.  Pods
+      # created by deployments or daemon sets are processed here. The
+      # following two rules recognize these two cases.
+      #
+      # 1: For DaemonSet, remove the last 5-digit pod name hash.
+      #   e.g. node-exporter-ltxgz
+      - source_labels: [__meta_kubernetes_pod_controller_kind, __meta_kubernetes_pod_name]
+        action: replace
+        regex: DaemonSet;(.*)(-[^-]{5})
+        replacement: $1
+        target_label: deployment
+
+      # 2: For ReplicaSet, remove the last 10-digit + 5-digit pod name hash.
+      # In the case of a daemon set that does not have the trailing hash, the
+      # regex will not match and deployment remains unchanged.
+      #   e.g. prometheus-server-3165440997-ppf9w
+      - source_labels: [__meta_kubernetes_pod_controller_kind, __meta_kubernetes_pod_name]
+        action: replace
+        regex: ReplicaSet;(.*)(-[^-]+)(-[^-]{5})
+        replacement: $1
+        target_label: deployment
+
+      # Add the kubernetes pod name.
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
+        target_label: pod
+
+      # Add the kubernetes pod container name.
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        action: replace
+        target_label: container

--- a/k8s/daemonsets/core/node-exporter.yml
+++ b/k8s/daemonsets/core/node-exporter.yml
@@ -31,7 +31,6 @@ spec:
         - --no-collector.bcache
         - --no-collector.bonding
         - --no-collector.conntrack
-        - --no-collector.cpufreq
         - --no-collector.entropy
         - --no-collector.filefd
         - --no-collector.infiniband
@@ -67,10 +66,10 @@ spec:
           name: textfile
           readOnly: true
       - name: kube-rbac-proxy
-        image: quay.io/coreos/kube-rbac-proxy
+        image: quay.io/coreos/kube-rbac-proxy:v0.4.1
         args:
         - --logtostderr
-        - --insecure-listen-address=$(IP):9100
+        - --secure-listen-address=$(IP):9100
         - --upstream=http://127.0.0.1:9100/
         env:
         - name: IP

--- a/k8s/daemonsets/core/node-exporter.yml
+++ b/k8s/daemonsets/core/node-exporter.yml
@@ -1,64 +1,82 @@
-apiVersion: apps/v1
+apiVersion: apps/v1beta2
 kind: DaemonSet
 metadata:
+  labels:
+    app: node-exporter
   name: node-exporter
-  namespace: default
 spec:
   selector:
     matchLabels:
-      run: node-exporter
+      app: node-exporter
   template:
     metadata:
       labels:
-        run: node-exporter
+        app: node-exporter
       annotations:
         prometheus.io/scrape: 'true'
     spec:
-      # We want node-exporter running on the k8s masters too.
-      tolerations:
-      - key: "node-role.kubernetes.io/master"
-        operator: "Exists"
-        effect: "NoSchedule"
-      # The kube-controller-manager is launched with flag
-      # --configure-cloud-routes=false to avoid issues with the platform
-      # bare-metal nodes (which are not in the cloud), but this has the side
-      # effect of adding the following taint to all cloud nodes, which we
-      # tolerate here, since we need Prometheus running regardless.
-      - key: "node.kubernetes.io/network-unavailable"
-        operator: "Exists"
-        effect: "NoSchedule"
-
+      serviceAccountName: kube-rbac-proxy
       containers:
       - name: node-exporter
-        image: prom/node-exporter
-        # TODO: enable --web.listen-address to listen on private IPs.
+        image: quay.io/prometheus/node-exporter:v0.17.0
         args:
+        - --web.listen-address=127.0.0.1:9100
         - --path.procfs=/host/proc
         - --path.sysfs=/host/sys
-        - --collector.textfile.directory=/host/textfile
+        - --path.rootfs=/host/root
+        - --collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+)($|/)
+        - --collector.filesystem.ignored-fs-types=^(autofs|binfmt_misc|cgroup|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|mqueue|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|sysfs|tracefs)$
+        resources:
+          limits:
+            cpu: 250m
+            memory: 180Mi
+          requests:
+            cpu: 102m
+            memory: 180Mi
+        volumeMounts:
+        - mountPath: /host/proc
+          name: proc
+          readOnly: false
+        - mountPath: /host/sys
+          name: sys
+          readOnly: false
+        - mountPath: /host/root
+          mountPropagation: HostToContainer
+          name: root
+          readOnly: true
+      - name: kube-rbac-proxy
+        image: quay.io/coreos/kube-rbac-proxy:v0.4.1
+        args:
+        - --logtostderr
+        - --insecure-listen-address=$(IP):9100
+        - --upstream=http://127.0.0.1:9100/
+        env:
+        - name: IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
         ports:
         - containerPort: 9100
           hostPort: 9100
-          name: scrape
-        volumeMounts:
-        - name: proc
-          mountPath: /host/proc
-          readOnly: true
-        - name: sys
-          mountPath: /host/sys
-          readOnly: true
-        - name: textfile
-          mountPath: /host/textfile
-          readOnly: true
-      volumes:
-      - name: proc
-        hostPath:
-          path: /proc
-      - name: sys
-        hostPath:
-          path: /sys
-      - name: textfile
-        configMap:
-          name: demo-nodeexporter
+        resources:
+          limits:
+            cpu: 20m
+            memory: 40Mi
+          requests:
+            cpu: 10m
+            memory: 20Mi
       hostNetwork: true
       hostPID: true
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+      volumes:
+      - hostPath:
+          path: /proc
+        name: proc
+      - hostPath:
+          path: /sys
+        name: sys
+      - hostPath:
+          path: /
+        name: root

--- a/k8s/daemonsets/core/node-exporter.yml
+++ b/k8s/daemonsets/core/node-exporter.yml
@@ -27,6 +27,24 @@ spec:
         - --collector.textfile.directory=/host/textfile
         - --collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+)($|/)
         - --collector.filesystem.ignored-fs-types=^(autofs|binfmt_misc|cgroup|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|mqueue|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|sysfs|tracefs)$
+        - --no-collector.arp
+        - --no-collector.bcache
+        - --no-collector.bonding
+        - --no-collector.conntrack
+        - --no-collector.cpufreq
+        - --no-collector.entropy
+        - --no-collector.filefd
+        - --no-collector.infiniband
+        - --no-collector.ipvs
+        - --no-collector.mdadm
+        - --no-collector.netclass
+        - --no-collector.nfs
+        - --no-collector.nfsd
+        - --no-collector.timex
+        - --no-collector.uname
+        - --no-collector.vmstat
+        - --no-collector.xfs
+        - --no-collector.zfs
         resources:
           limits:
             cpu: 250m

--- a/k8s/daemonsets/core/node-exporter.yml
+++ b/k8s/daemonsets/core/node-exporter.yml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   labels:
@@ -18,12 +18,13 @@ spec:
       serviceAccountName: kube-rbac-proxy
       containers:
       - name: node-exporter
-        image: quay.io/prometheus/node-exporter:v0.17.0
+        image: quay.io/prometheus/node-exporter
         args:
         - --web.listen-address=127.0.0.1:9100
         - --path.procfs=/host/proc
         - --path.sysfs=/host/sys
         - --path.rootfs=/host/root
+        - --collector.textfile.directory=/host/textfile
         - --collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+)($|/)
         - --collector.filesystem.ignored-fs-types=^(autofs|binfmt_misc|cgroup|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|mqueue|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|sysfs|tracefs)$
         resources:
@@ -44,8 +45,11 @@ spec:
           mountPropagation: HostToContainer
           name: root
           readOnly: true
+        - mountPath: /host/textfile
+          name: textfile
+          readOnly: true
       - name: kube-rbac-proxy
-        image: quay.io/coreos/kube-rbac-proxy:v0.4.1
+        image: quay.io/coreos/kube-rbac-proxy
         args:
         - --logtostderr
         - --insecure-listen-address=$(IP):9100
@@ -80,3 +84,6 @@ spec:
       - hostPath:
           path: /
         name: root
+      - configMap:
+          name: demo-nodeexporter
+        name: textfile

--- a/k8s/roles/kube-rbac-proxy.yml
+++ b/k8s/roles/kube-rbac-proxy.yml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-rbac-proxy
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kube-rbac-proxy
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kube-rbac-proxy
+subjects:
+- kind: ServiceAccount
+  name: kube-rbac-proxy
+  namespace: default
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kube-rbac-proxy
+rules:
+- apiGroups: ["authentication.k8s.io"]
+  resources:
+  - tokenreviews
+  verbs: ["create"]
+- apiGroups: ["authorization.k8s.io"]
+  resources:
+  - subjectaccessreviews
+  verbs: ["create"]


### PR DESCRIPTION
The node_exporter requires `hostNetwork: true` and `hostPID: true` to properly collect metrics for the entire machine. This causes node_exporter to listen on the node's public interface, exposing all collected metrics publicly.  a) this opens the service up to DoS abuse b) it exposes far too much information about the internals of each machine.

To get around this issue the [sidecar container kube-rbac-proxy](https://github.com/brancz/kube-rbac-proxy/) was added to the node_exporter DaemonSet. With this configuration, node_exporter listens on the loopback address only, and kube-rbac-proxy listens on the public interface. kube-rbac-proxy authenticates the bearer token supplied in each scrape request with the k8s API server, and also verifies that the requesting ServiceAccount (Prometheus) actually has permission to scrape node_exporter. Any other requests get a 401 Unauthorized reply from kube-rbac-proxy.

This PR also includes some optimizations and improvements to the node_exporter configuration.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/125)
<!-- Reviewable:end -->
