### PR TITLE
Add recording rule for Pusher data volume

### DIFF
--- a/config/prometheus/rules.yml
+++ b/config/prometheus/rules.yml
@@ -174,5 +174,5 @@ groups:
 ## Pusher Daily Volume metrics
 #
 # This rule optimizes the alert query used for PusherDailyDataVolumeTooLow.
-  - record: datatype:pusher_bytes_per_tarile:increase24h
+  - record: datatype:pusher_bytes_per_tarfile:increase24h
     expr: sum by(datatype) (increase(pusher_bytes_per_tarfile_sum[1d]))

--- a/config/prometheus/rules.yml
+++ b/config/prometheus/rules.yml
@@ -170,3 +170,9 @@ groups:
           }
         [1h]) * 8
       )
+
+## Pusher Daily Volume metrics
+#
+# This rule optimizes the alert query used for PusherDailyDataVolumeTooLow.
+  - record: datatype:pusher_bytes_per_tarile:increase24h
+    expr: sum by(datatype) (increase(pusher_bytes_per_tarfile_sum[1d]))


### PR DESCRIPTION
This change adds a new recording rule for the pusher data volume. This will be used in an alert in the prometheus-federation cluster.

Part of https://github.com/m-lab/dev-tracker/issues/507

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/295)
<!-- Reviewable:end -->
