### PR TITLE
Add SOCATProxy as standard part of core service deployments

### DIFF
--- a/k8s/daemonsets/README.md
+++ b/k8s/daemonsets/README.md
@@ -1,3 +1,34 @@
 We have two kinds of daemonset we want to run on our nodes: Those that make the platform work ([core]) and those which cause an actual researcher's experiment to run ([experiments]).
 
 [templates.json] contains helpful templates for the creation of new daemonsets of both kinds.
+
+## Access Metrics and PProf Instrumentation
+
+Our core services (tcpinfo, traceroute, pcap, pusher) are built with native
+prometheus metrics and pprof instrumentation. Ordinarily, access to the
+`/metrics` and `/debug/pprof` targets are only accessible to the private k8s
+network.
+
+Operators can access these targets by following these steps.
+
+1. Identify a pod of interest. For example:
+
+```sh
+$ kubectl get pods -o wide | grep mlab1.lga0t | grep ndt
+ndt-w6tr6   9/9       Running   0          29m     192.168.3.24    mlab1.lga0t
+```
+
+2. Forward a local port to the remote pod port for the container of interest.
+   Check the latest port-to-container mapping in k8s/daemonsets/templates.jsonnet
+
+```sh
+$ kubectl port-forward pod/ndt-w6tr6 9993:9993
+```
+
+3. Access localhost:9993 using a browser, `go tool pprof <url>`, or other tool.
+
+```sh
+$ google-chrome http://localhost:9993/metrics
+$ go tool pprof -top http://localhost:9993/debug/pprof/heap
+$ lynx http://localhost:9993/debug/pprof/
+```

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -53,7 +53,7 @@ local SOCATProxy(name, port) = {
   args: [
     // socat does not support long options.
     '-dd', // debug.
-    'tcp-listen:' + port + ',fork,reuseaddr',
+    'tcp-listen:127.0.0.1:' + port + ',fork,reuseaddr',
     'tcp-connect:$(IP):' +  port,
   ],
   env: [

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -53,7 +53,7 @@ local SOCATProxy(name, port) = {
   args: [
     // socat does not support long options.
     '-dd', // debug.
-    'tcp-listen:127.0.0.1:' + port + ',fork,reuseaddr',
+    'tcp-listen:' + port + ',bind=127.0.0.1,fork,reuseaddr',
     'tcp-connect:$(IP):' +  port,
   ],
   env: [


### PR DESCRIPTION
This change adds a new sidecar container for core services so that we can easily connect to the metric and instrumentation ports using `kubectl port-forward`.

With this change an operator can:

```
$ # identify the pod to connect to somehow.
$ kubectl port-forward pod/<pod-name> <local-port>:<remote-port>
$ # access localhost:<local-port> using your browser, `go tool pprof <url>`, lynx, or other tool.
```

Note: kube-rbac-proxy allows unauthenticated access to localhost automatically. So, the above steps work for `hostNetwork:true` pods using the RBACProxy already.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/335)
<!-- Reviewable:end -->
