### PR TITLE
Updates utility-support image to v2.0.6 in utilization DaemonSet.

### DIFF
--- a/k8s/daemonsets/core/utilization.jsonnet
+++ b/k8s/daemonsets/core/utilization.jsonnet
@@ -27,7 +27,7 @@ local exp = import '../templates.jsonnet';
         containers: [
           {
             name: 'collectd',
-            image: 'measurementlab/utility-support:v2.0.5',
+            image: 'measurementlab/utility-support:v2.0.6',
             env: [
               {
                 name: 'HOSTNAME',


### PR DESCRIPTION
This PR should put the fix for https://github.com/m-lab/utility-support/issues/25 into the cluster.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/282)
<!-- Reviewable:end -->
