### PR TITLE
Creates canary DaemonSets deployed to machines with mlab/release=canary

### DIFF
--- a/canaries.jsonnet
+++ b/canaries.jsonnet
@@ -1,0 +1,8 @@
+{
+  kind: 'List',
+  apiVersion: 'v1',
+  items: [
+    // Daemonsets
+    import 'k8s/daemonsets/experiments/ndt.jsonnet',
+  ],
+}

--- a/canaries.jsonnet
+++ b/canaries.jsonnet
@@ -3,6 +3,8 @@
   apiVersion: 'v1',
   items: [
     // Daemonsets
+    import 'k8s/daemonsets/core/host.jsonnet',
+    import 'k8s/daemonsets/experiments/bismark.jsonnet',
     import 'k8s/daemonsets/experiments/ndt.jsonnet',
   ],
 }

--- a/cloudbuild-canary.yaml
+++ b/cloudbuild-canary.yaml
@@ -1,0 +1,13 @@
+steps:
+
+# Fetch the KUBECONFIG file from GCS.
+- name: 'gcr.io/cloud-builders/gsutil'
+  args: ['cp', 'gs://k8s-support-$PROJECT_ID/admin.conf', '/workspace/admin.conf']
+
+# Push the configs.
+- name: 'gcr.io/cloud-builders/kubectl'
+  dir: '/workspace/manage-cluster'
+  entrypoint: '/workspace/manage-cluster/deploy_canary_k8s_configs.sh'
+  args:
+  - $PROJECT_ID
+  - /workspace/admin.conf

--- a/k8s/daemonsets/experiments/ndt.jsonnet
+++ b/k8s/daemonsets/experiments/ndt.jsonnet
@@ -1,33 +1,10 @@
 local exp = import '../templates.jsonnet';
 local project = std.extVar('PROJECT_ID');
