### PR TITLE
Adds the nodeinfo daemonset to core

### DIFF
--- a/k8s/daemonsets/core/nodeinfo.yml
+++ b/k8s/daemonsets/core/nodeinfo.yml
@@ -20,6 +20,10 @@ spec:
     spec:
       nodeSelector:
         mlab/type: 'platform'
+      # Note: with hostNetwork: true, this will make any metrics published by
+      # either container open to the public. If there is anything that we might
+      # consider even a little sensitive in the metrics of either, then we
+      # should work around this.
       hostNetwork: true
       hostPID: true
       containers:

--- a/k8s/daemonsets/core/nodeinfo.yml
+++ b/k8s/daemonsets/core/nodeinfo.yml
@@ -1,0 +1,88 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app: nodeinfo
+  name: nodeinfo
+spec:
+  selector:
+    matchLabels:
+      app: nodeinfo
+  updateStrategy:
+    type: RollingUpdate
+
+  template:
+    metadata:
+      labels:
+        app: nodeinfo
+      annotations:
+        prometheus.io/scrape: 'true'
+    spec:
+      nodeSelector:
+        mlab/type: 'platform'
+      hostNetwork: true
+      hostPID: true
+      containers:
+      - name: nodeinfo
+        image: measurementlab/nodeinfo:v0.2
+        ports:
+        - containerPort: 9990
+        args:
+        - -datadir=/var/spool/nodeinfo
+        - -wait=1h
+        - -prometheusx.listen-address=:9990
+        - -datatype=lspci
+        - -datatype=lsusb
+        - -datatype=ifconfig
+        - -datatype=route-v4
+        - -datatype=route-v6
+        - -datatype=uname
+        - -datatype=lshw
+        volumeMounts:
+        - name: nodeinfo-data
+          mountPath: /var/spool/nodeinfo
+
+      - name: pusher
+        image: measurementlab/pusher:v1.7
+        ports:
+        - containerPort: 9991
+        args:
+        - -monitoring_address=:9991
+        - -experiment=nodeinfo
+        - -archive_size_threshold=50MB
+        - -directory=/var/spool/nodeinfo
+        - -datatype=lspci
+        - -datatype=lsusb
+        - -datatype=ifconfig
+        - -datatype=route
+        - -datatype=uname
+        - -datatype=lshw
+        env:
+        - name: GOOGLE_APPLICATION_CREDENTIALS
+          value: /etc/credentials/pusher.json
+        - name: BUCKET
+          valueFrom:
+            configMapKeyRef:
+              name: pusher-dropbox
+              key: bucket
+        - name: MLAB_NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
+        volumeMounts:
+        - name: nodeinfo-data
+          mountPath: /var/spool/nodeinfo
+        - name: pusher-credentials
+          mountPath: /etc/credentials
+          readOnly: true
+
+      volumes:
+      - name: nodeinfo-data
+        hostPath:
+          path: /cache/data/node/nodeinfo
+          type: DirectoryOrCreate
+      - name: pusher-credentials
+        secret:
+          secretName: pusher-credentials
+      - name: uuid-prefix
+        emptyDir: {}


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/178)
<!-- Reviewable:end -->
