### PR TITLE
Increases the machine type for the Prometheus VM to a n1-highmem-16

### DIFF
--- a/manage-cluster/bootstrap_prometheus.sh
+++ b/manage-cluster/bootstrap_prometheus.sh
@@ -41,7 +41,7 @@ case $PROJECT in
   mlab-staging)
     MACHINE_TYPE="n1-standard-8";;
   mlab-oti)
-    MACHINE_TYPE="n1-highmem-8";;
+    MACHINE_TYPE="n1-highmem-16";;
   *)
     echo "Unknown GCP project: ${PROJECT}"
     exit 1


### PR DESCRIPTION
With n1-highmem-8 we were hitting the mem limits and Prom was crashing periodically. n1-highmem-16 will give us 16 vCPUs and 105GB of memory, which should give us breathing room for the remaining 50 US mlab1 nodes which will soon join the cluster, as well as room for new sites in the pipeline (e.g., Mexico).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/294)
<!-- Reviewable:end -->
