### PR TITLE
Adds a node label to all kubernetes-nodes auto-discovered targets

### DIFF
--- a/config/prometheus/prometheus.yml
+++ b/config/prometheus/prometheus.yml
@@ -105,6 +105,12 @@ scrape_configs:
         action: replace
         target_label: node
 
+      # Add a machine label to make it easier to join these metrics with
+      # existing metrics that use machine instead of the node label.
+      - source_labels: [__meta_kubernetes_pod_node_name]
+        action: replace
+        target_label: machine
+
       # TODO: find a better source of this information or remove it. The value
       # returned is incomplete. Used only by Prometheus_SelfMonitoring.json.
       # Extract the "<cluster>-<node-pool>" name from the GKE node name.
@@ -145,12 +151,6 @@ scrape_configs:
       - source_labels: [__meta_kubernetes_pod_container_name]
         action: replace
         target_label: container
-
-      # Add a machine label to make it easier to join these metrics with
-      # existing metrics that use machine instead of the node label.
-      - source_labels: [__meta_kubernetes_pod_node_name]
-        action: replace
-        target_label: machine
 
 
   # Scrape config for kubernetes service endpoints.

--- a/config/prometheus/prometheus.yml
+++ b/config/prometheus/prometheus.yml
@@ -228,10 +228,15 @@ scrape_configs:
         action: replace
         target_label: namespace
 
-      # Add the GKE node name.
+      # Add the node name to a label named node.
       - source_labels: [__meta_kubernetes_pod_node_name]
         action: replace
         target_label: node
+
+      # Add a machine label to each target node that is auto-discovered.
+      - source_labels: [__meta_kubernetes_pod_node_name]
+        action: replace
+        target_label: machine
 
       # Identify the deployment name for replica set or daemon set.  Pods
       # created by deployments or daemon sets are processed here. The

--- a/config/prometheus/prometheus.yml
+++ b/config/prometheus/prometheus.yml
@@ -52,6 +52,11 @@ scrape_configs:
         regex: (.+)
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics
+      # Add a node label to each target node that is auto-discovered.
+      - source_labels: [__meta_kubernetes_node_address_Hostname]
+        regex: (.+)
+        target_label: node
+        replacement: ${1}
 
 
   # Scrape config for kubernetes pods.

--- a/config/prometheus/prometheus.yml
+++ b/config/prometheus/prometheus.yml
@@ -57,6 +57,11 @@ scrape_configs:
         regex: (.+)
         target_label: node
         replacement: ${1}
+      # Add a machine label to each target node that is auto-discovered.
+      - source_labels: [__meta_kubernetes_node_address_Hostname]
+        regex: (.+)
+        target_label: machine
+        replacement: ${1}
 
 
   # Scrape config for kubernetes pods.

--- a/config/prometheus/prometheus.yml
+++ b/config/prometheus/prometheus.yml
@@ -53,15 +53,13 @@ scrape_configs:
         target_label: __metrics_path__
         replacement: /api/v1/nodes/${1}/proxy/metrics
       # Add a node label to each target node that is auto-discovered.
-      - source_labels: [__meta_kubernetes_node_address_Hostname]
-        regex: (.+)
+      - source_labels: [__meta_kubernetes_node_name]
+        action: replace
         target_label: node
-        replacement: ${1}
       # Add a machine label to each target node that is auto-discovered.
-      - source_labels: [__meta_kubernetes_node_address_Hostname]
-        regex: (.+)
+      - source_labels: [__meta_kubernetes_node_name]
+        action: replace
         target_label: machine
-        replacement: ${1}
 
 
   # Scrape config for kubernetes pods.
@@ -147,6 +145,12 @@ scrape_configs:
       - source_labels: [__meta_kubernetes_pod_container_name]
         action: replace
         target_label: container
+
+      # Add a machine label to make it easier to join these metrics with
+      # existing metrics that use machine instead of the node label.
+      - source_labels: [__meta_kubernetes_pod_node_name]
+        action: replace
+        target_label: machine
 
 
   # Scrape config for kubernetes service endpoints.


### PR DESCRIPTION
The new `node` and `machine` labels are set to the value of `kubernetes_io_hostname`. Having `node` 
 and `machine` labels will make it much easier to join these metrics with other kubernetes-related metrics as well as to older metrics (e.g., gmx_machine_maintenance) that use the label `machine` instead of `node`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/153)
<!-- Reviewable:end -->
