### PR TITLE
Adds a Daemonset manifest for the BISmark server

### DIFF
--- a/k8s/daemonsets/experiments.jsonnet
+++ b/k8s/daemonsets/experiments.jsonnet
@@ -1,3 +1,4 @@
 [
   import 'experiments/ndt.jsonnet',
+  import 'experiments/bismark.jsonnet',
 ]

--- a/k8s/daemonsets/experiments/bismark.jsonnet
+++ b/k8s/daemonsets/experiments/bismark.jsonnet
@@ -1,0 +1,230 @@
+{
+  apiVersion: 'apps/v1',
+  kind: 'DaemonSet',
+  metadata: {
+    name: 'bismark',
+    namespace: 'default',
+  },
+  spec: {
+    selector: {
+      matchLabels: {
+        workload: 'bismark',
+      },
+    },
+    template: {
+      metadata: {
+        annotations: {
+          'k8s.v1.cni.cncf.io/networks': '[{ "name": "index2ip-index-9-conf" }]',
+          'prometheus.io/scrape': 'true',
+          'v1.multus-cni.io/default-network': 'flannel-experiment-conf',
+        },
+        labels: {
+          workload: 'bismark',
+        },
+      },
+      spec: {
+        containers: [
+          {
+            name: 'bismark',
+            image: 'measurementlab/bismark-test:v1.0.0',
+            ports: [
+              {
+                containerPort: 9090,
+              },
+            ],
+            volumeMounts: [
+              {
+                mountPath: '/var/local/uuid',
+                name: 'uuid-prefix',
+                readOnly: true,
+              },
+            ],
+          },
+          {
+            name: 'tcpinfo',
+            image: 'measurementlab/tcp-info:v0.0.8',
+            args: [
+              '-prometheusx.listen-address=:9091',
+              '-output=/var/spool/bismark/tcpinfo',
+              '-uuid-prefix-file=/var/local/uuid/prefix',
+            ],
+            ports: [
+              {
+                containerPort: 9091,
+              },
+            ],
+            volumeMounts: [
+              {
+                mountPath: '/var/spool/bismark/tcpinfo',
+                name: 'tcpinfo-data',
+              },
+              {
+                mountPath: '/var/local/uuid',
+                name: 'uuid-prefix',
+                readOnly: true,
+              },
+            ],
+          },
+          {
+            name: 'traceroute',
+            image: 'measurementlab/traceroute-caller:v0.0.5',
+            args: [
+              '-prometheusx.listen-address=:9092',
+              '-outputPath=/var/spool/bismark/traceroute',
+              '-uuid-prefix-file=/var/local/uuid/prefix',
+            ],
+            ports: [
+              {
+                containerPort: 9092,
+              },
+            ],
+            volumeMounts: [
+              {
+                mountPath: '/var/spool/bismark/traceroute',
+                name: 'traceroute-data',
+              },
+              {
+                mountPath: '/var/local/uuid',
+                name: 'uuid-prefix',
+                readOnly: true,
+              },
+            ],
+          },
+          {
+            name: 'pusher',
+            image: 'measurementlab/pusher:v1.8',
+            args: [
+              '-prometheusx.listen-address=:9093',
+              '-experiment=bismark',
+              '-archive_size_threshold=50MB',
+              '-directory=/var/spool/bismark',
+              '-datatype=tcpinfo',
+              '-datatype=traceroute',
+              '-datatype=legacy',
+              '-datatype=bismark',
+            ],
+            env: [
+              {
+                name: 'GOOGLE_APPLICATION_CREDENTIALS',
+                value: '/etc/credentials/pusher.json',
+              },
+              {
+                name: 'BUCKET',
+                valueFrom: {
+                  configMapKeyRef: {
+                    key: 'bucket',
+                    name: 'pusher-dropbox',
+                  },
+                },
+              },
+              {
+                name: 'MLAB_NODE_NAME',
+                valueFrom: {
+                  fieldRef: {
+                    fieldPath: 'spec.nodeName',
+                  },
+                },
+              },
+            ],
+            ports: [
+              {
+                containerPort: 9093,
+              },
+            ],
+            volumeMounts: [
+              {
+                mountPath: '/var/spool/bismark/traceroute',
+                name: 'traceroute-data',
+              },
+              {
+                mountPath: '/var/spool/bismark/tcpinfo',
+                name: 'tcpinfo-data',
+              },
+              {
+                mountPath: '/var/spool/bismark/legacy',
+                name: 'legacy-data',
+              },
+              {
+                mountPath: '/etc/credentials',
+                name: 'pusher-credentials',
+                readOnly: true,
+              },
+            ],
+          },
+        ],
+        initContainers: [
+          // TODO: this is a hack. Remove the hack by fixing the
+          // contents of resolv.conf
+          {
+            name: 'fix-resolv-conf',
+            image: 'busybox',
+            command: [
+              'sh',
+              '-c',
+              'echo "nameserver 8.8.8.8" > /etc/resolv.conf',
+            ],
+          },
+          // Write out the UUID prefix to a well-known location. For
+          // more on this, see DESIGN.md in
+          // https://github.com/m-lab/uuid/
+          {
+
+            name: 'set-up-uuid-prefix-file',
+            image: 'measurementlab/uuid:v0.1',
+            args: [
+              '-filename=/var/local/uuid/prefix',
+            ],
+            volumeMounts: [
+              {
+                mountPath: '/var/local/uuid',
+                name: 'uuid-prefix',
+              },
+            ],
+          },
+        ],
+        nodeSelector: {
+          'mlab/type': 'platform',
+        },
+        volumes: [
+          {
+            hostPath: {
+              path: '/cache/data/bismark/traceroute',
+              type: 'DirectoryOrCreate',
+            },
+            name: 'traceroute-data',
+          },
+          {
+            hostPath: {
+              path: '/cache/data/bismark/tcpinfo',
+              type: 'DirectoryOrCreate',
+            },
+            name: 'tcpinfo-data',
+          },
+          {
+            hostPath: {
+              path: '/cache/data/bismark/legacy',
+              type: 'DirectoryOrCreate',
+            },
+            name: 'legacy-data',
+          },
+          {
+            name: 'pusher-credentials',
+            secret: {
+              secretName: 'pusher-credentials',
+            },
+          },
+          {
+            emptyDir: {},
+            name: 'uuid-prefix',
+          },
+        ],
+      },
+    },
+    updateStrategy: {
+      rollingUpdate: {
+        maxUnavailable: 2,
+      },
+      type: 'RollingUpdate',
+    },
+  },
+}

