### PR TITLE
Specifies different GCE machine types for each project

### DIFF
--- a/manage-cluster/bootstraplib.sh
+++ b/manage-cluster/bootstraplib.sh
@@ -10,6 +10,8 @@ function create_master {
 
   GCE_ARGS=("--zone=${gce_zone}" "${GCP_ARGS[@]}")
 
+  GCE_TYPE_VAR="GCE_TYPE_${PROJECT//-/_}"
+
   # Create a static IP for the GCE instance, or use the one that already exists.
   EXISTING_IP=$(gcloud compute addresses list \
       --filter "name=${gce_name} AND region:${GCE_REGION}" \
@@ -91,7 +93,7 @@ function create_master {
     --subnet "${GCE_K8S_SUBNET}" \
     --can-ip-forward \
     --tags "${GCE_NET_TAGS}" \
-    --machine-type "${GCE_TYPE}" \
+    --machine-type "${!GCE_TYPE_VAR}" \
     --address "${EXTERNAL_IP}" \
     --scopes "${GCE_API_SCOPES}" \
     --metadata-from-file "user-data=cloud-config_master.yml" \

--- a/manage-cluster/k8s_deploy.conf
+++ b/manage-cluster/k8s_deploy.conf
@@ -7,7 +7,9 @@ GCE_NETWORK="mlab-platform-network"
 GCE_K8S_SUBNET="kubernetes"
 GCE_EPOXY_SUBNET="epoxy"
 GCE_NET_TAGS="platform-cluster" # Comma separated list
-GCE_TYPE="n1-standard-4"
+GCE_TYPE_mlab_sandbox="n1-standard-2"
+GCE_TYPE_mlab_staging="n1-standard-4"
+GCE_TYPE_mlab_oti="n1-standard-8"
 
 # Monitoring variables. Note: "prometheus" is reserved for other deployments.
 PROM_BASE_NAME="prometheus-${GCE_BASE_NAME}"


### PR DESCRIPTION
Each project manages a very different sum of machines.

* Sandbox needs very little resources, since it currently only manages around 8 nodes.
* Staging is okay with n1-standard-4, and manages around 130 nodes.
* Production manages upward of 400 nodes, and needs more horsepower.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/316)
<!-- Reviewable:end -->
