### PR TITLE
Deploy packet-headers unconditionally

### DIFF
--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -286,13 +286,8 @@ local ExperimentNoIndex(name, datatypes, hostNetwork, bucket) = {
           std.flattenArrays([
             Tcpinfo(name, 9991, hostNetwork),
             Traceroute(name, 9992, hostNetwork),
-            if std.extVar('PROJECT_ID') != 'mlab-oti' then
-              std.flattenArrays([
-                Pcap(name, 9993, hostNetwork),
-                Pusher(name, 9994, ['tcpinfo', 'traceroute', 'pcap'] + datatypes, hostNetwork, bucket),
-              ])
-            else
-              Pusher(name, 9994, ['tcpinfo', 'traceroute'] + datatypes, hostNetwork, bucket)
+            Pcap(name, 9993, hostNetwork),
+            Pusher(name, 9994, ['tcpinfo', 'traceroute', 'pcap'] + datatypes, hostNetwork, bucket),
           ]),
         [if hostNetwork then 'serviceAccountName']: 'kube-rbac-proxy',
         initContainers: [


### PR DESCRIPTION
After load testing we believe that packet headers should be able to operate safely with production load.

This change makes the pcap deployment unconditional.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/332)
<!-- Reviewable:end -->
