### PR TITLE
Fixes jsonnet output to avoid a 'null' value where a container definition should be

### DIFF
--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -99,7 +99,7 @@ local Tcpinfo(expName, tcpPort, hostNetwork) = [
       uuid.volumemount,
     ],
   },
-  if hostNetwork then RBACProxy('tcpinfo', tcpPort),
+  if hostNetwork then RBACProxy('tcpinfo', tcpPort) else {}
 ];
 
 
@@ -135,7 +135,7 @@ local Traceroute(expName, tcpPort, hostNetwork) = [
       uuid.volumemount,
     ],
   },
-  if hostNetwork then RBACProxy('traceroute', tcpPort),
+  if hostNetwork then RBACProxy('traceroute', tcpPort) else {}
 ];
 
 local Pusher(expName, tcpPort, datatypes, hostNetwork, bucket) = [
@@ -191,7 +191,7 @@ local Pusher(expName, tcpPort, datatypes, hostNetwork, bucket) = [
       },
     ],
   },
-  if hostNetwork then RBACProxy('pusher', tcpPort),
+  if hostNetwork then RBACProxy('pusher', tcpPort) else {}
 ];
 
 local ExperimentNoIndex(name, datatypes, hostNetwork, bucket) = {

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -98,10 +98,12 @@ local Tcpinfo(expName, tcpPort, hostNetwork) = [
       VolumeMount(expName),
       uuid.volumemount,
     ],
-  },
-  if hostNetwork then RBACProxy('tcpinfo', tcpPort) else {}
-];
-
+  }] +
+  if hostNetwork then
+    [RBACProxy('tcpinfo', tcpPort)]
+  else
+    []
+;
 
 local Traceroute(expName, tcpPort, hostNetwork) = [
   {
@@ -134,9 +136,12 @@ local Traceroute(expName, tcpPort, hostNetwork) = [
       VolumeMount(expName),
       uuid.volumemount,
     ],
-  },
-  if hostNetwork then RBACProxy('traceroute', tcpPort) else {}
-];
+  }] +
+  if hostNetwork then
+    [RBACProxy('traceroute', tcpPort)]
+  else
+    []
+;
 
 local Pusher(expName, tcpPort, datatypes, hostNetwork, bucket) = [
   {
@@ -190,9 +195,12 @@ local Pusher(expName, tcpPort, datatypes, hostNetwork, bucket) = [
         readOnly: true,
       },
     ],
-  },
-  if hostNetwork then RBACProxy('pusher', tcpPort) else {}
-];
+  }] +
+  if hostNetwork then
+    [RBACProxy('pusher', tcpPort)]
+  else
+    []
+;
 
 local ExperimentNoIndex(name, datatypes, hostNetwork, bucket) = {
   apiVersion: 'extensions/v1beta1',


### PR DESCRIPTION
The way I had configured it was causing the jsonnet `if` condition to evaluate to 'null', and a literal "null" text value was showing up in the output, causing a parse error from k8s.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/259)
<!-- Reviewable:end -->
