### PR TITLE
Sets ipvlan mode to l3s, and adds a new flannel config for experiments.

### DIFF
--- a/k8s/custom-resource-definitions/network-attachment-definitions.yml
+++ b/k8s/custom-resource-definitions/network-attachment-definitions.yml
@@ -28,6 +28,8 @@ spec:
 
 # The CRD objects.
 ---
+# The default flannel configuration that gets applied to non-experiment pods.
+# The important bit here is that isDefaultGateway=true.
 apiVersion: "k8s.cni.cncf.io/v1"
 kind: NetworkAttachmentDefinition
 metadata:
@@ -42,6 +44,23 @@ spec:
     }
   }'
 ---
+# The flannel configuration that gets applied to experiment pods. Only pods
+# with the following annotation will use this configuration:
+# `v1.multus-cni.io/default-network: flannel-experiment-conf`
+apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+ name: flannel-experiment-conf
+spec:
+  config: '{
+    "cniVersion": "0.3.0",
+    "type": "flannel",
+    "delegate": {
+       "hairpinMode": true,
+       "isDefaultGateway": false
+    }
+  }'
+---
 apiVersion: "k8s.cni.cncf.io/v1"
 kind: NetworkAttachmentDefinition
 metadata:
@@ -52,6 +71,7 @@ spec:
     "name": "ipvlan-index-1",
     "type": "ipvlan",
     "master": "eth0",
+    "mode": "l3s",
     "ipam": {
       "type": "index2ip",
       "index": 1
@@ -68,6 +88,7 @@ spec:
     "name": "ipvlan-index-2",
     "type": "ipvlan",
     "master": "eth0",
+    "mode": "l3s",
     "ipam": {
       "type": "index2ip",
       "index": 2
@@ -84,6 +105,7 @@ spec:
     "name": "ipvlan-index-4",
     "type": "ipvlan",
     "master": "eth0",
+    "mode": "l3s",
     "ipam": {
       "type": "index2ip",
       "index": 4
@@ -100,6 +122,7 @@ spec:
     "name": "ipvlan-index-5",
     "type": "ipvlan",
     "master": "eth0",
+    "mode": "l3s",
     "ipam": {
       "type": "index2ip",
       "index": 5
@@ -116,6 +139,7 @@ spec:
     "name": "ipvlan-index-6,
     "type": "ipvlan",
     "master": "eth0",
+    "mode": "l3s",
     "ipam": {
       "type": "index2ip",
       "index": 6
@@ -132,6 +156,7 @@ spec:
     "name": "ipvlan-index-7",
     "type": "ipvlan",
     "master": "eth0",
+    "mode": "l3s",
     "ipam": {
       "type": "index2ip",
       "index": 7
@@ -148,6 +173,7 @@ spec:
     "name": "ipvlan-index-8",
     "type": "ipvlan",
     "master": "eth0",
+    "mode": "l3s",
     "ipam": {
       "type": "index2ip",
       "index": 8
@@ -164,6 +190,7 @@ spec:
     "name": "ipvlan-index-9",
     "type": "ipvlan",
     "master": "eth0",
+    "mode": "l3s",
     "ipam": {
       "type": "index2ip",
       "index": 9
@@ -180,6 +207,7 @@ spec:
     "name": "ipvlan-index-10",
     "type": "ipvlan",
     "master": "eth0",
+    "mode": "l3s",
     "ipam": {
       "type": "index2ip",
       "index": 10
@@ -196,6 +224,7 @@ spec:
     "name": "ipvlan-index-11",
     "type": "ipvlan",
     "master": "eth0",
+    "mode": "l3s",
     "ipam": {
       "type": "index2ip",
       "index": 11
@@ -212,6 +241,7 @@ spec:
     "name": "ipvlan-index-12",
     "type": "ipvlan",
     "master": "eth0",
+    "mode": "l3s",
     "ipam": {
       "type": "index2ip",
       "index": 12

--- a/k8s/custom-resource-definitions/network-attachment-definitions.yml
+++ b/k8s/custom-resource-definitions/network-attachment-definitions.yml
@@ -29,7 +29,7 @@ spec:
 # The CRD objects.
 ---
 # The default flannel configuration that gets applied to non-experiment pods.
-# The important bit here is that isDefaultGateway=true.
+# The important difference here is that isDefaultGateway=true.
 apiVersion: "k8s.cni.cncf.io/v1"
 kind: NetworkAttachmentDefinition
 metadata:

--- a/k8s/daemonsets/experiments/ndt.yml
+++ b/k8s/daemonsets/experiments/ndt.yml
@@ -20,6 +20,7 @@ spec:
       annotations:
         prometheus.io/scrape: 'true'
         k8s.v1.cni.cncf.io/networks: '[{ "name": "index2ip-index-2-conf" }]'
+        v1.multus-cni.io/default-network: flannel-experiment-conf
     spec:
       # The default grace period after k8s sends SIGTERM is 30s. We extend the
       # grace period to give time for the following shutdown sequence. After the


### PR DESCRIPTION
The default ipvlan mode is "l2". In this mode (and "l3" mode) traffic through the ipvlan interface **only** traverses iptables rules in the container's network namespace, which causes all traffic to bypass kube-proxy iptables rules. This is fine for experiment traffic, but k8s traffic needs to pass through those rules for everything to work as expected. This PR sets to the ipvlan mode to "l3s" which is a special mode to allow for traffic to pass through iptables rules in the default network namespace.

Additionally, this PR introduces a new flannel NetworkAttachmentDefinition which will be applied to experiment DaemonSets. This new config sets to `isDefaultGateway=false` so that experiment traffic is routed through the ipvlan interface, and not the flannel bridge.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/166)
<!-- Reviewable:end -->
