### PR TITLE
Revert "update ndt image tag"

### DIFF
--- a/k8s/daemonsets/experiments/ndt.yml
+++ b/k8s/daemonsets/experiments/ndt.yml
@@ -37,9 +37,8 @@ spec:
       nodeSelector:
         mlab/type: 'platform'
       containers:
-      # Image tags refer to hub.docker.com images, e.g. docker pull measurementlab/ndt-server:v0.6.0
       - name: ndt-server
-        image: measurementlab/ndt-server:v0.6.0
+        image: measurementlab/ndt-server:v0.5
         args:
         - -key=/certs/key.pem
         - -cert=/certs/cert.pem


### PR DESCRIPTION
Reverts m-lab/k8s-support#134

This version of ndt-server has a bug in call to r.Cancel()

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/140)
<!-- Reviewable:end -->
