### PR TITLE
Temporarily remove the pcap datatype from pusher

### DIFF
--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -286,7 +286,7 @@ local ExperimentNoIndex(name, datatypes, hostNetwork, bucket) = {
             Tcpinfo(name, 9991, hostNetwork),
             Traceroute(name, 9992, hostNetwork),
             // Pcap(name, 9993, hostNetwork),
-            Pusher(name, 9994, ['tcpinfo', 'traceroute', 'pcap'] + datatypes, hostNetwork, bucket),
+            Pusher(name, 9994, ['tcpinfo', 'traceroute'] + datatypes, hostNetwork, bucket),
           ]),
         [if hostNetwork then 'serviceAccountName']: 'kube-rbac-proxy',
         initContainers: [


### PR DESCRIPTION
This PR temporarily removes the `pcap` datatype from pusher's configuration since we have removed the `pcap` container. 

This change should be reverted, together with https://github.com/m-lab/k8s-support/pull/302, or replaced with a more general solution after the production deployment.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/303)
<!-- Reviewable:end -->
