### PR TITLE
Creates /opt dir and makes a symlink /opt/cni that points to /usr/cni.

### DIFF
--- a/node/setup_k8s.sh.template
+++ b/node/setup_k8s.sh.template
@@ -56,6 +56,12 @@ curl --silent --show-error --location "https://raw.githubusercontent.com/kuberne
 # it doesn't exist, polluting the logs terribly.
 mkdir -p /etc/kubernetes/manifests
 
+# CNI binaries are baked into the boot images at /usr/cni/bin, however, the
+# kubelet expects to find them in /opt/cni/bin by default. Rather than muck
+# with default settings, we just create a symlink here.
+mkdir -p /opt
+ln -s /usr/cni /opt/cni
+
 systemctl daemon-reload
 systemctl enable docker
 systemctl start docker


### PR DESCRIPTION
Previously, the CNI binaries were copied into /opt/cni/bin by setup_k8s.sh. We removed that, and now binaries are baked into boot images at /usr/cni. This PR adds a symlink from /opt/cni to /usr/cni rather than attempting to modify the default kubelet `--cni-bin-dir`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/217)
<!-- Reviewable:end -->
