### PR TITLE
Add node-exporter process metrics and faster sandbox deploys

### DIFF
--- a/k8s/daemonsets/core/node-exporter.jsonnet
+++ b/k8s/daemonsets/core/node-exporter.jsonnet
@@ -34,6 +34,7 @@
               '--collector.netstat.fields=^(.*_(InErrors|InErrs)|Ip_Forwarding|Ip(6|Ext)_(InOctets|OutOctets)|Icmp6?_(InMsgs|OutMsgs)|TcpExt_(TCPDSACK.*|Listen.*|Syncookies.*|TCPSynRetrans)|Tcp_(ActiveOpens|InSegs|OutSegs|PassiveOpens|RetransSegs|CurrEstab)|Udp6?_(InDatagrams|OutDatagrams|NoPorts))$',
               '--collector.systemd',
               '--collector.systemd.unit-whitelist=^(setup-after-boot.service|system-cloudinit.+|docker.service|kubelet.service)',
+              '--collector.processes',
               '--no-collector.arp',
               '--no-collector.bcache',
               '--no-collector.bonding',

--- a/k8s/daemonsets/experiments/ndt.jsonnet
+++ b/k8s/daemonsets/experiments/ndt.jsonnet
@@ -58,7 +58,9 @@ exp.Experiment('ndt', 2, 'pusher-' + std.extVar('PROJECT_ID'), ['ndt5', 'ndt7'])
         // Feel free to change this to a smaller value for speedy
         // sandbox deployments to enable faster compile-run-debug loops,
         // but 60+60+30=150 is what it needs to be for staging and prod.
-        terminationGracePeriodSeconds: 150,
+        //
+        // Only enable grace period where production traffic is possible.
+        [if std.extVar('PROJECT_ID') != 'mlab-sandbox' then 'terminationGracePeriodSeconds']: 150,
         volumes+: [
           {
             name: 'ndt-tls',


### PR DESCRIPTION
This change removes the terminationGracePeriodSeconds for ndt in sandbox for faster deploys.

As well, this change adds the processes collector to the node-exporter in lieu of more fine-grain process counts from pods or containers, since it's unclear how to get that currently.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/328)
<!-- Reviewable:end -->
