### PR TITLE
Add DSACK collection, and disable packet-headers

### DIFF
--- a/k8s/daemonsets/core/node-exporter.jsonnet
+++ b/k8s/daemonsets/core/node-exporter.jsonnet
@@ -31,6 +31,7 @@
               '--collector.textfile.directory=/var/spool/node-exporter',
               '--collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+)($|/)',
               '--collector.filesystem.ignored-fs-types=^(autofs|binfmt_misc|cgroup|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|mqueue|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|sysfs|tracefs)$',
+              '--collector.netstat.fields="^(.*_(InErrors|InErrs)|Ip_Forwarding|Ip(6|Ext)_(InOctets|OutOctets)|Icmp6?_(InMsgs|OutMsgs)|TcpExt_(TCPDSACK.*|Listen.*|Syncookies.*|TCPSynRetrans)|Tcp_(ActiveOpens|InSegs|OutSegs|PassiveOpens|RetransSegs|CurrEstab)|Udp6?_(InDatagrams|OutDatagrams|NoPorts))$"',
               '--no-collector.arp',
               '--no-collector.bcache',
               '--no-collector.bonding',

--- a/k8s/daemonsets/core/node-exporter.jsonnet
+++ b/k8s/daemonsets/core/node-exporter.jsonnet
@@ -31,7 +31,7 @@
               '--collector.textfile.directory=/var/spool/node-exporter',
               '--collector.filesystem.ignored-mount-points=^/(dev|proc|sys|var/lib/docker/.+)($|/)',
               '--collector.filesystem.ignored-fs-types=^(autofs|binfmt_misc|cgroup|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|mqueue|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|sysfs|tracefs)$',
-              '--collector.netstat.fields="^(.*_(InErrors|InErrs)|Ip_Forwarding|Ip(6|Ext)_(InOctets|OutOctets)|Icmp6?_(InMsgs|OutMsgs)|TcpExt_(TCPDSACK.*|Listen.*|Syncookies.*|TCPSynRetrans)|Tcp_(ActiveOpens|InSegs|OutSegs|PassiveOpens|RetransSegs|CurrEstab)|Udp6?_(InDatagrams|OutDatagrams|NoPorts))$"',
+              '--collector.netstat.fields=^(.*_(InErrors|InErrs)|Ip_Forwarding|Ip(6|Ext)_(InOctets|OutOctets)|Icmp6?_(InMsgs|OutMsgs)|TcpExt_(TCPDSACK.*|Listen.*|Syncookies.*|TCPSynRetrans)|Tcp_(ActiveOpens|InSegs|OutSegs|PassiveOpens|RetransSegs|CurrEstab)|Udp6?_(InDatagrams|OutDatagrams|NoPorts))$',
               '--no-collector.arp',
               '--no-collector.bcache',
               '--no-collector.bonding',

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -285,12 +285,12 @@ local ExperimentNoIndex(name, datatypes, hostNetwork, bucket) = {
           std.flattenArrays([
             Tcpinfo(name, 9991, hostNetwork),
             Traceroute(name, 9992, hostNetwork),
-            if std.extVar('PROJECT_ID') != 'mlab-oti' then
+            /* if std.extVar('PROJECT_ID') != 'mlab-oti' then
               std.flattenArrays([
                 Pcap(name, 9993, hostNetwork),
                 Pusher(name, 9994, ['tcpinfo', 'traceroute', 'pcap'] + datatypes, hostNetwork, bucket),
               ])
-            else
+            else */
               Pusher(name, 9994, ['tcpinfo', 'traceroute'] + datatypes, hostNetwork, bucket)
           ]),
         [if hostNetwork then 'serviceAccountName']: 'kube-rbac-proxy',


### PR DESCRIPTION
This change adds DSACK netstat metrics to node-exporter. By default the "TCPDSACK*" pattern is not included. This change adds the default pattern and adds `TCPDSACK.*|`.

FYI: @mattmathis & @pboothe 

Note: I've disabled packet-headers entirely for now to remove one variable from the system while investigating the ndt network timeout issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/306)
<!-- Reviewable:end -->
