### PR TITLE
Write NDT tcp-info and traceroute data to /cache/data instead of /cache/core

### DIFF
--- a/k8s/daemonsets/core/node-exporter.yml
+++ b/k8s/daemonsets/core/node-exporter.yml
@@ -44,7 +44,6 @@ spec:
         - --no-collector.timex
         - --no-collector.uname
         - --no-collector.vmstat
-        - --no-collector.xfs
         - --no-collector.zfs
         resources:
           limits:

--- a/k8s/daemonsets/experiments/ndt.yml
+++ b/k8s/daemonsets/experiments/ndt.yml
@@ -141,11 +141,11 @@ spec:
       volumes:
       - name: tcpinfo-data
         hostPath:
-          path: /cache/core/ndt/tcpinfo
+          path: /cache/data/ndt/tcpinfo
           type: DirectoryOrCreate
       - name: traceroute-data
         hostPath:
-          path: /cache/core/ndt/traceroute
+          path: /cache/data/ndt/traceroute
           type: DirectoryOrCreate
       - name: pusher-credentials
         secret:


### PR DESCRIPTION
This PR modifies the NDT DaemonSet to write tcp-info and traceroute data to the `/cache/data` directory instead of `/cache/core`. Indeed, `/cache/core` will no longer exist. For now, all "core" and experiment data will be written to one large pool of disk space.

We also enable XFS metrics in node_exporter, [now that our platform nodes will be using XFS instead of EXT4](https://github.com/m-lab/epoxy-images/pull/101).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/172)
<!-- Reviewable:end -->
