### PR TITLE
Refactors pretty much all CPU and memory Prometheus recording rules

### DIFF
--- a/config/prometheus/rules.yml
+++ b/config/prometheus/rules.yml
@@ -4,28 +4,20 @@ groups:
 
 ## PlatformCluster
 
-  #  Optimize aggregation of container CPU and memory utilization by containter_name.
+  #  Sums by container_name the 5m rate of CPU usage for a container.
   - record: container_name:container_cpu_usage_seconds:sum_rate5m
     expr: |
       sum by (container_label_io_kubernetes_container_name) (
         rate (container_cpu_usage_seconds_total{
           container_label_io_kubernetes_container_name != "POD",
           container_label_io_kubernetes_container_name != "",
-          image != ""}
-        [5m])
-      )
-  - record: container_name:container_memory_working_set_bytes:sum_rate5m
-    expr: |
-      sum by (container_label_io_kubernetes_container_name) (
-        rate (container_memory_working_set_bytes{
-          container_label_io_kubernetes_container_name != "POD",
-          container_label_io_kubernetes_container_name != "",
+          machine=~"mlab[1-4].*",
           image != ""}
         [5m])
       )
 
-  # Optimize aggregation of container CPU and memory utilization by containter_name.
-  - record: node_container_name:container_cpu_usage_seconds:sum_rate5m
+  # Sums by machine and container_name the 5m rate of CPU usage.
+  - record: machine_container_name:container_cpu_usage_seconds:sum_rate5m
     expr: |
       sum by (machine, container_label_io_kubernetes_container_name) (
         rate (container_cpu_usage_seconds_total{
@@ -34,13 +26,24 @@ groups:
           image != ""}
         [5m])
       )
-  - record: node_container_name:container_memory_working_set_bytes:sum_rate5m
+
+  # Calculates container memory usage as a ratio of all memory on a machine.
+  - record: container:container_memory_working_set_bytes:ratio
     expr: |
-      sum by (machine, container_label_io_kubernetes_container_name) (
-        rate (container_memory_working_set_bytes{
-          container_label_io_kubernetes_container_name != "POD",
-          container_label_io_kubernetes_container_name != "",
-          image != ""}
-        [5m])
-      )
+      container_memory_working_set_bytes{
+        container_label_io_kubernetes_container_name != "POD",
+        container_label_io_kubernetes_container_name != "",
+        machine=~"mlab[1-4].*",
+        image != ""
+      } / on(machine) group_left machine_memory_bytes
+
+  # Calculates container memory usage (sum of all bytes).
+  - record: container:container_memory_working_set_bytes:sum
+    expr: |
+      container_memory_working_set_bytes{
+        container_label_io_kubernetes_container_name != "POD",
+        container_label_io_kubernetes_container_name != "",
+        machine=~"mlab[1-4].*",
+        image != ""
+      }
 

--- a/config/prometheus/rules.yml
+++ b/config/prometheus/rules.yml
@@ -27,7 +27,7 @@ groups:
   - record: daemonset:container_cpu_usage_seconds:ratio
     expr: |
       daemonset:container_cpu_usage_seconds:sum_rate5m
-      / scalar(sum(machine_cpu_cores))
+      / scalar(sum(machine_cpu_cores{machine=~"mlab[1-4].*"}))
 
   # Calculates aggregate DaemonSet CPU usage on a machine.
   - record: machine_daemonset:container_cpu_usage_seconds:sum_rate5m
@@ -83,7 +83,7 @@ groups:
   - record: daemonset:container_memory_working_set_bytes:ratio
     expr: |
       daemonset:container_memory_working_set_bytes:sum
-      / scalar(sum(machine_memory_bytes))
+      / scalar(sum(machine_memory_bytes{machine=~"mlab[1-4].*"}))
 
   # Calculates aggregate DaemonSet memory usage on a machine.
   - record: machine_daemonset:container_memory_working_set_bytes:sum

--- a/config/prometheus/rules.yml
+++ b/config/prometheus/rules.yml
@@ -4,8 +4,10 @@ groups:
 
 ## PlatformCluster
 
+  ## CPU METRICS
+
   #  Calculates aggregate 5m rate of CPU usage for a container across all
