### PR TITLE
Rollback traceroute caller for staging

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,4 @@ To deploy NDT pod:
 1. cd manage-cluster
 1. ./bootstrap_k8s_workloads.sh
 1. kubectl get pods
+

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -153,7 +153,7 @@ local Tcpinfo(expName, tcpPort, hostNetwork) = [
 local Traceroute(expName, tcpPort, hostNetwork) = [
   {
     name: 'traceroute',
-    image: 'measurementlab/traceroute-caller:v0.5.1',
+    image: 'measurementlab/traceroute-caller:v0.3.2',
     args: [
       if hostNetwork then
         '-prometheusx.listen-address=127.0.0.1:' + tcpPort
@@ -161,9 +161,6 @@ local Traceroute(expName, tcpPort, hostNetwork) = [
         '-prometheusx.listen-address=$(PRIVATE_IP):' + tcpPort,
       '-outputPath=' + VolumeMount(expName).mountPath + '/traceroute',
       '-uuid-prefix-file=' + uuid.prefixfile,
-      '-poll=false',
-      '-tcpinfo.eventsocket=' + tcpinfoServiceVolume.eventsocketFilename,
-      '-tracetool=scamper-daemon-with-scamper-backup',
     ],
     env: if hostNetwork then [] else [
       {


### PR DESCRIPTION
We rolled this back for prod -- similarly for staging -- See: https://github.com/m-lab/k8s-support/issues/345

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/346)
<!-- Reviewable:end -->
