### PR TITLE
Removes the --before-reboot-annotations flag from the update-operator

### DIFF
--- a/k8s/deployments/update-operator.jsonnet
+++ b/k8s/deployments/update-operator.jsonnet
@@ -25,9 +25,6 @@
       spec: {
         containers: [
           {
-            args: [
-              '-before-reboot-annotations=mlab-reboot-ok',
-            ],
             command: [
               '/bin/update-operator',
             ],


### PR DESCRIPTION
Setting an extra annotation that is fully under our control would be nice as safety gate for reboots, but it would require us us add that annotation incrementally through the course of a rolling reboot, which is not tenable.

CLUO operates on one node at a time, and before operating on a node it first removes all `--before-reboot-annotations` from the node, then hangs around waiting for that annotation to be added back.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/244)
<!-- Reviewable:end -->
