### PR TITLE
Upgrades k8s to 1.14.8 + several other fixes and improvements

### DIFF
--- a/k8s/daemonsets/core/flannel-cloud.jsonnet
+++ b/k8s/daemonsets/core/flannel-cloud.jsonnet
@@ -23,9 +23,15 @@
     namespace: 'kube-system',
   },
   spec: {
+    selector: {
+      matchLabels: {
+        workload: 'flannel-cloud',
+      },
+    },
     template: {
       metadata: {
         labels: {
+          workload: 'flannel-cloud',
           app: 'flannel',
           tier: 'node',
         },

--- a/k8s/daemonsets/core/flannel-cloud.jsonnet
+++ b/k8s/daemonsets/core/flannel-cloud.jsonnet
@@ -18,6 +18,7 @@
     labels: {
       app: 'flannel',
       tier: 'node',
+      workload: 'flannel-cloud',
     },
     name: 'kube-flannel-ds-cloud',
     namespace: 'kube-system',
@@ -25,15 +26,17 @@
   spec: {
     selector: {
       matchLabels: {
+        app: 'flannel',
+        tier: 'node',
         workload: 'flannel-cloud',
       },
     },
     template: {
       metadata: {
         labels: {
-          workload: 'flannel-cloud',
           app: 'flannel',
           tier: 'node',
+          workload: 'flannel-cloud',
         },
       },
       spec: {

--- a/k8s/daemonsets/core/flannel-cloud.jsonnet
+++ b/k8s/daemonsets/core/flannel-cloud.jsonnet
@@ -12,7 +12,7 @@
 // https://github.com/kubernetes/kubernetes/issues/44254
 
 {
-  apiVersion: 'extensions/v1beta1',
+  apiVersion: 'apps/v1',
   kind: 'DaemonSet',
   metadata: {
     labels: {

--- a/k8s/daemonsets/core/flannel-cloud.jsonnet
+++ b/k8s/daemonsets/core/flannel-cloud.jsonnet
@@ -15,11 +15,6 @@
   apiVersion: 'apps/v1',
   kind: 'DaemonSet',
   metadata: {
-    labels: {
-      app: 'flannel',
-      tier: 'node',
-      workload: 'flannel-cloud',
-    },
     name: 'kube-flannel-ds-cloud',
     namespace: 'kube-system',
   },

--- a/k8s/daemonsets/core/flannel-platform.jsonnet
+++ b/k8s/daemonsets/core/flannel-platform.jsonnet
@@ -19,9 +19,15 @@
     namespace: 'kube-system',
   },
   spec: {
+    selector: {
+      matchLabels: {
+        workload: 'flannel-platform',
+      }
+    }
     template: {
       metadata: {
         labels: {
+          workload: 'flannel-platform',
           app: 'flannel',
           tier: 'node',
         },

--- a/k8s/daemonsets/core/flannel-platform.jsonnet
+++ b/k8s/daemonsets/core/flannel-platform.jsonnet
@@ -22,8 +22,8 @@
     selector: {
       matchLabels: {
         workload: 'flannel-platform',
-      }
-    }
+      },
+    },
     template: {
       metadata: {
         labels: {

--- a/k8s/daemonsets/core/flannel-platform.jsonnet
+++ b/k8s/daemonsets/core/flannel-platform.jsonnet
@@ -22,7 +22,7 @@
   spec: {
     selector: {
       matchLabels: {
-        app: 'flanne',
+        app: 'flannel',
         tier: 'node',
         workload: 'flannel-platform',
       },

--- a/k8s/daemonsets/core/flannel-platform.jsonnet
+++ b/k8s/daemonsets/core/flannel-platform.jsonnet
@@ -11,11 +11,6 @@
   apiVersion: 'apps/v1',
   kind: 'DaemonSet',
   metadata: {
-    labels: {
-      app: 'flannel',
-      tier: 'node',
-      workload: 'flannel-platform',
-    },
     name: 'kube-flannel-ds-platform',
     namespace: 'kube-system',
   },

--- a/k8s/daemonsets/core/flannel-platform.jsonnet
+++ b/k8s/daemonsets/core/flannel-platform.jsonnet
@@ -8,7 +8,7 @@
 // their external networking run done by ipvlan with a custom IPAM plugin. The
 // ability to have multus network interfaces in a pod is provided by multus.
 {
-  apiVersion: 'extensions/v1beta1',
+  apiVersion: 'apps/v1',
   kind: 'DaemonSet',
   metadata: {
     labels: {

--- a/k8s/daemonsets/core/flannel-platform.jsonnet
+++ b/k8s/daemonsets/core/flannel-platform.jsonnet
@@ -14,6 +14,7 @@
     labels: {
       app: 'flannel',
       tier: 'node',
+      workload: 'flannel-platform',
     },
     name: 'kube-flannel-ds-platform',
     namespace: 'kube-system',
@@ -21,15 +22,17 @@
   spec: {
     selector: {
       matchLabels: {
+        app: 'flanne',
+        tier: 'node',
         workload: 'flannel-platform',
       },
     },
     template: {
       metadata: {
         labels: {
-          workload: 'flannel-platform',
           app: 'flannel',
           tier: 'node',
+          workload: 'flannel-platform',
         },
       },
       spec: {

--- a/k8s/daemonsets/core/utilization.jsonnet
+++ b/k8s/daemonsets/core/utilization.jsonnet
@@ -1,7 +1,7 @@
 local exp = import '../templates.jsonnet';
 
 {
-  apiVersion: 'extensions/v1beta1',
+  apiVersion: 'apps/v1',
   kind: 'DaemonSet',
   metadata: {
     name: 'utilization',

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -201,7 +201,7 @@ local Pusher(expName, tcpPort, datatypes, hostNetwork, bucket) = [
 ;
 
 local ExperimentNoIndex(name, datatypes, hostNetwork, bucket) = {
-  apiVersion: 'extensions/v1beta1',
+  apiVersion: 'apps/v1',
   kind: 'DaemonSet',
   metadata: {
     name: name,

--- a/manage-cluster/bootstraplib.sh
+++ b/manage-cluster/bootstraplib.sh
@@ -164,7 +164,7 @@ function create_master {
 
     # Install CNI plugins.
     mkdir -p /opt/cni/bin
-    curl -L "https://github.com/containernetworking/plugins/releases/download/${K8S_CNI_VERSION}/cni-plugins-amd64-${K8S_CNI_VERSION}.tgz" | tar -C /opt/cni/bin -xz
+    curl -L "https://github.com/containernetworking/plugins/releases/download/${K8S_CNI_VERSION}/cni-plugins-linux-amd64-${K8S_CNI_VERSION}.tgz" | tar -C /opt/cni/bin -xz
 
     # Install crictl.
     mkdir -p /opt/bin

--- a/manage-cluster/k8s_deploy.conf
+++ b/manage-cluster/k8s_deploy.conf
@@ -26,9 +26,9 @@ PROM_BASE_NAME="prometheus-${GCE_BASE_NAME}"
 # we learn more.
 GCE_API_SCOPES="cloud-platform"
 
-K8S_VERSION="v1.13.5"
-K8S_CNI_VERSION="v0.7.5"
-K8S_CRICTL_VERSION="v1.13.0"
+K8S_VERSION="v1.14.8"
+K8S_CNI_VERSION="v0.8.2"
+K8S_CRICTL_VERSION="v1.16.1"
 K8S_FLANNEL_VERSION="v0.11.0"
 K8S_CA_FILES="ca.crt ca.key sa.key sa.pub front-proxy-ca.crt front-proxy-ca.key etcd/ca.crt etcd/ca.key"
 K8S_PKI_DIR="/tmp/kubernetes-pki"

--- a/manage-cluster/upgrade_k8s_master_cluster.sh
+++ b/manage-cluster/upgrade_k8s_master_cluster.sh
@@ -36,7 +36,7 @@ UPGRADE_STATE="new"
 
 for zone in $GCE_ZONES; do
   gce_zone="${GCE_REGION}-${zone}"
-  gce_name="${GCE_BASE_NAME}-${gce_zone}"
+  gce_name="master-${GCE_BASE_NAME}-${gce_zone}"
 
   GCE_ARGS=("--zone=${gce_zone}" "${GCP_ARGS[@]}")
 

--- a/manage-cluster/upgrade_k8s_master_cluster.sh
+++ b/manage-cluster/upgrade_k8s_master_cluster.sh
@@ -92,6 +92,9 @@ for zone in $GCE_ZONES; do
   
     # Drain the node of most workloads, except DaemonSets, since some of those
     # are critical for the node to even be part of the cluster (e.g., flannel).
+    # The flag --delete-local-data causes the command to "continue even if
+    # there are pods using emptyDir". In our case, the CoreDNS pods use
+    # emptyDir volumes, but we don't care about the data in there.
     kubectl drain $gce_name --ignore-daemonsets --delete-local-data=true
   
     # Upgrade CNI plugins.

--- a/manage-cluster/upgrade_k8s_master_cluster.sh
+++ b/manage-cluster/upgrade_k8s_master_cluster.sh
@@ -95,7 +95,7 @@ for zone in $GCE_ZONES; do
     kubectl drain $gce_name --ignore-daemonsets
   
     # Upgrade CNI plugins.
-    curl -L "https://github.com/containernetworking/plugins/releases/download/${K8S_CNI_VERSION}/cni-plugins-amd64-${K8S_CNI_VERSION}.tgz" | tar -C /opt/cni/bin -xz
+    curl -L "https://github.com/containernetworking/plugins/releases/download/${K8S_CNI_VERSION}/cni-plugins-linux-amd64-${K8S_CNI_VERSION}.tgz" | tar -C /opt/cni/bin -xz
 
     # Upgrade crictl.
     curl -L "https://github.com/kubernetes-incubator/cri-tools/releases/download/${K8S_CRICTL_VERSION}/crictl-${K8S_CRICTL_VERSION}-linux-amd64.tar.gz" | tar -C /opt/bin -xz

--- a/manage-cluster/upgrade_k8s_master_cluster.sh
+++ b/manage-cluster/upgrade_k8s_master_cluster.sh
@@ -76,7 +76,7 @@ for zone in $GCE_ZONES; do
     sed -e 's|{{PROJECT}}|${PROJECT}|g' \
         -e 's|{{INTERNAL_IP}}|${INTERNAL_IP}|g' \
         -e 's|{{MASTER_NAME}}|${gce_name}|g' \
-        -e 's|{{LOAD_BALANCER_NAME}}|${GCE_BASE_NAME}|g' \
+        -e 's|{{LOAD_BALANCER_NAME}}|api-${GCE_BASE_NAME}|g' \
         -e 's|{{K8S_VERSION}}|${K8S_VERSION}|g' \
         -e 's|{{K8S_CLUSTER_CIDR}}|${K8S_CLUSTER_CIDR}|g' \
         -e 's|{{K8S_SERVICE_CIDR}}|${K8S_SERVICE_CIDR}|g' \

--- a/manage-cluster/upgrade_k8s_master_cluster.sh
+++ b/manage-cluster/upgrade_k8s_master_cluster.sh
@@ -92,7 +92,7 @@ for zone in $GCE_ZONES; do
   
     # Drain the node of most workloads, except DaemonSets, since some of those
     # are critical for the node to even be part of the cluster (e.g., flannel).
-    kubectl drain $gce_name --ignore-daemonsets
+    kubectl drain $gce_name --ignore-daemonsets --delete-local-data=true
   
     # Upgrade CNI plugins.
     curl -L "https://github.com/containernetworking/plugins/releases/download/${K8S_CNI_VERSION}/cni-plugins-linux-amd64-${K8S_CNI_VERSION}.tgz" | tar -C /opt/cni/bin -xz

--- a/node/setup_k8s.sh.template
+++ b/node/setup_k8s.sh.template
@@ -77,8 +77,8 @@ TOKEN=$( curl --fail --silent --show-error -XPOST --data-binary "{}" \
     ${K8S_TOKEN_URL} 2> $K8S_TOKEN_ERROR_FILE )
 # IF there was an error and the error was 408 (Request Timeout), then reboot
 # the machine to reset the token timeout.
-ERROR_CODE=$(grep --only-matching '...$' $K8S_TOKEN_ERROR_FILE)
-if [[ $ERROR_CODE -eq "408" ]]; then
+ERROR_CODE=$(grep '408 Request Timeout' $K8S_TOKEN_ERROR_FILE)
+if [[ -n $ERROR_CODE ]]; then
   /sbin/reboot
 fi
 

--- a/node/setup_k8s.sh.template
+++ b/node/setup_k8s.sh.template
@@ -77,7 +77,7 @@ TOKEN=$( curl --fail --silent --show-error -XPOST --data-binary "{}" \
     ${K8S_TOKEN_URL} 2> $K8S_TOKEN_ERROR_FILE )
 # IF there was an error and the error was 408 (Request Timeout), then reboot
 # the machine to reset the token timeout.
-ERROR_CODE=$(grep -o '...$' $K8S_TOKEN_ERROR_FILE)
+ERROR_CODE=$(grep --only-matching '...$' $K8S_TOKEN_ERROR_FILE)
 if [[ $ERROR_CODE -eq "408" ]]; then
   /sbin/reboot
 fi

--- a/node/setup_k8s.sh.template
+++ b/node/setup_k8s.sh.template
@@ -22,6 +22,7 @@ GCP_PROJECT=${1:?GCP Project is missing.}
 # IPV4="$2"  # Currently unused.
 HOSTNAME=${3:?Node hostname is missing.}
 K8S_TOKEN_URL=${4:?k8s token URL is missing. Node cannot join k8s cluster.}
+K8S_TOKEN_ERROR_FILE="/tmp/k8s_token_error"
 
 # Turn the hostname into its component parts.
 MACHINE=$(echo "${HOSTNAME}" | tr . ' ' | awk '{ print $1 }')
@@ -70,8 +71,17 @@ systemctl daemon-reload
 systemctl enable docker
 systemctl start docker
 
-# Fetch k8s token via K8S_TOKEN_URL. Curl should report most errors to stderr.
-TOKEN=$( curl --fail --silent --show-error -XPOST --data-binary "{}" ${K8S_TOKEN_URL} )
+# Fetch k8s token via K8S_TOKEN_URL. Curl should report most errors to stderr,
+# so write stderr to a file so we can read any error code.
+TOKEN=$( curl --fail --silent --show-error -XPOST --data-binary "{}" \
+    ${K8S_TOKEN_URL} 2> $K8S_TOKEN_ERROR_FILE )
+# IF there was an error and the error was 408 (Request Timeout), then reboot
+# the machine to reset the token timeout.
+ERROR_CODE=$(grep -o '...$' $K8S_TOKEN_ERROR_FILE)
+if [[ $ERROR_CODE -eq "408" ]]; then
+  /sbin/reboot
+fi
+
 export PATH=/sbin:/usr/sbin:/opt/bin:${PATH}
 # TODO: Stop regenerating the CA on every call to setup_cloud_k8s_master.sh so
 # that we can hard-code the CA hash below without having to change it all the

--- a/node/setup_k8s.sh.template
+++ b/node/setup_k8s.sh.template
@@ -77,8 +77,8 @@ TOKEN=$( curl --fail --silent --show-error -XPOST --data-binary "{}" \
     ${K8S_TOKEN_URL} 2> $K8S_TOKEN_ERROR_FILE )
 # IF there was an error and the error was 408 (Request Timeout), then reboot
 # the machine to reset the token timeout.
-ERROR_CODE=$(grep '408 Request Timeout' $K8S_TOKEN_ERROR_FILE)
-if [[ -n $ERROR_CODE ]]; then
+ERROR_408=$(grep '408 Request Timeout' $K8S_TOKEN_ERROR_FILE || :)
+if [[ -n $ERROR_408 ]]; then
   /sbin/reboot
 fi
 


### PR DESCRIPTION
* k8s is upgraded (in configs) from v1.13.5 to v1.14.8
* All DaemonSets now use apiVersion `apps/v1` (`extensions/v1beta1`) is deprecated.
* Adds missing required `selector` config to flannel DaemonSets
* Adds sanity checking to cluster upgrade script, resolving issue #151 
*  Adds logic to `setup_k8s.sh` script to reboot a node if ePoxy replies with a 408 Request Timeout error, which indicates that the original token expired.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/290)
<!-- Reviewable:end -->
