### PR TITLE
Fixes two recording rules

### DIFF
--- a/config/prometheus/rules.yml
+++ b/config/prometheus/rules.yml
@@ -27,7 +27,7 @@ groups:
   # Optimize aggregation of container CPU and memory utilization by containter_name.
   - record: node_container_name:container_cpu_usage_seconds:sum_rate5m
     expr: |
-      sum by (node, container_label_io_kubernetes_container_name) (
+      sum by (machine, container_label_io_kubernetes_container_name) (
         rate (container_cpu_usage_seconds_total{
           container_label_io_kubernetes_container_name != "POD",
           container_label_io_kubernetes_container_name != "",
@@ -36,7 +36,7 @@ groups:
       )
   - record: node_container_name:container_memory_working_set_bytes:sum_rate5m
     expr: |
-      sum by (node, container_label_io_kubernetes_container_name) (
+      sum by (machine, container_label_io_kubernetes_container_name) (
         rate (container_memory_working_set_bytes{
           container_label_io_kubernetes_container_name != "POD",
           container_label_io_kubernetes_container_name != "",


### PR DESCRIPTION
These recording rules previously relied on the 'node' label, but now rely on the 'machine' label that we rewrite into metrics. This is necessary due to [a recent PR](https://github.com/m-lab/k8s-support/pull/239) which removed the rewrite rule that categorically overwrote any `node` label with the value of `__meta_kubernetes_pod_node_name`, which is sometimes what we want, but not always.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/243)
<!-- Reviewable:end -->
