### PR TITLE
Sets spec.strategy to Recreate, and enables some additional kube-state-metrics collectors.

### DIFF
--- a/k8s/deployments/kube-state-metrics.yml
+++ b/k8s/deployments/kube-state-metrics.yml
@@ -1,6 +1,4 @@
 apiVersion: apps/v1
-# Kubernetes version 1.8.x should use apps/v1beta2
-# Kubernetes versions before 1.8.0 should use apps/v1beta1 or extensions/v1beta1
 kind: Deployment
 metadata:
   name: kube-state-metrics
@@ -11,7 +9,7 @@ spec:
       k8s-app: kube-state-metrics
   replicas: 1
   strategy:
-    type: RollingUpdate
+    type: Recreate
   template:
     metadata:
       labels:
@@ -37,7 +35,7 @@ spec:
           initialDelaySeconds: 5
           timeoutSeconds: 5
         args: [
-          "--collectors=deployments,nodes,pods,services"
+          "--collectors=daemonsets,deployments,nodes,pods,resourcequotas,services"
         ]
       - name: addon-resizer
         image: k8s.gcr.io/addon-resizer:1.8.3


### PR DESCRIPTION
Doesn't make sense to have a RollingUpdate on a replicaset with 1 replica. Also, we have lots of DaemonSets, so we should be collecting metrics on them. And the `resourcequotas` collector sounded interesting too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/182)
<!-- Reviewable:end -->
