### PR TITLE
Upgrade prometheus to v2.14.0

### DIFF
--- a/k8s/deployments/prometheus.jsonnet
+++ b/k8s/deployments/prometheus.jsonnet
@@ -37,7 +37,7 @@ local prometheusConfig = import '../../config/prometheus.jsonnet';
               '--config.file=/etc/prometheus/prometheus.yml',
               '--storage.tsdb.path=/prometheus',
               '--web.enable-lifecycle',
-              '--storage.tsdb.retention=2880h',
+              '--storage.tsdb.retention.time=2880h',
             ],
             image: 'prom/prometheus:v2.14.0',
             name: 'prometheus',

--- a/k8s/deployments/prometheus.jsonnet
+++ b/k8s/deployments/prometheus.jsonnet
@@ -39,7 +39,7 @@ local prometheusConfig = import '../../config/prometheus.jsonnet';
               '--web.enable-lifecycle',
               '--storage.tsdb.retention=2880h',
             ],
-            image: 'prom/prometheus:v2.4.2',
+            image: 'prom/prometheus:v2.14.0',
             name: 'prometheus',
             ports: [
               {


### PR DESCRIPTION
Upgrade prometheus to the latest version.

This is motivated by the recent upgrade of prometheus-support and that versions later than v2.7.0 support "subquery" support which will allow me to upgrade the Prometheus:Self-Monitoring dashboard to estimate disk usage without noise otherwise created by `predict_linear`. (yak, yak, yak).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/333)
<!-- Reviewable:end -->
