### PR TITLE
Calculates rate() over 1h (not 5m) + makes use of container_label_workload label.

### DIFF
--- a/config/prometheus/rules.yml
+++ b/config/prometheus/rules.yml
@@ -6,9 +6,9 @@ groups:
 
   ## CPU METRICS
 
-  #  Calculates aggregate 5m rate of CPU usage for a DaemonSet across all
+  #  Calculates aggregate 1h rate of CPU usage for a DaemonSet across all
   #  machines.
-  - record: daemonset:container_cpu_usage_seconds:sum_rate5m
+  - record: daemonset:container_cpu_usage_seconds:sum_rate1h
     expr: |
       sum by (daemonset) (
         label_replace(
@@ -17,20 +17,20 @@ groups:
             container_label_io_kubernetes_container_name != "",
             machine=~"mlab[1-4].*",
             image != ""}
-          [5m]),
+          [1h]),
           "daemonset", "$1", "container_label_io_kubernetes_pod_name", "^(.*)-[a-z0-9]+$"
         )
       )
 
-  #  Calculates aggregate 5m rate of CPU usage for a DaemonSet across all
+  #  Calculates aggregate 1h rate of CPU usage for a DaemonSet across all
   #  machines as a ratio of all CPU cores on all machines.
   - record: daemonset:container_cpu_usage_seconds:ratio
     expr: |
-      daemonset:container_cpu_usage_seconds:sum_rate5m
+      daemonset:container_cpu_usage_seconds:sum_rate1h
       / scalar(sum(machine_cpu_cores{machine=~"mlab[1-4].*"}))
 
   # Calculates aggregate DaemonSet CPU usage on a machine.
-  - record: machine_daemonset:container_cpu_usage_seconds:sum_rate5m
+  - record: machine_daemonset:container_cpu_usage_seconds:sum_rate1h
     expr: |
       sum by (machine, daemonset) (
         label_replace(
@@ -39,7 +39,7 @@ groups:
             container_label_io_kubernetes_container_name != "",
             machine=~"mlab[1-4].*",
             image != ""}
-          [5m]),
+          [1h]),
           "daemonset", "$1", "container_label_io_kubernetes_pod_name", "^(.*)-[a-z0-9]+$"
         )
       )
@@ -48,7 +48,7 @@ groups:
   # cores on that machine.
   - record: machine_daemonset:container_cpu_usage_seconds:ratio
     expr: |
-      machine_daemonset:container_cpu_usage_seconds:sum_rate5m
+      machine_daemonset:container_cpu_usage_seconds:sum_rate1h
       / on(machine) group_left machine_cpu_cores
 
 
@@ -136,7 +136,7 @@ groups:
             machine =~ "mlab[1-4].*",
             image != ""
           }
-        [5m]) * 8
+        [1h]) * 8
       )
     )
 
@@ -153,7 +153,7 @@ groups:
             machine =~ "mlab[1-4].*",
             image != ""
           }
-        [5m]) * 8
+        [1h]) * 8
       )
     )
 
@@ -170,6 +170,6 @@ groups:
             machine =~ "mlab[1-4].*",
             image != ""
           }
-        [5m]) * 8
+        [1h]) * 8
       )
     )

--- a/config/prometheus/rules.yml
+++ b/config/prometheus/rules.yml
@@ -100,71 +100,76 @@ groups:
 
 
   ## NETWORK METRICS
+  #
+  # These network metric expressions deliberately exclude the 'host' and
+  # 'node-exporter' which run with hostNetwork=true. Because of this they
+  # capture essentially all node network traffic, which duplicates regular
+  # experiment metrics as well as being just generally not useful.
 
   # Calculates aggregate DaemonSet network trasmit bytes on the platform.
-  - record: daemonset:container_network_transmit_bytes_total:sum
+  - record: workload:container_network_transmit_bytes_total:sum
     expr: |
-      sum by (daemonset) (
-        label_replace(
-          rate(
-            container_network_transmit_bytes_total{
-              container_label_io_kubernetes_container_name = "POD",
-              container_label_io_kubernetes_container_name != "",
-              machine =~ "mlab[1-4].*",
-              image != ""
-            }
-          [5m]) * 8,
-          "daemonset", "$1", "container_label_io_kubernetes_pod_name", "^(.*)-[a-z0-9]+$"
-        )
+      sum by (container_label_workload) (
+        rate(
+          container_network_transmit_bytes_total{
+            container_label_io_kubernetes_container_name = "POD",
+            container_label_io_kubernetes_container_name != "",
+            container_label_workload != "",
+            container_label_workload !~ "(host|node-exporter)",
+            machine =~ "mlab[1-4].*",
+            image != ""
+          }
+        [1h]) * 8
       )
+    )
 
   # Calculates aggregate DaemonSet network receive bytes on the platform.
