### PR TITLE
Add mlab/project label to nodes + configure bismark to only run in sandbox

### DIFF
--- a/k8s/daemonsets/experiments/bismark.jsonnet
+++ b/k8s/daemonsets/experiments/bismark.jsonnet
@@ -10,11 +10,9 @@ exp.Experiment('bismark', 9, []) + {
             image: 'measurementlab/bismark-test:v1.0.2',
           },
         ],
-        nodeSelector+: [
-          {
-            'mlab/project': 'mlab-sandbox',
-          },
-        ],
+        nodeSelector+: {
+          'mlab/project': 'mlab-sandbox',
+        },
       },
     },
   },

--- a/k8s/daemonsets/experiments/bismark.jsonnet
+++ b/k8s/daemonsets/experiments/bismark.jsonnet
@@ -10,6 +10,9 @@ exp.Experiment('bismark', 9, []) + {
             image: 'measurementlab/bismark-test:v1.0.2',
           },
         ],
+        nodeSelector+: [
+          'mlab/project': 'mlab-sandbox',
+        ],
       },
     },
   },

--- a/k8s/daemonsets/experiments/bismark.jsonnet
+++ b/k8s/daemonsets/experiments/bismark.jsonnet
@@ -11,7 +11,9 @@ exp.Experiment('bismark', 9, []) + {
           },
         ],
         nodeSelector+: [
-          'mlab/project': 'mlab-sandbox',
+          {
+            'mlab/project': 'mlab-sandbox',
+          },
         ],
       },
     },

--- a/node/setup_k8s.sh.template
+++ b/node/setup_k8s.sh.template
@@ -43,7 +43,8 @@ curl --silent --show-error --location "https://raw.githubusercontent.com/kuberne
 #
 # TODO: Add annotations to the node as well as labels. The annotations should
 #       contain most of /proc/cmdline as well as the args to this script.
-NODE_LABELS="mlab/machine=${MACHINE},mlab/site=${SITE},mlab/metro=${METRO},mlab/type=platform"
+
+NODE_LABELS="mlab/machine=${MACHINE},mlab/site=${SITE},mlab/metro=${METRO},mlab/type=platform,mlab/project=${GCP_PROJECT}"
 DYNAMIC_CONFIG_DIR="/var/lib/kubelet/dynamic-configs"
 mkdir -p /etc/systemd/system/kubelet.service.d
 curl --silent --show-error --location "https://raw.githubusercontent.com/kubernetes/kubernetes/${RELEASE}/build/debs/10-kubeadm.conf" \


### PR DESCRIPTION
This PR adds a new label to all platform nodes: `mlab/project`. This new label can be useful in numerous ways, but one particular way is as a `nodeSelector` for DaemonSets and Deployments, where we only want to deploy in a particular project.

This PR also takes advantage of this new label to only schedule bismark on testing nodes.

**NOTE**: In order for the new label to show, the node must be deleted in the k8s API, then rebooted. The `--node-labels` kubelet flag is _only_ evaluated if the node doesn't already exist in the API.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/248)
<!-- Reviewable:end -->
