### PR TITLE
Enable storage retention for prometheus

### DIFF
--- a/k8s/deployments/prometheus.jsonnet
+++ b/k8s/deployments/prometheus.jsonnet
@@ -37,8 +37,7 @@ local prometheusConfig = import '../../config/prometheus.jsonnet';
               '--config.file=/etc/prometheus/prometheus.yml',
               '--storage.tsdb.path=/prometheus',
               '--web.enable-lifecycle',
-              // TODO: enable longer retention once persistent volumes are available.
-              //  "--storage.tsdb.retention=2880h",
+              '--storage.tsdb.retention=2880h',
             ],
             image: 'prom/prometheus:v2.4.2',
             name: 'prometheus',


### PR DESCRIPTION
Current retention eriod is the default of 2 weeks. This is inadequate for production use and we have persistent storage now.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/304)
<!-- Reviewable:end -->