-  - record: daemonset:container_network_receive_bytes_total:sum
+  - record: workload:container_network_receive_bytes_total:sum
     expr: |
-      sum by (daemonset) (
-        label_replace(
-          rate(
-            container_network_receive_bytes_total{
-              container_label_io_kubernetes_container_name = "POD",
-              container_label_io_kubernetes_container_name != "",
-              machine =~ "mlab[1-4].*",
-              image != ""
-            }
-          [5m]) * 8,
-          "daemonset", "$1", "container_label_io_kubernetes_pod_name", "^(.*)-[a-z0-9]+$"
-        )
+      sum by (container_label_workload) (
+        rate(
+          container_network_receive_bytes_total{
+            container_label_io_kubernetes_container_name = "POD",
+            container_label_io_kubernetes_container_name != "",
+            container_label_workload != "",
+            container_label_workload !~ "(host|node-exporter)",
+            machine =~ "mlab[1-4].*",
+            image != ""
+          }
+        [5m]) * 8
       )
+    )
 
   # Calculates aggregate DaemonSet network trasmit bytes on a machine.
-  - record: machine_daemonset:container_network_transmit_bytes_total:sum
+  - record: machine_workload:container_network_transmit_bytes_total:sum
     expr: |
-      sum by (machine, daemonset) (
-        label_replace(
-          rate(
-            container_network_transmit_bytes_total{
-              container_label_io_kubernetes_container_name = "POD",
-              container_label_io_kubernetes_container_name != "",
-              machine =~ "mlab[1-4].*",
-              image != ""
-            }
-          [5m]) * 8,
-          "daemonset", "$1", "container_label_io_kubernetes_pod_name", "^(.*)-[a-z0-9]+$"
-        )
+      sum by (machine, container_label_workload) (
+        rate(
+          container_network_transmit_bytes_total{
+            container_label_io_kubernetes_container_name = "POD",
+            container_label_io_kubernetes_container_name != "",
+            container_label_workload != "",
+            container_label_workload !~ "(host|node-exporter)",
+            machine =~ "mlab[1-4].*",
+            image != ""
+          }
+        [5m]) * 8
       )
+    )
 
   # Calculates aggregate DaemonSet network receive bytes on a machine.
-  - record: machine_daemonset:container_network_receive_bytes_total:sum
+  - record: machine_workload:container_network_receive_bytes_total:sum
     expr: |
-      sum by (machine, daemonset) (
-        label_replace(
-          rate(
-            container_network_receive_bytes_total{
-              container_label_io_kubernetes_container_name = "POD",
-              container_label_io_kubernetes_container_name != "",
-              machine =~ "mlab[1-4].*",
-              image != ""
-            }
-          [5m]) * 8,
-          "daemonset", "$1", "container_label_io_kubernetes_pod_name", "^(.*)-[a-z0-9]+$"
-        )
+      sum by (machine, container_label_workload) (
+        rate(
+          container_network_receive_bytes_total{
+            container_label_io_kubernetes_container_name = "POD",
+            container_label_io_kubernetes_container_name != "",
+            container_label_workload != "",
+            container_label_workload !~ "(host|node-exporter)",
+            machine =~ "mlab[1-4].*",
+            image != ""
+          }
+        [5m]) * 8
       )
+    )


### PR DESCRIPTION
We were finding that calculating a rate over 5m was causing too much noise in most of the graphs of these recording rules. Changing it to 1h smooths everything out and clears the clutter.

Additionally, I realized that the network metrics include the label `container_label_workload`, which is identical to the value from the old `label_replace()` to create daemonset, so this PR moves to use that label instead and removes the `label_replace()`s for network metrics. Additionally, the network metrics now exclude the `host` and `node-exporter` workloads, which both run with `hostNetwork=true`, causing them to essentially duplicate all network metric counts from every other pods, giving useless and confusing data. It also now excludes workloads that don't have the `container_label_workload` label set to avoid getting a bunch of system pods (e.g., kube-proxy, flannel, etc.).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/260)
<!-- Reviewable:end -->
