### PR TITLE
Updates the utilization (utility-support) Docker image to v2.0.7.

### DIFF
--- a/k8s/daemonsets/core/utilization.jsonnet
+++ b/k8s/daemonsets/core/utilization.jsonnet
@@ -27,7 +27,7 @@ local exp = import '../templates.jsonnet';
         containers: [
           {
             name: 'collectd',
-            image: 'measurementlab/utility-support:v2.0.6',
+            image: 'measurementlab/utility-support:v2.0.7',
             env: [
               {
                 name: 'HOSTNAME',


### PR DESCRIPTION
v2.0.6 was the victim of a Docker Hub caching configuration which has now been resolved.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/283)
<!-- Reviewable:end -->
