### PR TITLE
Tells Prometheus to ignore TLS certificate verification when scraping api-servers

### DIFF
--- a/config/prometheus/prometheus.yml
+++ b/config/prometheus/prometheus.yml
@@ -18,6 +18,7 @@ scrape_configs:
     scheme: https
     tls_config:
       ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+      insecure_skip_verify: true
     bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
 
     relabel_configs:


### PR DESCRIPTION
The api-server certificates do not currently include SANs for the public IPs of the nodes, yet Prometheus is scraping them via the public IP (because `--advertise-address` on api-servers is set to public IP for other reasons). Ignore these errors for now and scrape anyway. We may chose to resolve this later in some other way.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/157)
<!-- Reviewable:end -->
