### PR TITLE
Enable Prometheus scraping for fluentd.

### DIFF
--- a/k8s/daemonsets/core/fluentd.yml
+++ b/k8s/daemonsets/core/fluentd.yml
@@ -20,10 +20,11 @@ spec:
         workload: fluentd
         kubernetes.io/cluster-service: "true"
         version: v2.0
-      # This annotation ensures that fluentd does not get evicted if the node
-      # supports critical pod annotation based priority scheme.
-      # Note that this does not guarantee admission on the nodes (#40573).
       annotations:
+        prometheus.io/scrape: "true"
+        # This annotation ensures that fluentd does not get evicted if the node
+        # supports critical pod annotation based priority scheme.
+        # Note that this does not guarantee admission on the nodes (#40573).
         scheduler.alpha.kubernetes.io/critical-pod: ''
     spec:
       dnsPolicy: Default
@@ -54,6 +55,10 @@ spec:
           requests:
             cpu: 100m
             memory: 200Mi
+        ports:
+        - containerPort: 9900
+          name: scrape
+          protocol: TCP
         volumeMounts:
         - name: varlog
           mountPath: /var/log


### PR DESCRIPTION
This PR allows Prometheus to scrape fluentd by adding a `containerPort` and the relevant annotation.
This is useful to get metrics about the log ingestion status and create relevant alerts in future.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/194)
<!-- Reviewable:end -->
