### PR TITLE
Whitelist systemd units we want to monitor only

### DIFF
--- a/k8s/daemonsets/core/node-exporter.jsonnet
+++ b/k8s/daemonsets/core/node-exporter.jsonnet
@@ -33,6 +33,7 @@
               '--collector.filesystem.ignored-fs-types=^(autofs|binfmt_misc|cgroup|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|mqueue|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|sysfs|tracefs)$',
               '--collector.netstat.fields=^(.*_(InErrors|InErrs)|Ip_Forwarding|Ip(6|Ext)_(InOctets|OutOctets)|Icmp6?_(InMsgs|OutMsgs)|TcpExt_(TCPDSACK.*|Listen.*|Syncookies.*|TCPSynRetrans)|Tcp_(ActiveOpens|InSegs|OutSegs|PassiveOpens|RetransSegs|CurrEstab)|Udp6?_(InDatagrams|OutDatagrams|NoPorts))$',
               '--collector.systemd',
+              '--collector.systemd.unit-whitelist=^(setup-after-boot.service|system-cloudinit.+)',
               '--no-collector.arp',
               '--no-collector.bcache',
               '--no-collector.bonding',

--- a/k8s/daemonsets/core/node-exporter.jsonnet
+++ b/k8s/daemonsets/core/node-exporter.jsonnet
@@ -33,7 +33,7 @@
               '--collector.filesystem.ignored-fs-types=^(autofs|binfmt_misc|cgroup|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|mqueue|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|sysfs|tracefs)$',
               '--collector.netstat.fields=^(.*_(InErrors|InErrs)|Ip_Forwarding|Ip(6|Ext)_(InOctets|OutOctets)|Icmp6?_(InMsgs|OutMsgs)|TcpExt_(TCPDSACK.*|Listen.*|Syncookies.*|TCPSynRetrans)|Tcp_(ActiveOpens|InSegs|OutSegs|PassiveOpens|RetransSegs|CurrEstab)|Udp6?_(InDatagrams|OutDatagrams|NoPorts))$',
               '--collector.systemd',
-              '--collector.systemd.unit-whitelist=^(setup-after-boot.service|system-cloudinit.+)',
+              '--collector.systemd.unit-whitelist=^(setup-after-boot|system-cloudinit|docker|kubelet)',
               '--no-collector.arp',
               '--no-collector.bcache',
               '--no-collector.bonding',

--- a/k8s/daemonsets/core/node-exporter.jsonnet
+++ b/k8s/daemonsets/core/node-exporter.jsonnet
@@ -33,7 +33,7 @@
               '--collector.filesystem.ignored-fs-types=^(autofs|binfmt_misc|cgroup|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|mqueue|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|sysfs|tracefs)$',
               '--collector.netstat.fields=^(.*_(InErrors|InErrs)|Ip_Forwarding|Ip(6|Ext)_(InOctets|OutOctets)|Icmp6?_(InMsgs|OutMsgs)|TcpExt_(TCPDSACK.*|Listen.*|Syncookies.*|TCPSynRetrans)|Tcp_(ActiveOpens|InSegs|OutSegs|PassiveOpens|RetransSegs|CurrEstab)|Udp6?_(InDatagrams|OutDatagrams|NoPorts))$',
               '--collector.systemd',
-              '--collector.systemd.unit-whitelist=^(setup-after-boot|system-cloudinit|docker|kubelet)',
+              '--collector.systemd.unit-whitelist=^(setup-after-boot.service|system-cloudinit.+|docker.service|kubelet.service)',
               '--no-collector.arp',
               '--no-collector.bcache',
               '--no-collector.bonding',


### PR DESCRIPTION
Collecting metrics for all the systemd units can easily overwhelm Prometheus, since we have hundreds of k8s nodes and units. Also, the fact every unit generates five different time series (one for each `status`) does not help.

This PR whitelists two systemd units that we want to monitor, while ignoring everything else.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/325)
<!-- Reviewable:end -->
