### PR TITLE
Removes 2 relabel_configs for kubernetes-pods job that aren't good for the platform cluster

### DIFF
--- a/config/prometheus/prometheus.yml
+++ b/config/prometheus/prometheus.yml
@@ -127,25 +127,11 @@ scrape_configs:
         action: replace
         target_label: namespace
 
-      # Add the GKE node name.
-      - source_labels: [__meta_kubernetes_pod_node_name]
-        action: replace
-        target_label: node
-
       # Add a machine label to make it easier to join these metrics with
       # existing metrics that use machine instead of the node label.
       - source_labels: [__meta_kubernetes_pod_node_name]
         action: replace
         target_label: machine
-
-      # TODO: find a better source of this information or remove it. The value
-      # returned is incomplete. Used only by Prometheus_SelfMonitoring.json.
-      # Extract the "<cluster>-<node-pool>" name from the GKE node name.
-      - source_labels: [__meta_kubernetes_pod_node_name]
-        action: replace
-        regex: gke-(.*)(-[^-]+){2}
-        replacement: $1
-        target_label: cluster
 
       # Identify the deployment name for replica set or daemon set.  Pods
       # created by deployments or daemon sets are processed here. The


### PR DESCRIPTION
Some (most?) of the relabel rules for the `kubernetes-pods` job came from the Prometheus configs for our prometheus-federation cluster instance, running in GKE. It seems that some of those relabel rules aren't right for the platform cluster.

* The rule with a regex beginning with `gke-` is clearly a mistake (though no-op) for the platform cluster.
* The rule to categorically take the value of `__meta_kubernetes_pod_node_name` and overwrite the value of a `node` label doesn't seem right, because many metrics produced by exporters in kubernetes will by default have a `node` label that we want to keep. Take the example of the `kube-state-metrics` pod. In the platform cluster, it runs on the same machine where Prometheus runs. In this case, the value of `__meta_kubernetes_pod_node_name` will always be the node name of the node where Prometheus runs (`prometheus-platform-cluster`). We don't want to overwrite a native `node` label from `kube-state-metrics` with a meta label which will always be the node name where Prometheus runs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/239)
<!-- Reviewable:end -->
