### PR TITLE
Use a single data volume for each experiment

### DIFF
--- a/k8s/daemonsets/core/host.jsonnet
+++ b/k8s/daemonsets/core/host.jsonnet
@@ -12,7 +12,7 @@ exp.ExperimentNoIndex('host', nodeinfo_datatypes, true) + {
             name: 'nodeinfo',
             image: 'measurementlab/nodeinfo:v1.2',
             args: [
-              '-datadir=/var/spool/' + name,
+              '-datadir=/var/spool/host',
               '-wait=1h',
               '-prometheusx.listen-address=127.0.0.1:9990',
               '-config=/etc/nodeinfo/config.json',

--- a/k8s/daemonsets/core/host.jsonnet
+++ b/k8s/daemonsets/core/host.jsonnet
@@ -23,6 +23,7 @@ exp.ExperimentNoIndex('host', nodeinfo_datatypes, true) + {
                 name: 'nodeinfo-config',
                 readOnly: true,
               },
+              exp.VolumeMount('host'),
             ],
           },
           exp.RBACProxy('nodeinfo', 9990),

--- a/k8s/daemonsets/core/host.jsonnet
+++ b/k8s/daemonsets/core/host.jsonnet
@@ -12,7 +12,7 @@ exp.ExperimentNoIndex('host', nodeinfo_datatypes, true) + {
             name: 'nodeinfo',
             image: 'measurementlab/nodeinfo:v1.2',
             args: [
-              '-datadir=/var/spool/nodeinfo',
+              '-datadir=/var/spool/' + name,
               '-wait=1h',
               '-prometheusx.listen-address=127.0.0.1:9990',
               '-config=/etc/nodeinfo/config.json',
@@ -23,7 +23,7 @@ exp.ExperimentNoIndex('host', nodeinfo_datatypes, true) + {
                 name: 'nodeinfo-config',
                 readOnly: true,
               },
-            ] + [exp.VolumeMount('nodeinfo', d) for d in nodeinfo_datatypes],
+            ],
           },
           exp.RBACProxy('nodeinfo', 9990),
         ],

--- a/k8s/daemonsets/experiments/ndt.jsonnet
+++ b/k8s/daemonsets/experiments/ndt.jsonnet
@@ -32,8 +32,7 @@ exp.Experiment('ndt', 2, ['ndt5', 'ndt7']) + {
                 readOnly: true,
               },
               exp.uuid.volumemount,
-              exp.VolumeMount('ndt', 'ndt5'),
-              exp.VolumeMount('ndt', 'ndt7'),
+              exp.VolumeMount('ndt'),
             ],
             ports: [
               {

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -26,17 +26,17 @@ local uuid = {
   },
 };
 
-local volume(name, datatype) = {
+local volume(name) = {
   hostPath: {
-    path: '/cache/data/' + name + '/' + datatype,
+    path: '/cache/data/' + name,
     type: 'DirectoryOrCreate',
   },
-  name: datatype + '-data',
+  name: name + '-data',
 };
 
-local VolumeMount(name, datatype) = {
-  mountPath: '/var/spool/' + name + '/' + datatype,
-  name: datatype + '-data',
+local VolumeMount(name) = {
+  mountPath: '/var/spool/' + name,
+  name: name + '-data',
 };
 
 local RBACProxy(name, port) = {
@@ -98,7 +98,7 @@ local ExperimentNoIndex(name, datatypes, hostNetworking) = {
               else
                 '-prometheusx.listen-address=$(PRIVATE_IP):9991'
               ,
-              '-output=' + VolumeMount(name, 'tcpinfo').mountPath,
+              '-output=' + VolumeMount(name).mountPath + '/tcpinfo',
               '-uuid-prefix-file=' + uuid.prefixfile,
             ],
             env: if hostNetworking then [] else [
@@ -117,7 +117,7 @@ local ExperimentNoIndex(name, datatypes, hostNetworking) = {
               },
             ],
             volumeMounts: [
-              VolumeMount(name, 'tcpinfo'),
+              VolumeMount(name),
               uuid.volumemount,
             ],
           },
@@ -129,7 +129,7 @@ local ExperimentNoIndex(name, datatypes, hostNetworking) = {
                 '-prometheusx.listen-address=127.0.0.1:9992'
               else
                 '-prometheusx.listen-address=$(PRIVATE_IP):9992',
-              '-outputPath=' + VolumeMount(name, 'traceroute').mountPath,
+              '-outputPath=' + VolumeMount(name).mountPath + '/traceroute,
               '-uuid-prefix-file=' + uuid.prefixfile,
             ],
             env: if hostNetworking then [] else [
@@ -148,7 +148,7 @@ local ExperimentNoIndex(name, datatypes, hostNetworking) = {
               },
             ],
             volumeMounts: [
-              VolumeMount(name, 'traceroute'),
+              VolumeMount(name),
               uuid.volumemount,
             ],
           },
@@ -204,14 +204,13 @@ local ExperimentNoIndex(name, datatypes, hostNetworking) = {
               },
             ],
             volumeMounts: [
-              VolumeMount(name, 'tcpinfo'),
-              VolumeMount(name, 'traceroute'),
+              VolumeMount(name),
               {
                 mountPath: '/etc/credentials',
                 name: 'pusher-credentials',
                 readOnly: true,
               },
-            ] + [VolumeMount(name, d) for d in datatypes],
+            ],
           },
         ] + if hostNetworking then [
           RBACProxy('tcpinfo', 9991),
@@ -233,9 +232,8 @@ local ExperimentNoIndex(name, datatypes, hostNetworking) = {
             },
           },
           uuid.volume,
-          volume(name, 'traceroute'),
-          volume(name, 'tcpinfo'),
-        ] + [volume(name, d) for d in datatypes],
+          volume(name),
+        ],
       },
     },
     updateStrategy: {
@@ -292,7 +290,7 @@ local Experiment(name, index, datatypes=[]) = ExperimentNoIndex(name, datatypes,
 
   // Returns a volumemount for a given datatype. All produced volume mounts
   // in /var/spool/name/
-  VolumeMount(name, datatype):: VolumeMount(name, datatype),
+  VolumeMount(name):: VolumeMount(name),
 
   // Helper object containing uuid-related filenames, volumes, and volumemounts.
   uuid: uuid,

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -129,7 +129,7 @@ local ExperimentNoIndex(name, datatypes, hostNetworking) = {
                 '-prometheusx.listen-address=127.0.0.1:9992'
               else
                 '-prometheusx.listen-address=$(PRIVATE_IP):9992',
-              '-outputPath=' + VolumeMount(name).mountPath + '/traceroute,
+              '-outputPath=' + VolumeMount(name).mountPath + '/traceroute',
               '-uuid-prefix-file=' + uuid.prefixfile,
             ],
             env: if hostNetworking then [] else [


### PR DESCRIPTION
Currently, each datatype in each experiment pod has it's own unique Volume and VolumeMount. For the `host` experiment, for example, which has 12 datatypes, this was meaning the pod had around 15 volumes and mounts created for every pod. This seemed excessive and unnecessary.

What this PR intends is that each experiment will have a single data Volume and a single VolumeMount for that Volume for each experiment, and then each container will write its datatypes to subdirectories of that single mount. This should significantly reduce the number of Volumes and VolumeMounts on all of the platform nodes.

I believe that this is now running as intended on the sandbox platform cluster.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/231)
<!-- Reviewable:end -->
