### PR TITLE
Sets the tcpinfo container in the ndt DaemonSet to pull v0.0.7

### DIFF
--- a/k8s/daemonsets/experiments/ndt.yml
+++ b/k8s/daemonsets/experiments/ndt.yml
@@ -60,7 +60,7 @@ spec:
           readOnly: true
 
       - name: tcpinfo
-        image: measurementlab/tcp-info:v0.0.6
+        image: measurementlab/tcp-info:v0.0.7
         args:
         - -prom=:9091
         - -output=/var/spool/ndt/tcpinfo


### PR DESCRIPTION
v0.0.7 is a bugfix release.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/168)
<!-- Reviewable:end -->
