### PR TITLE
ConfigMaps are now write-once.

### DIFF
--- a/config/configmap.jsonnet
+++ b/config/configmap.jsonnet
@@ -1,0 +1,9 @@
+{
+  metadata(name, contents):: {
+      name: name + '-' + std.md5(std.toString(contents)),
+      annotations+: {
+          'mlab/deploymentstamp': std.extVar('DEPLOYMENTSTAMP'),
+          'mlab/configmaptruename': name,
+      },
+  },
+}

--- a/config/fluentd.jsonnet
+++ b/config/fluentd.jsonnet
@@ -1,16 +1,17 @@
+local cmutil = import 'cloudmap-utils.jsonnet';
 local outputConfMissingProjectAndZone = importstr 'fluentd/output.conf.template';
 local outputConfMissingZone = std.strReplace(outputConfMissingProjectAndZone, '{{PROJECT_ID}}', std.extVar('PROJECT_ID'));
 local outputConf = std.strReplace(outputConfMissingZone, '{{GCE_ZONE}}', std.extVar('GCE_ZONE'));
 
+local data = {
+  'containers.input.conf': importstr 'fluentd/containers.input.conf',
+  'monitoring.conf': importstr 'fluentd/monitoring.conf',
+  'output.conf': outputConf,
+};
+
 {
   kind: 'ConfigMap',
   apiVersion: 'v1',
-  metadata: {
-    name: 'fluentd-config',
-  },
-  data: {
-    'containers.input.conf': importstr 'fluentd/containers.input.conf',
-    'monitoring.conf': importstr 'fluentd/monitoring.conf',
-    'output.conf': outputConf,
-  },
+  metadata: cmutil.metadata('fluentd-config', data),
+  data: data,
 }

--- a/config/fluentd.jsonnet
+++ b/config/fluentd.jsonnet
@@ -1,4 +1,4 @@
-local cmutil = import 'cloudmap-utils.jsonnet';
+local cmutil = import 'configmap.jsonnet';
 local outputConfMissingProjectAndZone = importstr 'fluentd/output.conf.template';
 local outputConfMissingZone = std.strReplace(outputConfMissingProjectAndZone, '{{PROJECT_ID}}', std.extVar('PROJECT_ID'));
 local outputConf = std.strReplace(outputConfMissingZone, '{{GCE_ZONE}}', std.extVar('GCE_ZONE'));

--- a/config/nodeinfo.jsonnet
+++ b/config/nodeinfo.jsonnet
@@ -1,4 +1,4 @@
-local cmutil = import 'cloudmap-utils.jsonnet';
+local cmutil = import 'configmap.jsonnet';
 local config = import 'nodeinfo/config.jsonnet';
 
 local data = {

--- a/config/nodeinfo.jsonnet
+++ b/config/nodeinfo.jsonnet
@@ -1,12 +1,13 @@
+local cmutil = import 'cloudmap-utils.jsonnet';
 local config = import 'nodeinfo/config.jsonnet';
+
+local data = {
+  'config.json': std.toString(config),
+};
 
 {
   apiVersion: 'v1',
-  data: {
-    'config.json': std.toString(config),
-  },
+  data: data,
   kind: 'ConfigMap',
-  metadata: {
-    name: 'nodeinfo-config',
-  },
+  metadata: cmutil.metadata('nodeinfo-config', data),
 }

--- a/k8s/daemonsets/core/fluentd.jsonnet
+++ b/k8s/daemonsets/core/fluentd.jsonnet
@@ -1,3 +1,5 @@
+local fluentdConfig = import '../../../config/fluentd.jsonnet';
+
 {
   apiVersion: 'apps/v1',
   kind: 'DaemonSet',
@@ -154,7 +156,7 @@
           },
           {
             configMap: {
-              name: 'fluentd-config',
+              name: fluentdConfig.metadata.name,
             },
             name: 'config-volume',
           },

--- a/k8s/daemonsets/core/host.jsonnet
+++ b/k8s/daemonsets/core/host.jsonnet
@@ -1,3 +1,5 @@
+local nodeinfoConfig = import '../../../config/nodeinfo.jsonnet';
+
 local exp = import '../templates.jsonnet';
 
 local nodeinfoconfig = import '../../../config/nodeinfo/config.jsonnet';
@@ -33,7 +35,7 @@ exp.ExperimentNoIndex('host', nodeinfo_datatypes, true, 'pusher-' + std.extVar('
         volumes+: [
           {
             configMap: {
-              name: 'nodeinfo-config',
+              name: nodeinfoConfig.metadata.name,
             },
             name: 'nodeinfo-config',
           },

--- a/manage-cluster/create_k8s_configs.sh
+++ b/manage-cluster/create_k8s_configs.sh
@@ -28,6 +28,8 @@ jsonnet \
    --ext-str K8S_CLUSTER_CIDR=${K8S_CLUSTER_CIDR} \
    --ext-str K8S_FLANNEL_VERSION=${K8S_FLANNEL_VERSION} \
    --ext-str PROJECT_ID=${PROJECT} \
+   --ext-str PROJECT_ID=${PROJECT} \
+   --ext-str DEPLOYMENTSTAMP=$(date +%s) \
    ../system.jsonnet > system.json
 
 # Download every secret, and turn each one into a config.


### PR DESCRIPTION
When a ConfigMap is updated, a new configmap with a new name is created. This allows old deployments to use old configurations and new deployments to use new configurations. It also means that daemonsets and deployments that use this technique do not have to do the configmap-reload dance.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/271)
<!-- Reviewable:end -->
