### PR TITLE
Sets updateStrategy to RollingUpdate for all DaemonSets and Deployments

### DIFF
--- a/k8s/daemonsets/core/cadvisor.yml
+++ b/k8s/daemonsets/core/cadvisor.yml
@@ -7,6 +7,8 @@ spec:
   selector:
     matchLabels:
       run: cadvisor
+  updateStrategy:
+    type: RollingUpdate
   template:
     metadata:
       labels:

--- a/k8s/daemonsets/core/kube-state-metrics.yml
+++ b/k8s/daemonsets/core/kube-state-metrics.yml
@@ -10,6 +10,8 @@ spec:
     matchLabels:
       k8s-app: kube-state-metrics
   replicas: 1
+  updateStrategy:
+    type: RollingUpdate
   template:
     metadata:
       labels:

--- a/k8s/daemonsets/core/node-exporter.yml
+++ b/k8s/daemonsets/core/node-exporter.yml
@@ -8,6 +8,8 @@ spec:
   selector:
     matchLabels:
       app: node-exporter
+  updateStrategy:
+    type: RollingUpdate
   template:
     metadata:
       labels:

--- a/k8s/daemonsets/core/scamper.yml
+++ b/k8s/daemonsets/core/scamper.yml
@@ -7,6 +7,8 @@ spec:
   selector:
     matchLabels:
       run: scamper
+  updateStrategy:
+    type: RollingUpdate
   template:
     metadata:
       labels:
@@ -14,6 +16,8 @@ spec:
       annotations:
         prometheus.io/scrape: 'false'
     spec:
+      nodeSelector:
+        mlab/type: 'platform'
       containers:
       - name: scamper
         image: measurementlab/scamper:v2.0

--- a/k8s/deployments/container-linux-update-operator.yml
+++ b/k8s/deployments/container-linux-update-operator.yml
@@ -9,6 +9,8 @@ spec:
   selector:
     matchLabels:
       app: container-linux-update-operator
+  updateStrategy:
+    type: RollingUpdate
   template:
     metadata:
       labels:

--- a/k8s/deployments/prometheus.yml
+++ b/k8s/deployments/prometheus.yml
@@ -7,6 +7,10 @@ spec:
   selector:
     matchLabels:
       app: prometheus-server
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
   template:
     metadata:
       labels:


### PR DESCRIPTION
Additional, sets the nodeSelector to mlab/type=platform for the scamper DS.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/145)
<!-- Reviewable:end -->
