### PR TITLE
Rollback `-tcpinfo.socket` flag to traceroute caller

### DIFF
--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -130,8 +130,7 @@ local Traceroute(expName, tcpPort, hostNetwork) = [
       else
         '-prometheusx.listen-address=$(PRIVATE_IP):' + tcpPort,
       '-outputPath=' + VolumeMount(expName).mountPath + '/traceroute',
-      '-uuid-prefix-file=' + uuid.prefixfile,
-      '-tcpinfo.socket=' + tcpinfoServiceVolume.eventsocketFilename,
+      '-uuid-prefix-file=' + uuid.prefixfile
     ],
     env: if hostNetwork then [] else [
       {


### PR DESCRIPTION
Originally added in https://github.com/m-lab/k8s-support/pull/292 this flag is coincidental with an increase in segfaults in scamper and leaking open fds visible in prometheus https://github.com/m-lab/traceroute-caller/issues/38

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/314)
<!-- Reviewable:end -->
