### PR TITLE
Moves cadvisor version to v0.34.0.

### DIFF
--- a/k8s/daemonsets/core/cadvisor.jsonnet
+++ b/k8s/daemonsets/core/cadvisor.jsonnet
@@ -31,7 +31,7 @@
               // Only show stats for docker containers.
               '--docker_only',
             ],
-            image: 'k8s.gcr.io/cadvisor:v0.33.0',
+            image: 'k8s.gcr.io/cadvisor:v0.34.0',
             name: 'cadvisor',
             ports: [
               {

--- a/k8s/daemonsets/core/cadvisor.jsonnet
+++ b/k8s/daemonsets/core/cadvisor.jsonnet
@@ -31,7 +31,7 @@
               // Only show stats for docker containers.
               '--docker_only',
             ],
-            image: 'k8s.gcr.io/cadvisor:v0.35.0',
+            image: 'k8s.gcr.io/cadvisor:v0.33.0',
             name: 'cadvisor',
             ports: [
               {


### PR DESCRIPTION
I earlier missed that v0.35.0 is still pre-release and there is not even a Docker image published for it in gcr.io.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/337)
<!-- Reviewable:end -->
