### PR TITLE
Allow for sandbox-only k8s objects

### DIFF
--- a/manage-cluster/apply_k8s_configs.sh
+++ b/manage-cluster/apply_k8s_configs.sh
@@ -47,3 +47,11 @@ kubectl apply -f secret-configs/
 kubectl apply -f system.json || true
 kubectl apply -f system.json || true
 kubectl apply -f system.json
+
+# Apply sandbox-only configurations. As mentioned in the comment above, to be
+# sure, run kubectl-apply three times to be sure that everything gets created.
+if [[ "${PROJECT}" == "mlab-sandbox" ]]; then
+  kubectl apply -f system-sandbox.json || true
+  kubectl apply -f system-sandbox.json || true
+  kubectl apply -f system-sandbox.json
+fi

--- a/manage-cluster/create_k8s_configs.sh
+++ b/manage-cluster/create_k8s_configs.sh
@@ -22,7 +22,18 @@ GCE_NAME="master-${GCE_BASE_NAME}-${GCE_ZONE}"
 
 GCS_BUCKET_K8S="GCS_BUCKET_K8S_${PROJECT//-/_}"
 
-# Create the json configuration for the entire cluster (except for secrets)
+# Create the JSON configuration for ojects that should only be deployed to
+# the sandbox platform cluster.
+if [[ "${PROJECT}" == "mlab-sandbox" ]]; then
+  jsonnet \
+     --ext-str GCE_ZONE=${GCE_ZONE} \
+     --ext-str K8S_CLUSTER_CIDR=${K8S_CLUSTER_CIDR} \
+     --ext-str K8S_FLANNEL_VERSION=${K8S_FLANNEL_VERSION} \
+     --ext-str PROJECT_ID=mlab-sandbox
+     ../system-sandbox.jsonnet > system-sandbox.json
+fi
+
+# Create the json configuration for everything else (except for secrets).
 jsonnet \
    --ext-str GCE_ZONE=${GCE_ZONE} \
    --ext-str K8S_CLUSTER_CIDR=${K8S_CLUSTER_CIDR} \

--- a/manage-cluster/create_k8s_configs.sh
+++ b/manage-cluster/create_k8s_configs.sh
@@ -29,7 +29,7 @@ if [[ "${PROJECT}" == "mlab-sandbox" ]]; then
      --ext-str GCE_ZONE=${GCE_ZONE} \
      --ext-str K8S_CLUSTER_CIDR=${K8S_CLUSTER_CIDR} \
      --ext-str K8S_FLANNEL_VERSION=${K8S_FLANNEL_VERSION} \
-     --ext-str PROJECT_ID=mlab-sandbox
+     --ext-str PROJECT_ID=mlab-sandbox \
      ../system-sandbox.jsonnet > system-sandbox.json
 fi
 

--- a/system-sandbox.jsonnet
+++ b/system-sandbox.jsonnet
@@ -1,0 +1,24 @@
+{
+  // These k8s objects will only be created in sandbox. To migrate them to
+  // staging and production, remove them from this file and add them to
+  // system.jsonnet.
+
+  kind: 'List',
+  apiVersion: 'v1',
+  items: [
+    // Configmaps
+
+    // Custom resource definitions
+
+    // Daemonsets
+    import 'k8s/daemonsets/experiments/bismark.jsonnet',
+
+    // Deployments
+
+    // Namespaces
+
+    // Networks (which are in array form already).
+
+    // Roles (which are in array form already).
+  ],
+}

--- a/system.jsonnet
+++ b/system.jsonnet
@@ -18,7 +18,6 @@
     import 'k8s/daemonsets/core/host.jsonnet',
     import 'k8s/daemonsets/core/node-exporter.jsonnet',
     import 'k8s/daemonsets/core/update-agent.jsonnet',
-    import 'k8s/daemonsets/experiments/bismark.jsonnet',
     import 'k8s/daemonsets/experiments/ndt.jsonnet',
     // Deployments
     import 'k8s/deployments/kube-state-metrics.jsonnet',


### PR DESCRIPTION
Currently, there is no way to pin a certain object (e.g., DaemonSet) to the mlab-sandbox platform cluster. As it is, once a change gets merged into master it is then automatically deployed to staging, and from there once the repository gets tagged it automatically goes to production. However, there are going to be cases where we want something merged to master to stay only in the sandbox cluster. As a case in point, we currently want the BISMark experiment to remain in sandbox indefinitely (until the developers test the container, or rewrite it altogether).

This PR attempts to resolve this situation by creating a new `system-sandbox.jsonnet` file which will contain all objects that should only be deployed to the sandbox platform cluster. This new file only gets evaluated and applied to the cluster if the project is `mlab-sandbox` else it is skipped.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/247)
<!-- Reviewable:end -->
