### PR TITLE
Renames CLUO workloads to shorter names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,15 @@
 *.swp
+etcd-tls/
 ndt-tls/
 flannel.yml
 flannel-cloud.yml
 flannel-platform.yml
+fluentd.json
 kube-config
+output.conf
 pusher.json
+reboot-api/
+reboot-api.yml
 setup_k8s.sh
+
+

--- a/k8s/daemonsets/core/update-agent.yml
+++ b/k8s/daemonsets/core/update-agent.yml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: container-linux-update-agent
+  name: update-agent
   namespace: reboot-coordinator
 spec:
   selector:

--- a/k8s/deployments/update-operator.yml
+++ b/k8s/deployments/update-operator.yml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: container-linux-update-operator
+  name: update-operator
   namespace: reboot-coordinator
 spec:
   replicas: 1


### PR DESCRIPTION
In PR #187 we updated the CLUO label names and files names to use a shorter name, but I failed to update the actual names of the workloads themselves. This PR resolves that.

Additionally it add more patterns to .gitignore.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/193)
<!-- Reviewable:end -->
