### PR TITLE
Sources /root/.bashrc so that etcdctl commands work.

### DIFF
--- a/manage-cluster/cloud-config_master.yml
+++ b/manage-cluster/cloud-config_master.yml
@@ -133,6 +133,7 @@ write_files:
       #!/bin/bash
       REBOOT_DAY=$(cat /etc/reboot-node-day)
       TODAY=$(date +%a)
+      source /root/.bashrc
       ETCD_MEMBERS=$(/usr/bin/etcdctl member list | wc -l)
       if [[ "${REBOOT_DAY}" != "${TODAY}" ]]; then
         echo "Reboot day ${REBOOT_DAY} doesn't equal today: ${TODAY}. Not rebooting."


### PR DESCRIPTION
Automated weekly reboots of master nodes was failing because `etcdctl` commands were failing, and they were failing because `etcdctl` didn't have the right env variables available. Sourcing /root/.bashrc should fix this.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/264)
<!-- Reviewable:end -->
