### PR TITLE
Update ndt-server to v0.13.3.

### DIFF
--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -1,4 +1,4 @@
-local ndtVersion = 'v0.13.2';
+local ndtVersion = 'v0.13.3';
 
 local uuid = {
   initContainer: {


### PR DESCRIPTION
This PR updates ndt-server to v0.13.3, which includes the NDT S2C test fix for legacy clients.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/301)
<!-- Reviewable:end -->
