### PR TITLE
Removes the maxUnavailable=0 option for RollingUpdate on the Prom Deployment.

### DIFF
--- a/k8s/deployments/prometheus.yml
+++ b/k8s/deployments/prometheus.yml
@@ -9,8 +9,6 @@ spec:
       app: prometheus-server
   updateStrategy:
     type: RollingUpdate
-    rollingUpdate:
-      maxUnavailable: 0
   template:
     metadata:
       labels:


### PR DESCRIPTION
Since the Prom pods can only be scheduled on a single, special purpose node, this would cause port conflicts and the possibility of two Prom pods both writing to the DB at the same time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/146)
<!-- Reviewable:end -->