--- a/k8s/daemonsets/experiments/bismark.jsonnet
+++ b/k8s/daemonsets/experiments/bismark.jsonnet
@@ -100,8 +100,7 @@
               '-directory=/var/spool/bismark',
               '-datatype=tcpinfo',
               '-datatype=traceroute',
-              '-datatype=legacy',
-              '-datatype=bismark',
+              '-datatype=legacy'
             ],
             env: [
               {

--- a/k8s/daemonsets/experiments/bismark.jsonnet
+++ b/k8s/daemonsets/experiments/bismark.jsonnet
@@ -100,7 +100,6 @@
               '-directory=/var/spool/bismark',
               '-datatype=tcpinfo',
               '-datatype=traceroute',
-              '-datatype=legacy'
             ],
             env: [
               {
@@ -138,10 +137,6 @@
               {
                 mountPath: '/var/spool/bismark/tcpinfo',
                 name: 'tcpinfo-data',
-              },
-              {
-                mountPath: '/var/spool/bismark/legacy',
-                name: 'legacy-data',
               },
               {
                 mountPath: '/etc/credentials',
@@ -198,13 +193,6 @@
               type: 'DirectoryOrCreate',
             },
             name: 'tcpinfo-data',
-          },
-          {
-            hostPath: {
-              path: '/cache/data/bismark/legacy',
-              type: 'DirectoryOrCreate',
-            },
-            name: 'legacy-data',
           },
           {
             name: 'pusher-credentials',

--- a/k8s/daemonsets/experiments/bismark.jsonnet
+++ b/k8s/daemonsets/experiments/bismark.jsonnet
@@ -26,7 +26,7 @@
         containers: [
           {
             name: 'bismark',
-            image: 'measurementlab/bismark-test:v1.0.0',
+            image: 'measurementlab/bismark-test:v1.0.1',
             ports: [
               {
                 containerPort: 9090,


### PR DESCRIPTION
I have cloned the BISmark repo, built the Docker image, and pushed it to a temporary location in m-lab's Docker Hub account. We can formalize the location once things are working as expected.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/215)
<!-- Reviewable:end -->
