### PR TITLE
Sets disk size for the Prom VM based on project

### DIFF
--- a/k8s/daemonsets/core/cadvisor.jsonnet
+++ b/k8s/daemonsets/core/cadvisor.jsonnet
@@ -31,7 +31,7 @@
               // Only show stats for docker containers.
               '--docker_only',
             ],
-            image: 'k8s.gcr.io/cadvisor:v0.32.0',
+            image: 'k8s.gcr.io/cadvisor:v0.35.0',
             name: 'cadvisor',
             ports: [
               {

--- a/k8s/deployments/kube-state-metrics.jsonnet
+++ b/k8s/deployments/kube-state-metrics.jsonnet
@@ -30,7 +30,7 @@
             args: [
               '--collectors=daemonsets,deployments,nodes,pods,resourcequotas,services',
             ],
-            image: 'quay.io/coreos/kube-state-metrics:v1.5.0',
+            image: 'quay.io/coreos/kube-state-metrics:v1.8.0',
             name: 'kube-state-metrics',
             ports: [
               {

--- a/manage-cluster/bootstrap_prometheus.sh
+++ b/manage-cluster/bootstrap_prometheus.sh
@@ -37,11 +37,17 @@ GCE_ARGS=("--zone=${GCE_ZONE}" "${GCP_ARGS[@]}")
 # The type of GCE VM which will be deployed.
 case $PROJECT in
   mlab-sandbox)
-    MACHINE_TYPE="n1-standard-2";;
+    MACHINE_TYPE="n1-standard-2"
+    DISK_SIZE="200GB"
+    ;;
   mlab-staging)
-    MACHINE_TYPE="n1-standard-8";;
+    MACHINE_TYPE="n1-standard-8"
+    DISK_SIZE="500GB"
+    ;;
   mlab-oti)
-    MACHINE_TYPE="n1-highmem-16";;
+    MACHINE_TYPE="n1-highmem-16"
+    DISK_SIZE="2000GB"
+    ;;
   *)
     echo "Unknown GCP project: ${PROJECT}"
     exit 1
@@ -169,7 +175,7 @@ if [[ -z "${EXISTING_DISK}" ]]; then
   # Attempt to create disk and ignore errors.
   gcloud compute disks create \
       "${DISK_NAME}" \
-      --size "500GB" \
+      --size "${DISK_SIZE}" \
       --type "pd-ssd" \
       --labels "${PROM_BASE_NAME}=true" \
       "${GCE_ARGS[@]}" || :


### PR DESCRIPTION
The Prometheus instance in each cluster will use vastly different amounts of disk space. This PR sets up the disk size based on the project.

It also updates a few more Docker images.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/336)
<!-- Reviewable:end -->
