### PR TITLE
Rollback traceroute-caller to v0.3.2

### DIFF
--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -123,7 +123,7 @@ local Tcpinfo(expName, tcpPort, hostNetwork) = [
 local Traceroute(expName, tcpPort, hostNetwork) = [
   {
     name: 'traceroute',
-    image: 'measurementlab/traceroute-caller:v0.3.3',
+    image: 'measurementlab/traceroute-caller:v0.3.2',
     args: [
       if hostNetwork then
         '-prometheusx.listen-address=127.0.0.1:' + tcpPort


### PR DESCRIPTION
This change is already tagged and rolling out to production.

This change is to apply the change to staging.

https://github.com/m-lab/k8s-support/releases/tag/v2.3.1

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/334)
<!-- Reviewable:end -->
