### PR TITLE
Sandbox tcpinfo metrics for sidestream dashboard

### DIFF
--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -91,6 +91,7 @@ local ExperimentNoIndex(name, datatypes, hostNetworking) = {
         containers: [
           {
             name: 'tcpinfo',
+            
             image: 'measurementlab/tcp-info:stats2',
             args: [
               if hostNetworking then

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -91,7 +91,7 @@ local ExperimentNoIndex(name, datatypes, hostNetworking) = {
         containers: [
           {
             name: 'tcpinfo',
-            image: 'measurementlab/tcp-info:v0.0.9',
+            image: 'measurementlab/tcp-info:stats',
             args: [
               if hostNetworking then
                 '-prometheusx.listen-address=127.0.0.1:9991'

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -91,7 +91,7 @@ local ExperimentNoIndex(name, datatypes, hostNetworking) = {
         containers: [
           {
             name: 'tcpinfo',
-            image: 'measurementlab/tcp-info:stats3',
+            image: 'measurementlab/tcp-info:stats4',
             args: [
               if hostNetworking then
                 '-prometheusx.listen-address=127.0.0.1:9991'

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -91,7 +91,7 @@ local ExperimentNoIndex(name, datatypes, hostNetworking) = {
         containers: [
           {
             name: 'tcpinfo',
-            image: 'measurementlab/tcp-info:stats4',
+            image: 'measurementlab/tcp-info:v1.0.0',
             args: [
               if hostNetworking then
                 '-prometheusx.listen-address=127.0.0.1:9991'

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -91,7 +91,7 @@ local ExperimentNoIndex(name, datatypes, hostNetworking) = {
         containers: [
           {
             name: 'tcpinfo',
-            image: 'measurementlab/tcp-info:stats',
+            image: 'measurementlab/tcp-info:stats2',
             args: [
               if hostNetworking then
                 '-prometheusx.listen-address=127.0.0.1:9991'

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -91,8 +91,7 @@ local ExperimentNoIndex(name, datatypes, hostNetworking) = {
         containers: [
           {
             name: 'tcpinfo',
-            
-            image: 'measurementlab/tcp-info:stats2',
+            image: 'measurementlab/tcp-info:stats3',
             args: [
               if hostNetworking then
                 '-prometheusx.listen-address=127.0.0.1:9991'


### PR DESCRIPTION
This updates tcpinfo to v1.0.0 to get the new metrics.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/249)
<!-- Reviewable:end -->
