### PR TITLE
Sets the update strategy for reboot-api to Recreate

### DIFF
--- a/k8s/deployments/reboot-api.yml.template
+++ b/k8s/deployments/reboot-api.yml.template
@@ -7,6 +7,8 @@ spec:
   selector:
     matchLabels:
       workload: reboot-api
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:


### PR DESCRIPTION
Apparently `RollingUpdate` is the default, but you can't do a rolling update on a deployment with only a single replica. It will hang with the old pod still running and the new one pending.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/200)
<!-- Reviewable:end -->