-  #  nodes.
+  #  machines.
   - record: container_name:container_cpu_usage_seconds:sum_rate5m
     expr: |
       sum by (container_label_io_kubernetes_container_name) (
@@ -17,16 +19,28 @@ groups:
         [5m])
       )
 
-  #  Calculates aggregate 5m rate of CPU usage for a container across all nodes
-  #  as a ratio of all CPU cores on all nodes.
+  #  Calculates aggregate 5m rate of CPU usage for a container across all
+  #  machines as a ratio of all CPU cores on all machines.
   - record: container_name:container_cpu_usage_seconds_per_total_cpus:ratio_sum_rate5m
     expr: |
       container_name:container_cpu_usage_seconds:sum_rate5m
       / ignoring(container_label_io_kubernetes_container_name)
         group_left sum(machine_cpu_cores)
 
-  # Calculates container CPU usage on a node as a ratio of all CPU cores on
-  # that machine.
+  # Calculates aggregate container CPU usage on a machine.
+  - record: machine_container_name:container_cpu_usage_seconds:sum_rate5m
+    expr: |
+      sum by (machine, container_label_io_kubernetes_container_name) (
+        rate (container_cpu_usage_seconds_total{
+          container_label_io_kubernetes_container_name != "POD",
+          container_label_io_kubernetes_container_name != "",
+          machine=~"mlab[1-4].*",
+          image != ""}
+        [5m])
+      )
+
+  # Calculates aggregate container CPU usage on a node as a ratio of all CPU
+  # cores on that machine.
   - record: machine_container_name:container_cpu_usage_seconds_per_machine_cpus:ratio_sum_rate5m
     expr: |
       sum by (machine, container_label_io_kubernetes_container_name) (
@@ -38,7 +52,10 @@ groups:
         [5m])
       ) / on(machine) group_left machine_cpu_cores
 
-  #  Calculates aggregate container memory usage across all nodes.
+
+  ## MEMORY METRICS
+
+  #  Calculates aggregate container memory usage across all machines.
   - record: container_name:container_memory_working_set_bytes:sum
     expr: |
       sum by (container_label_io_kubernetes_container_name) (
@@ -50,16 +67,28 @@ groups:
         }
       )
 
-  #  Calculates aggregate container memory usage across all nodes as a ratio of
-  #  all memory on all nodes.
+  #  Calculates aggregate container memory usage across all machines as a ratio of
+  #  all memory on all machines.
   - record: container_name:container_memory_working_set_bytes_per_total_bytes:ratio_sum
     expr: |
       container_name:container_memory_working_set_bytes:sum
       / ignoring(container_label_io_kubernetes_container_name)
           group_left sum(machine_memory_bytes)
 
