### PR TITLE
Updates tcpinfo container from v0.0.8 to v0.0.9.

### DIFF
--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -91,7 +91,7 @@ local ExperimentNoIndex(name, datatypes, hostNetworking) = {
         containers: [
           {
             name: 'tcpinfo',
-            image: 'measurementlab/tcp-info:v0.0.8',
+            image: 'measurementlab/tcp-info:v0.0.9',
             args: [
               if hostNetworking then
                 '-prometheusx.listen-address=127.0.0.1:9991'


### PR DESCRIPTION
This fixes an issue in tcp-info in which it would crash if its data directory didn't exist. It will now attempt to create the data directory on initialization.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/237)
<!-- Reviewable:end -->
