### PR TITLE
update ndt image tag

### DIFF
--- a/k8s/daemonsets/experiments/ndt.yml
+++ b/k8s/daemonsets/experiments/ndt.yml
@@ -37,9 +37,9 @@ spec:
       nodeSelector:
         mlab/type: 'platform'
       containers:
-      #Image tags refer to hub.docker.com images, e.g. docker pull measurementlab/ndt-server:v0.6.1
+      #Image tags refer to hub.docker.com images, e.g. docker pull measurementlab/ndt-server:v0.6.0
       - name: ndt-server
-        image: measurementlab/ndt-server:0.6.1
+        image: measurementlab/ndt-server:v0.6.0
         args:
         - -key=/certs/key.pem
         - -cert=/certs/cert.pem

--- a/k8s/daemonsets/experiments/ndt.yml
+++ b/k8s/daemonsets/experiments/ndt.yml
@@ -37,8 +37,9 @@ spec:
       nodeSelector:
         mlab/type: 'platform'
       containers:
+      #Image tags refer to hub.docker.com images, e.g. docker pull measurementlab/ndt-server:v0.6.1
       - name: ndt-server
-        image: measurementlab/ndt-server:v0.5
+        image: measurementlab/ndt-server:0.6.1
         args:
         - -key=/certs/key.pem
         - -cert=/certs/cert.pem

--- a/k8s/daemonsets/experiments/ndt.yml
+++ b/k8s/daemonsets/experiments/ndt.yml
@@ -37,7 +37,7 @@ spec:
       nodeSelector:
         mlab/type: 'platform'
       containers:
-      #Image tags refer to hub.docker.com images, e.g. docker pull measurementlab/ndt-server:v0.6.0
+      # Image tags refer to hub.docker.com images, e.g. docker pull measurementlab/ndt-server:v0.6.0
       - name: ndt-server
         image: measurementlab/ndt-server:v0.6.0
         args:


### PR DESCRIPTION
This updates the ndt-server image tag to 0.6.1

Ideally, this should be v0.6.1 but there was an error in the tag expression.  Fixed the expression and rebuilding, and we should update the tag to v0.6.1 if the build is successful.

See https://github.com/m-lab/dev-tracker/issues/219 and
https://cloud.docker.com/u/measurementlab/repository/docker/measurementlab/ndt-server/general

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/134)
<!-- Reviewable:end -->
