### PR TITLE
Add "utilization" experiment to daemonsets/core (aka DISCO, collectd)

### DIFF
--- a/k8s/daemonsets/core/utilization.jsonnet
+++ b/k8s/daemonsets/core/utilization.jsonnet
@@ -77,11 +77,11 @@ local exp = import '../templates.jsonnet';
           },
           {
             name: 'utilization-data',
-		    hostPath: {
+            hostPath: {
               path: '/cache/data/utilization',
               type: 'DirectoryOrCreate',
             },
-		  },
+          },
           {
             name: 'node-exporter-data',
             hostPath: {

--- a/k8s/daemonsets/core/utilization.jsonnet
+++ b/k8s/daemonsets/core/utilization.jsonnet
@@ -27,7 +27,7 @@ local exp = import '../templates.jsonnet';
         containers: [
           {
             name: 'collectd',
-            image: 'measurementlab/utility-support:v2.0.3',
+            image: 'measurementlab/utility-support:v2.0.4',
             env: [
               {
                 name: 'HOSTNAME',

--- a/k8s/daemonsets/core/utilization.jsonnet
+++ b/k8s/daemonsets/core/utilization.jsonnet
@@ -1,0 +1,102 @@
+local exp = import '../templates.jsonnet';
+
+{
+  apiVersion: 'extensions/v1beta1',
+  kind: 'DaemonSet',
+  metadata: {
+    name: 'utilization',
+    namespace: 'default',
+  },
+  spec: {
+    selector: {
+      matchLabels: {
+        workload: 'utilization',
+      },
+    },
+    template: {
+      metadata: {
+        annotations: {
+          'prometheus.io/scrape': 'true',
+          'prometheus.io/scheme': 'https'
+        },
+        labels: {
+          workload: 'utilization',
+        },
+      },
+      spec: {
+        containers: [
+          {
+            name: 'collectd',
+            image: 'measurementlab/utility-support:v2.0.3',
+            env: [
+              {
+                name: 'HOSTNAME',
+                valueFrom: {
+                  fieldRef: {
+                    fieldPath: 'spec.nodeName',
+                  },
+                },
+              },
+              {
+                name: 'COMMUNITY',
+                valueFrom: {
+                  secretKeyRef: {
+                    name: 'snmp-community',
+                    key: 'snmp.community',
+                  },
+                },
+              },
+            ],
+            volumeMounts: [
+              {
+                mountPath: '/var/spool/node-exporter',
+                name: 'node-exporter-data',
+                readOnly: false,
+              },
+              {
+                mountPath: '/var/spool/mlab_utility',
+                name: 'utilization-data',
+                readOnly: false,
+              },
+            ],
+          }] + std.flattenArrays([
+            exp.Pusher('utilization', 9994, ['switch', 'system'], true, 'pusher-' + std.extVar('PROJECT_ID')),
+          ]),
+        hostNetwork: true,
+        // hostPID: true,
+        nodeSelector: {
+          'mlab/type': 'platform',
+        },
+        serviceAccountName: 'kube-rbac-proxy',
+        volumes: [
+          {
+            name: 'pusher-credentials',
+            secret: {
+              secretName: 'pusher-credentials',
+            },
+          },
+          {
+            name: 'utilization-data',
+		    hostPath: {
+              path: '/cache/data/utilization',
+              type: 'DirectoryOrCreate',
+            },
+		  },
+          {
+            name: 'node-exporter-data',
+            hostPath: {
+              path: '/cache/data/node-exporter',
+              type: 'DirectoryOrCreate',
+            },
+          },
+        ],
+      },
+    },
+    updateStrategy: {
+      rollingUpdate: {
+        maxUnavailable: 2,
+      },
+      type: 'RollingUpdate',
+    },
+  },
+}

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -156,8 +156,6 @@ local Pusher(expName, tcpPort, datatypes, hostNetwork, bucket) = [
       '-experiment=' + expName,
       '-archive_size_threshold=50MB',
       '-directory=/var/spool/' + expName,
-      '-datatype=tcpinfo',
-      '-datatype=traceroute',
     ] + ['-datatype=' + d for d in datatypes],
     env: [
       {
@@ -230,7 +228,7 @@ local ExperimentNoIndex(name, datatypes, hostNetwork, bucket) = {
           std.flattenArrays([
             Tcpinfo(name, 9991, hostNetwork),
             Traceroute(name, 9992, hostNetwork),
-            Pusher(name, 9993, datatypes, hostNetwork, bucket),
+            Pusher(name, 9993, ['tcpinfo', 'traceroute'] + datatypes, hostNetwork, bucket),
           ]),
         [if hostNetwork then 'serviceAccountName']: 'kube-rbac-proxy',
         initContainers: [
@@ -306,6 +304,10 @@ local Experiment(name, index, bucket, datatypes=[]) = ExperimentNoIndex(name, da
   // Returns a volumemount for a given datatype. All produced volume mounts
   // in /var/spool/name/
   VolumeMount(name):: VolumeMount(name),
+
+  // Returns a "container" configuration for pusher that will upload the named experiment datatypes.
+  // Users MUST declare a "pusher-credentials" volume as part of the deployment.
+  Pusher(expName, tcpPort, datatypes, hostNetwork, bucket):: Pusher(expName, tcpPort, datatypes, hostNetwork, bucket),
 
   // Helper object containing uuid-related filenames, volumes, and volumemounts.
   uuid: uuid,

--- a/manage-cluster/create_k8s_configs.sh
+++ b/manage-cluster/create_k8s_configs.sh
@@ -40,6 +40,7 @@ gsutil cp gs://${!GCS_BUCKET_K8S}/pusher-credentials.json secrets/pusher.json
 gsutil cp gs://${!GCS_BUCKET_K8S}/fluentd-credentials.json secrets/fluentd.json
 mkdir -p secrets/prometheus-etcd-tls
 gsutil cp gs://${!GCS_BUCKET_K8S}/prometheus-etcd-tls/client.* secrets/prometheus-etcd-tls/
+gsutil cp gs://${!GCS_BUCKET_K8S}/snmp-community/snmp.community secrets/snmp.community
 
 # Convert secret data into configs.
 kubectl create secret generic pusher-credentials --from-file secrets/pusher.json \
@@ -50,6 +51,8 @@ kubectl create secret generic fluentd-credentials --from-file secrets/fluentd.js
     --dry-run -o json > secret-configs/fluentd-credentials.json
 kubectl create secret generic prometheus-etcd-tls --from-file secrets/prometheus-etcd-tls/ \
     --dry-run -o json > secret-configs/prometheus-etcd-tls.json
+kubectl create secret generic snmp-community --from-file secrets/snmp.community \
+    --dry-run -o json > secret-configs/snmp-community.json
 
 # Download the platform cluster CA cert.
 gsutil cp gs://k8s-support-${PROJECT}/pki/ca.crt .

--- a/system.jsonnet
+++ b/system.jsonnet
@@ -17,6 +17,7 @@
     import 'k8s/daemonsets/core/host.jsonnet',
     import 'k8s/daemonsets/core/node-exporter.jsonnet',
     import 'k8s/daemonsets/core/update-agent.jsonnet',
+    import 'k8s/daemonsets/core/utilization.jsonnet',
     import 'k8s/daemonsets/experiments/bismark.jsonnet',
     import 'k8s/daemonsets/experiments/ndt.jsonnet',
     import 'k8s/daemonsets/experiments/ndtcloud.jsonnet',


### PR DESCRIPTION
This change adds a new daemonset/core experiment "utilization". This experiment generates two datatypes from local "switch" data and local "system" monitoring.

The utilization experiment only monitors the local environment and the switch via SNMP. Because there are no TCP-based connections (other than from pusher) the TCPINFO and TRACEROUTE side-cars are not included.

The `Pusher` function in templates.jsonnet is now public so that experiments like utilization can use the existing template without adding unnecessary side-cars.

The utilization experiment needs `hostNetwork: true` in order to discover the eth0 device, it's MAC address and lookup that MAC address in the tables returned from the switch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/263)
<!-- Reviewable:end -->
