### PR TITLE
A small fix for network aggregation Prometheus recording rules.

### DIFF
--- a/config/prometheus/rules.yml
+++ b/config/prometheus/rules.yml
@@ -107,7 +107,7 @@ groups:
       sum by (daemonset) (
         label_replace(
           container_network_transmit_bytes_total{
-            container_label_io_kubernetes_container_name != "POD",
+            container_label_io_kubernetes_container_name = "POD",
             container_label_io_kubernetes_container_name != "",
             machine=~"mlab[1-4].*",
             image != ""
@@ -122,7 +122,7 @@ groups:
       sum by (daemonset) (
         label_replace(
           container_network_receive_bytes_total{
-            container_label_io_kubernetes_container_name != "POD",
+            container_label_io_kubernetes_container_name = "POD",
             container_label_io_kubernetes_container_name != "",
             machine=~"mlab[1-4].*",
             image != ""
@@ -137,7 +137,7 @@ groups:
       sum by (machine, daemonset) (
         label_replace(
           container_network_transmit_bytes_total{
-            container_label_io_kubernetes_container_name != "POD",
+            container_label_io_kubernetes_container_name = "POD",
             container_label_io_kubernetes_container_name != "",
             machine=~"mlab[1-4].*",
             image != ""
@@ -152,7 +152,7 @@ groups:
       sum by (machine, daemonset) (
         label_replace(
           container_network_receive_bytes_total{
-            container_label_io_kubernetes_container_name != "POD",
+            container_label_io_kubernetes_container_name = "POD",
             container_label_io_kubernetes_container_name != "",
             machine=~"mlab[1-4].*",
             image != ""

--- a/config/prometheus/rules.yml
+++ b/config/prometheus/rules.yml
@@ -109,7 +109,7 @@ groups:
           container_network_transmit_bytes_total{
             container_label_io_kubernetes_container_name = "POD",
             container_label_io_kubernetes_container_name != "",
-            machine=~"mlab[1-4].*",
+            machine =~ "mlab[1-4].*",
             image != ""
           },
           "daemonset", "$1", "container_label_io_kubernetes_pod_name", "^(.*)-[a-z0-9]+$"
@@ -124,7 +124,7 @@ groups:
           container_network_receive_bytes_total{
             container_label_io_kubernetes_container_name = "POD",
             container_label_io_kubernetes_container_name != "",
-            machine=~"mlab[1-4].*",
+            machine =~ "mlab[1-4].*",
             image != ""
           },
           "daemonset", "$1", "container_label_io_kubernetes_pod_name", "^(.*)-[a-z0-9]+$"
@@ -139,7 +139,7 @@ groups:
           container_network_transmit_bytes_total{
             container_label_io_kubernetes_container_name = "POD",
             container_label_io_kubernetes_container_name != "",
-            machine=~"mlab[1-4].*",
+            machine =~ "mlab[1-4].*",
             image != ""
           },
           "daemonset", "$1", "container_label_io_kubernetes_pod_name", "^(.*)-[a-z0-9]+$"
@@ -154,7 +154,7 @@ groups:
           container_network_receive_bytes_total{
             container_label_io_kubernetes_container_name = "POD",
             container_label_io_kubernetes_container_name != "",
-            machine=~"mlab[1-4].*",
+            machine =~ "mlab[1-4].*",
             image != ""
           },
           "daemonset", "$1", "container_label_io_kubernetes_pod_name", "^(.*)-[a-z0-9]+$"


### PR DESCRIPTION
For network metrics we actually _want_ the container names named "POD" (the /pause containers).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/252)
<!-- Reviewable:end -->
