### PR TITLE
Only deploy pcap collection in sandbox and staging

### DIFF
--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -285,8 +285,12 @@ local ExperimentNoIndex(name, datatypes, hostNetwork, bucket) = {
           std.flattenArrays([
             Tcpinfo(name, 9991, hostNetwork),
             Traceroute(name, 9992, hostNetwork),
-            // Pcap(name, 9993, hostNetwork),
-            Pusher(name, 9994, ['tcpinfo', 'traceroute'] + datatypes, hostNetwork, bucket),
+            if std.extVar('PROJECT_ID') != 'mlab-oti' then [
+              Pcap(name, 9993, hostNetwork),
+              Pusher(name, 9994, ['tcpinfo', 'traceroute', 'pcap'] + datatypes, hostNetwork, bucket)
+            ] else [
+              Pusher(name, 9994, ['tcpinfo', 'traceroute'] + datatypes, hostNetwork, bucket),
+            ]
           ]),
         [if hostNetwork then 'serviceAccountName']: 'kube-rbac-proxy',
         initContainers: [

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -285,12 +285,13 @@ local ExperimentNoIndex(name, datatypes, hostNetwork, bucket) = {
           std.flattenArrays([
             Tcpinfo(name, 9991, hostNetwork),
             Traceroute(name, 9992, hostNetwork),
-            if std.extVar('PROJECT_ID') != 'mlab-oti' then [
-              Pcap(name, 9993, hostNetwork),
-              Pusher(name, 9994, ['tcpinfo', 'traceroute', 'pcap'] + datatypes, hostNetwork, bucket)
-            ] else [
-              Pusher(name, 9994, ['tcpinfo', 'traceroute'] + datatypes, hostNetwork, bucket),
-            ]
+            if std.extVar('PROJECT_ID') != 'mlab-oti' then
+              std.flattenArrays([
+                Pcap(name, 9993, hostNetwork),
+                Pusher(name, 9994, ['tcpinfo', 'traceroute', 'pcap'] + datatypes, hostNetwork, bucket),
+              ])
+            else
+              Pusher(name, 9994, ['tcpinfo', 'traceroute'] + datatypes, hostNetwork, bucket)
           ]),
         [if hostNetwork then 'serviceAccountName']: 'kube-rbac-proxy',
         initContainers: [


### PR DESCRIPTION
We want pcap collection in sandbox and staging, but are not quite ready for it in production. This PR adds a small conditional statement around the pcap parts of templates.jsonnet, such that it will only be deployed in sandbox and staging. Once we are comfortable with pcap collection and its impact on resource utilization on nodes, we will need to remove this conditional.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/305)
<!-- Reviewable:end -->
