### PR TITLE
Bumps the utilization DaemonSet to v2.0.8

### DIFF
--- a/k8s/daemonsets/core/utilization.jsonnet
+++ b/k8s/daemonsets/core/utilization.jsonnet
@@ -27,7 +27,7 @@ local exp = import '../templates.jsonnet';
         containers: [
           {
             name: 'collectd',
-            image: 'measurementlab/utility-support:v2.0.7',
+            image: 'measurementlab/utility-support:v2.0.8',
             env: [
               {
                 name: 'HOSTNAME',


### PR DESCRIPTION
This adds support for EX4200 switches to collectd-mlab.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/293)
<!-- Reviewable:end -->
