### PR TITLE
Make the Prometheus ConfigMap write-once

### DIFF
--- a/config/prometheus.jsonnet
+++ b/config/prometheus.jsonnet
@@ -1,11 +1,13 @@
+local cmutil = import 'configmap.jsonnet';
+
+local data = {
+    'rules.yml': importstr 'prometheus/rules.yml',
+    'prometheus.yml': importstr 'prometheus/prometheus.yml',
+};
+
 {
   kind: 'ConfigMap',
   apiVersion: 'v1',
-  metadata: {
-    name: 'prometheus-config',
-  },
-  data: {
-    'rules.yml': importstr 'prometheus/rules.yml',
-    'prometheus.yml': importstr 'prometheus/prometheus.yml',
-  },
+  metadata: cmutil.metadata('prometheus-config', data),
+  data: data,
 }

--- a/k8s/deployments/prometheus.jsonnet
+++ b/k8s/deployments/prometheus.jsonnet
@@ -1,3 +1,5 @@
+local prometheusConfig = import '../../../config/prometheus.jsonnet';
+
 {
   apiVersion: 'apps/v1',
   kind: 'Deployment',
@@ -60,36 +62,6 @@
               },
             ],
           },
-          {
-            args: [
-              '-webhook-url',
-              'http://localhost:9090/-/reload',
-              '-volume-dir',
-              '/etc/prometheus',
-            ],
-            // Check
-            // https://hub.docker.com/r/jimmidyson/configmap-reload/tags/
-            // for the current stable version.
-            image: 'jimmidyson/configmap-reload:v0.2.2',
-            name: 'configmap-reload',
-            resources: {
-              limits: {
-                cpu: '200m',
-                memory: '400Mi',
-              },
-              requests: {
-                cpu: '200m',
-                memory: '400Mi',
-              },
-            },
-            volumeMounts: [
-              // Mount the prometheus config volume so we can watch it for changes.
-              {
-                mountPath: '/etc/prometheus',
-                name: 'prometheus-config',
-              },
-            ],
-          },
         ],
         // TODO: use native k8s service entry points, if possible.
         hostNetwork: true,
@@ -101,7 +73,7 @@
         volumes: [
           {
             configMap: {
-              name: 'prometheus-config',
+              name: prometheusConfig.metadata.name,
             },
             name: 'prometheus-config',
           },

--- a/k8s/deployments/prometheus.jsonnet
+++ b/k8s/deployments/prometheus.jsonnet
@@ -1,4 +1,4 @@
-local prometheusConfig = import '../../../config/prometheus.jsonnet';
+local prometheusConfig = import '../../config/prometheus.jsonnet';
 
 {
   apiVersion: 'apps/v1',


### PR DESCRIPTION
Eliminates the need for the "configmap-reloader"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/272)
<!-- Reviewable:end -->
