### PR TITLE
Use most recent tcp-info

### DIFF
--- a/k8s/daemonsets/experiments/ndt.yml
+++ b/k8s/daemonsets/experiments/ndt.yml
@@ -60,7 +60,7 @@ spec:
           readOnly: true
 
       - name: tcpinfo
-        image: measurementlab/tcp-info:v0.0.7
+        image: measurementlab/tcp-info:v0.0.8
         args:
         - -prom=:9091
         - -output=/var/spool/ndt/tcpinfo


### PR DESCRIPTION
v0.0.8 adjusts the diff detection to reduce number of snapshots.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/183)
<!-- Reviewable:end -->