-local canary = std.extVar('CANARY');
 
 exp.Experiment('ndt', 2, 'pusher-' + project, ['ndt5', 'ndt7']) + {
-  metadata+: if canary then {
-    name: 'ndt-canary',
-  } else {},
   spec+: {
     template+: {
       spec+: {
-        affinity: {
-            nodeAffinity: {
-              requiredDuringSchedulingIgnoredDuringExecution: {
-                nodeSelectorTerms: [
-                  {
-                    matchExpressions: [
-                      {
-                        key: 'mlab/release',
-                        operator: if canary then 'In' else 'NotIn',
-                        values: [
-                          'canary',
-                        ],
-                      }
-                    ],
-                  },
-                ],
-              },
-            },
-          },
         containers+: [
           {
             name: 'ndt-server',

--- a/k8s/daemonsets/experiments/ndt.jsonnet
+++ b/k8s/daemonsets/experiments/ndt.jsonnet
@@ -1,9 +1,33 @@
 local exp = import '../templates.jsonnet';
+local project = std.extVar('PROJECT_ID');
+local canary = std.extVar('CANARY');
 
-exp.Experiment('ndt', 2, 'pusher-' + std.extVar('PROJECT_ID'), ['ndt5', 'ndt7']) + {
+exp.Experiment('ndt', 2, 'pusher-' + project, ['ndt5', 'ndt7']) + {
+  metadata+: if canary then {
+    name: 'ndt-canary',
+  } else {},
   spec+: {
     template+: {
       spec+: {
+        affinity: {
+            nodeAffinity: {
+              requiredDuringSchedulingIgnoredDuringExecution: {
+                nodeSelectorTerms: [
+                  {
+                    matchExpressions: [
+                      {
+                        key: 'mlab/release',
+                        operator: if canary then 'In' else 'NotIn',
+                        values: [
+                          'canary',
+                        ],
+                      }
+                    ],
+                  },
+                ],
+              },
+            },
+          },
         containers+: [
           {
             name: 'ndt-server',

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -211,7 +211,7 @@ local ExperimentNoIndex(name, datatypes, hostNetwork, bucket) = {
   spec: {
     selector: {
       matchLabels: {
-        workload: name,
+        workload: if canary then name + '-canary' else name,
       },
     },
     template: {
@@ -221,7 +221,7 @@ local ExperimentNoIndex(name, datatypes, hostNetwork, bucket) = {
           'prometheus.io/scheme': if hostNetwork then 'https' else 'http',
         },
         labels: {
-          workload: name,
+          workload: if canary then name + '-canary' else name,
         },
       },
       spec: {

--- a/manage-cluster/apply_k8s_configs.sh
+++ b/manage-cluster/apply_k8s_configs.sh
@@ -47,3 +47,7 @@ kubectl apply -f secret-configs/
 kubectl apply -f system.json || true
 kubectl apply -f system.json || true
 kubectl apply -f system.json
+
+# Apply the canary DaemonSets
+kubectl apply -f canaries.json
+

--- a/manage-cluster/create_k8s_configs.sh
+++ b/manage-cluster/create_k8s_configs.sh
@@ -28,10 +28,15 @@ jsonnet \
    --ext-str K8S_CLUSTER_CIDR=${K8S_CLUSTER_CIDR} \
    --ext-str K8S_FLANNEL_VERSION=${K8S_FLANNEL_VERSION} \
    --ext-str PROJECT_ID=${PROJECT} \
-   --ext-str PROJECT_ID=${PROJECT} \
    --ext-str DEPLOYMENTSTAMP=$(date +%s) \
    --ext-code CANARY=false \
    ../system.jsonnet > system.json
+
+# Create the canary DaemonSets
+jsonnet \
+   --ext-str PROJECT_ID=${PROJECT} \
+   --ext-code CANARY=true \
+   ../canaries.jsonnet > canaries.json
 
 # Download every secret, and turn each one into a config.
 mkdir -p secrets

--- a/manage-cluster/create_k8s_configs.sh
+++ b/manage-cluster/create_k8s_configs.sh
@@ -30,6 +30,7 @@ jsonnet \
    --ext-str PROJECT_ID=${PROJECT} \
    --ext-str PROJECT_ID=${PROJECT} \
    --ext-str DEPLOYMENTSTAMP=$(date +%s) \
+   --ext-code CANARY=false \
    ../system.jsonnet > system.json
 
 # Download every secret, and turn each one into a config.

--- a/manage-cluster/deploy_canary_k8s_configs.sh
+++ b/manage-cluster/deploy_canary_k8s_configs.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+USAGE="USAGE: $0 <google-cloud-project> <kubeconfig>"
+PROJECT=${1:?Please specify the google cloud project: $USAGE}
+KUBECONFIG=${2:?Please specify a valid KUBECONFIG: $USAGE}
+
+export KUBECONFIG=$KUBECONFIG
+
+# Create the canary configurations.
+jsonnet \
+   --ext-str PROJECT_ID=${PROJECT} \
+   --ext-code CANARY=true \
+   ../canaries.jsonnet > canaries.json
+
+# Apply the canary configurations to the cluster.
+kubectl apply -f canaries.json


### PR DESCRIPTION
This PR is the first step in resolving #268. This PR will create `<experiment>-canary` DaemonSets which are configured to only deploy to nodes with an `mlab/release=canary` label. Conversely, the normal experiment DaemonSet is configured to _not_ deploy to nodes with that label.

The `cloudbuild-canary.yaml` is as-yet untested, as it relies on a GCB trigger in mlab-oti that looks for pushes to the `master` branch and then runs a build configured using this file.

NOTE: While not technically necessary, this PR will create the `<exp>-canary` DaemonSets in sandbox and staging, mostly for the purposes of possibly testing the canary mechanism without affecting production nodes.

NOTE #2: We need to be careful when deploying this (if we deploy it). When you label a node with `mlab/release=canary`, the normal DaemonSet will immediately start terminating, but this takes 150s. Meanwhile, the new canary DaemonSet is also immediately deployed. It will repeated fail until the normal one finishing terminating due to an IP conflict, and will expose us to the condition (bug?) where flannel does not reap private IPs of failed pods, and we risk depleting all private flannel IPs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/278)
<!-- Reviewable:end -->
