### PR TITLE
sandbox tweak-bins

### DIFF
--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -91,7 +91,7 @@ local ExperimentNoIndex(name, datatypes, hostNetworking) = {
         containers: [
           {
             name: 'tcpinfo',
-            image: 'measurementlab/tcp-info:tweak-buckets',
+            image: 'measurementlab/tcp-info:v1.0.1',
             args: [
               if hostNetworking then
                 '-prometheusx.listen-address=127.0.0.1:9991'

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -91,7 +91,7 @@ local ExperimentNoIndex(name, datatypes, hostNetworking) = {
         containers: [
           {
             name: 'tcpinfo',
-            image: 'measurementlab/tcp-info:v1.0.0',
+            image: 'measurementlab/tcp-info:tweak-buckets',
             args: [
               if hostNetworking then
                 '-prometheusx.listen-address=127.0.0.1:9991'


### PR DESCRIPTION
This incorporates new bug-fix release of tcpinfo, which changes the send/receive bins.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/255)
<!-- Reviewable:end -->