-  # Calculates container memory usage on a node as a ratio of all memory on
-  # that machine.
+  # Calculates aggregate container memory usage on a machine.
+  - record: machine_container_name:container_memory_working_set_bytes:sum
+    expr: |
+      sum by (machine, container_label_io_kubernetes_container_name) (
+        container_memory_working_set_bytes{
+          container_label_io_kubernetes_container_name != "POD",
+          container_label_io_kubernetes_container_name != "",
+          machine=~"mlab[1-4].*",
+          image != ""
+        }
+      )
+
+  # Calculates aggregate container memory usage on a machine as a ratio of all
+  # memory on that machine.
   - record: machine_container_name:container_memory_working_set_bytes_per_machine_bytes:ratio_sum
     expr: |
       sum by (machine, container_label_io_kubernetes_container_name) (

--- a/config/prometheus/rules.yml
+++ b/config/prometheus/rules.yml
@@ -48,17 +48,8 @@ groups:
   # cores on that machine.
   - record: machine_daemonset:container_cpu_usage_seconds:ratio
     expr: |
-      sum by (machine, daemonset) (
-        label_replace(
-          rate (container_cpu_usage_seconds_total{
-            container_label_io_kubernetes_container_name != "POD",
-            container_label_io_kubernetes_container_name != "",
-            machine=~"mlab[1-4].*",
-            image != ""}
-          [5m]),
-          "daemonset", "$1", "container_label_io_kubernetes_pod_name", "^(.*)-[a-z0-9]+$"
-        )
-      ) / on(machine) group_left machine_cpu_cores
+      machine_daemonset:container_cpu_usage_seconds:sum_rate5m
+      / on(machine) group_left machine_cpu_cores
 
 
   ## MEMORY METRICS
@@ -104,15 +95,6 @@ groups:
   # memory on that machine.
   - record: machine_daemonset:container_memory_working_set_bytes:ratio
     expr: |
-      sum by (machine, daemonset) (
-        label_replace(
-          container_memory_working_set_bytes{
-            container_label_io_kubernetes_container_name != "POD",
-            container_label_io_kubernetes_container_name != "",
-            machine=~"mlab[1-4].*",
-            image != ""
-          },
-          "daemonset", "$1", "container_label_io_kubernetes_pod_name", "^(.*)-[a-z0-9]+$"
-        ) / on(machine) group_left machine_memory_bytes
-      )
+      machine_daemonset:container_memory_working_set_bytes:sum
+      / on(machine) group_left machine_memory_bytes
 

--- a/config/prometheus/rules.yml
+++ b/config/prometheus/rules.yml
@@ -21,11 +21,10 @@ groups:
 
   #  Calculates aggregate 5m rate of CPU usage for a container across all
   #  machines as a ratio of all CPU cores on all machines.
-  - record: container_name:container_cpu_usage_seconds_per_total_cpus:ratio_sum_rate5m
+  - record: container_name:container_cpu_usage_seconds:ratio
     expr: |
       container_name:container_cpu_usage_seconds:sum_rate5m
-      / ignoring(container_label_io_kubernetes_container_name)
-        group_left sum(machine_cpu_cores)
+      / scalar(sum(machine_cpu_cores))
 
   # Calculates aggregate container CPU usage on a machine.
   - record: machine_container_name:container_cpu_usage_seconds:sum_rate5m
@@ -41,7 +40,7 @@ groups:
 
   # Calculates aggregate container CPU usage on a node as a ratio of all CPU
   # cores on that machine.
-  - record: machine_container_name:container_cpu_usage_seconds_per_machine_cpus:ratio_sum_rate5m
+  - record: machine_container_name:container_cpu_usage_seconds:ratio
     expr: |
       sum by (machine, container_label_io_kubernetes_container_name) (
         rate (container_cpu_usage_seconds_total{
@@ -69,11 +68,10 @@ groups:
 
   #  Calculates aggregate container memory usage across all machines as a ratio of
   #  all memory on all machines.
-  - record: container_name:container_memory_working_set_bytes_per_total_bytes:ratio_sum
+  - record: container_name:container_memory_working_set_bytes:ratio
     expr: |
       container_name:container_memory_working_set_bytes:sum
-      / ignoring(container_label_io_kubernetes_container_name)
-          group_left sum(machine_memory_bytes)
+      / scalar(sum(machine_memory_bytes))
 
   # Calculates aggregate container memory usage on a machine.
   - record: machine_container_name:container_memory_working_set_bytes:sum
@@ -89,7 +87,7 @@ groups:
 
   # Calculates aggregate container memory usage on a machine as a ratio of all
   # memory on that machine.
-  - record: machine_container_name:container_memory_working_set_bytes_per_machine_bytes:ratio_sum
+  - record: machine_container_name:container_memory_working_set_bytes:ratio
     expr: |
       sum by (machine, container_label_io_kubernetes_container_name) (
         container_memory_working_set_bytes{

--- a/config/prometheus/rules.yml
+++ b/config/prometheus/rules.yml
@@ -4,7 +4,8 @@ groups:
 
 ## PlatformCluster
 
-  #  Sums by container_name the 5m rate of CPU usage for a container.
+  #  Calculates aggregate 5m rate of CPU usage for a container across all
+  #  nodes.
   - record: container_name:container_cpu_usage_seconds:sum_rate5m
     expr: |
       sum by (container_label_io_kubernetes_container_name) (
@@ -16,34 +17,57 @@ groups:
         [5m])
       )
 
-  # Sums by machine and container_name the 5m rate of CPU usage.
-  - record: machine_container_name:container_cpu_usage_seconds:sum_rate5m
+  #  Calculates aggregate 5m rate of CPU usage for a container across all nodes
+  #  as a ratio of all CPU cores on all nodes.
+  - record: container_name:container_cpu_usage_seconds_per_total_cpus:ratio_sum_rate5m
+    expr: |
+      container_name:container_cpu_usage_seconds:sum_rate5m
+      / ignoring(container_label_io_kubernetes_container_name)
+        group_left sum(machine_cpu_cores)
+
+  # Calculates container CPU usage on a node as a ratio of all CPU cores on
+  # that machine.
+  - record: machine_container_name:container_cpu_usage_seconds_per_machine_cpus:ratio_sum_rate5m
     expr: |
       sum by (machine, container_label_io_kubernetes_container_name) (
         rate (container_cpu_usage_seconds_total{
           container_label_io_kubernetes_container_name != "POD",
           container_label_io_kubernetes_container_name != "",
+          machine=~"mlab[1-4].*",
           image != ""}
         [5m])
+      ) / on(machine) group_left machine_cpu_cores
+
+  #  Calculates aggregate container memory usage across all nodes.
+  - record: container_name:container_memory_working_set_bytes:sum
+    expr: |
+      sum by (container_label_io_kubernetes_container_name) (
+        container_memory_working_set_bytes{
+          container_label_io_kubernetes_container_name != "POD",
+          container_label_io_kubernetes_container_name != "",
+          machine=~"mlab[1-4].*",
+          image != ""
+        }
       )
 
-  # Calculates container memory usage as a ratio of all memory on a machine.
-  - record: container:container_memory_working_set_bytes:ratio
+  #  Calculates aggregate container memory usage across all nodes as a ratio of
+  #  all memory on all nodes.
+  - record: container_name:container_memory_working_set_bytes_per_machine_bytes:ratio_sum
     expr: |
-      container_memory_working_set_bytes{
-        container_label_io_kubernetes_container_name != "POD",
-        container_label_io_kubernetes_container_name != "",
-        machine=~"mlab[1-4].*",
-        image != ""
-      } / on(machine) group_left machine_memory_bytes
+      container_name:container_memory_working_set_bytes:sum
+      / ignoring(container_label_io_kubernetes_container_name)
+          group_left sum(machine_memory_bytes)
 
-  # Calculates container memory usage (sum of all bytes).
-  - record: container:container_memory_working_set_bytes:sum
+  # Calculates container memory usage on a node as a ratio of all memory on
+  # that machine.
+  - record: machine_container_name:container_memory_working_set_bytes_per_total_memory:ratio_sum
     expr: |
-      container_memory_working_set_bytes{
-        container_label_io_kubernetes_container_name != "POD",
-        container_label_io_kubernetes_container_name != "",
-        machine=~"mlab[1-4].*",
-        image != ""
-      }
+      sum by (machine, container_label_io_kubernetes_container_name) (
+        container_memory_working_set_bytes{
+          container_label_io_kubernetes_container_name != "POD",
+          container_label_io_kubernetes_container_name != "",
+          machine=~"mlab[1-4].*",
+          image != ""
+        } / on(machine) group_left machine_memory_bytes
+      )
 

--- a/config/prometheus/rules.yml
+++ b/config/prometheus/rules.yml
@@ -6,95 +6,113 @@ groups:
 
   ## CPU METRICS
 
-  #  Calculates aggregate 5m rate of CPU usage for a container across all
+  #  Calculates aggregate 5m rate of CPU usage for a DaemonSet across all
   #  machines.
-  - record: container_name:container_cpu_usage_seconds:sum_rate5m
+  - record: daemonset:container_cpu_usage_seconds:sum_rate5m
     expr: |
-      sum by (container_label_io_kubernetes_container_name) (
-        rate (container_cpu_usage_seconds_total{
-          container_label_io_kubernetes_container_name != "POD",
-          container_label_io_kubernetes_container_name != "",
-          machine=~"mlab[1-4].*",
-          image != ""}
-        [5m])
+      sum by (daemonset) (
+        label_replace(
+          rate (container_cpu_usage_seconds_total{
+            container_label_io_kubernetes_container_name != "POD",
+            container_label_io_kubernetes_container_name != "",
+            machine=~"mlab[1-4].*",
+            image != ""}
+          [5m]),
+          "daemonset", "$1", "container_label_io_kubernetes_pod_name", "^(.*)-[a-z0-9]+$"
+        )
       )
 
-  #  Calculates aggregate 5m rate of CPU usage for a container across all
+  #  Calculates aggregate 5m rate of CPU usage for a DaemonSet across all
   #  machines as a ratio of all CPU cores on all machines.
-  - record: container_name:container_cpu_usage_seconds:ratio
+  - record: daemonset:container_cpu_usage_seconds:ratio
     expr: |
-      container_name:container_cpu_usage_seconds:sum_rate5m
+      daemonset:container_cpu_usage_seconds:sum_rate5m
       / scalar(sum(machine_cpu_cores))
 
-  # Calculates aggregate container CPU usage on a machine.
-  - record: machine_container_name:container_cpu_usage_seconds:sum_rate5m
+  # Calculates aggregate DaemonSet CPU usage on a machine.
+  - record: machine_daemonset:container_cpu_usage_seconds:sum_rate5m
     expr: |
-      sum by (machine, container_label_io_kubernetes_container_name) (
-        rate (container_cpu_usage_seconds_total{
-          container_label_io_kubernetes_container_name != "POD",
-          container_label_io_kubernetes_container_name != "",
-          machine=~"mlab[1-4].*",
-          image != ""}
-        [5m])
+      sum by (machine, daemonset) (
+        label_replace(
+          rate (container_cpu_usage_seconds_total{
+            container_label_io_kubernetes_container_name != "POD",
+            container_label_io_kubernetes_container_name != "",
+            machine=~"mlab[1-4].*",
+            image != ""}
+          [5m]),
+          "daemonset", "$1", "container_label_io_kubernetes_pod_name", "^(.*)-[a-z0-9]+$"
+        )
       )
 
-  # Calculates aggregate container CPU usage on a node as a ratio of all CPU
+  # Calculates aggregate DaemonSet CPU usage on a node as a ratio of all CPU
   # cores on that machine.
-  - record: machine_container_name:container_cpu_usage_seconds:ratio
+  - record: machine_daemonset:container_cpu_usage_seconds:ratio
     expr: |
-      sum by (machine, container_label_io_kubernetes_container_name) (
-        rate (container_cpu_usage_seconds_total{
-          container_label_io_kubernetes_container_name != "POD",
-          container_label_io_kubernetes_container_name != "",
-          machine=~"mlab[1-4].*",
-          image != ""}
-        [5m])
+      sum by (machine, daemonset) (
+        label_replace(
+          rate (container_cpu_usage_seconds_total{
+            container_label_io_kubernetes_container_name != "POD",
+            container_label_io_kubernetes_container_name != "",
+            machine=~"mlab[1-4].*",
+            image != ""}
+          [5m]),
+          "daemonset", "$1", "container_label_io_kubernetes_pod_name", "^(.*)-[a-z0-9]+$"
+        )
       ) / on(machine) group_left machine_cpu_cores
 
 
   ## MEMORY METRICS
 
-  #  Calculates aggregate container memory usage across all machines.
-  - record: container_name:container_memory_working_set_bytes:sum
+  #  Calculates aggregate DaemonSet memory usage across all machines.
+  - record: daemonset:container_memory_working_set_bytes:sum
     expr: |
-      sum by (container_label_io_kubernetes_container_name) (
-        container_memory_working_set_bytes{
-          container_label_io_kubernetes_container_name != "POD",
-          container_label_io_kubernetes_container_name != "",
-          machine=~"mlab[1-4].*",
-          image != ""
-        }
+      sum by (daemonset) (
+        label_replace(
+          container_memory_working_set_bytes{
+            container_label_io_kubernetes_container_name != "POD",
+            container_label_io_kubernetes_container_name != "",
+            machine=~"mlab[1-4].*",
+            image != ""
+          },
+          "daemonset", "$1", "container_label_io_kubernetes_pod_name", "^(.*)-[a-z0-9]+$"
+        )
       )
 
-  #  Calculates aggregate container memory usage across all machines as a ratio of
+  #  Calculates aggregate DaemonSet memory usage across all machines as a ratio of
   #  all memory on all machines.
-  - record: container_name:container_memory_working_set_bytes:ratio
+  - record: daemonset:container_memory_working_set_bytes:ratio
     expr: |
-      container_name:container_memory_working_set_bytes:sum
+      daemonset:container_memory_working_set_bytes:sum
       / scalar(sum(machine_memory_bytes))
 
-  # Calculates aggregate container memory usage on a machine.
-  - record: machine_container_name:container_memory_working_set_bytes:sum
+  # Calculates aggregate DaemonSet memory usage on a machine.
+  - record: machine_daemonset:container_memory_working_set_bytes:sum
     expr: |
-      sum by (machine, container_label_io_kubernetes_container_name) (
-        container_memory_working_set_bytes{
-          container_label_io_kubernetes_container_name != "POD",
-          container_label_io_kubernetes_container_name != "",
-          machine=~"mlab[1-4].*",
-          image != ""
-        }
+      sum by (machine, daemonset) (
+        label_replace(
+          container_memory_working_set_bytes{
+            container_label_io_kubernetes_container_name != "POD",
+            container_label_io_kubernetes_container_name != "",
+            machine=~"mlab[1-4].*",
+            image != ""
+          },
+          "daemonset", "$1", "container_label_io_kubernetes_pod_name", "^(.*)-[a-z0-9]+$"
+        )
       )
 
-  # Calculates aggregate container memory usage on a machine as a ratio of all
+  # Calculates aggregate DaemonSet memory usage on a machine as a ratio of all
   # memory on that machine.
-  - record: machine_container_name:container_memory_working_set_bytes:ratio
+  - record: machine_daemonset:container_memory_working_set_bytes:ratio
     expr: |
-      sum by (machine, container_label_io_kubernetes_container_name) (
-        container_memory_working_set_bytes{
-          container_label_io_kubernetes_container_name != "POD",
-          container_label_io_kubernetes_container_name != "",
-          machine=~"mlab[1-4].*",
-          image != ""
-        } / on(machine) group_left machine_memory_bytes
+      sum by (machine, daemonset) (
+        label_replace(
+          container_memory_working_set_bytes{
+            container_label_io_kubernetes_container_name != "POD",
+            container_label_io_kubernetes_container_name != "",
+            machine=~"mlab[1-4].*",
+            image != ""
+          },
+          "daemonset", "$1", "container_label_io_kubernetes_pod_name", "^(.*)-[a-z0-9]+$"
+        ) / on(machine) group_left machine_memory_bytes
       )
 

--- a/config/prometheus/rules.yml
+++ b/config/prometheus/rules.yml
@@ -52,7 +52,7 @@ groups:
 
   #  Calculates aggregate container memory usage across all nodes as a ratio of
   #  all memory on all nodes.
-  - record: container_name:container_memory_working_set_bytes_per_machine_bytes:ratio_sum
+  - record: container_name:container_memory_working_set_bytes_per_total_bytes:ratio_sum
     expr: |
       container_name:container_memory_working_set_bytes:sum
       / ignoring(container_label_io_kubernetes_container_name)
@@ -60,7 +60,7 @@ groups:
 
   # Calculates container memory usage on a node as a ratio of all memory on
   # that machine.
-  - record: machine_container_name:container_memory_working_set_bytes_per_total_memory:ratio_sum
+  - record: machine_container_name:container_memory_working_set_bytes_per_machine_bytes:ratio_sum
     expr: |
       sum by (machine, container_label_io_kubernetes_container_name) (
         container_memory_working_set_bytes{


### PR DESCRIPTION
Currently, the recording rules are partially broken. For example, some current rules are passing memory usage in bytes in `rate()`, which is a gauge, and it doesn't make sense. This means some of the panels in the K8s:WorkloadOverview are not portraying anything meaningful.

This PR fixes the broken recording rules and yet adds some additional ones to speed up any dashboard using these metrics.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/246)
<!-- Reviewable:end -->
