### PR TITLE
Update Helm to v3.0.2

### DIFF
--- a/manage-cluster/k8s_deploy.conf
+++ b/manage-cluster/k8s_deploy.conf
@@ -32,7 +32,7 @@ K8S_VERSION="v1.15.6"
 K8S_CNI_VERSION="v0.8.3"
 K8S_CRICTL_VERSION="v1.16.1"
 K8S_FLANNEL_VERSION="v0.11.0"
-K8S_HELM_VERSION="v3.0.0"
+K8S_HELM_VERSION="v3.0.2"
 # The URL to install the cert-manager CRDs uses a different format for the
 # version. If you upgrade cert-manager, you will need to change both variables.
 K8S_CERTMANAGER_VERSION="v0.11.0"


### PR DESCRIPTION
Helm 3.0 has a known bug that sometimes prevents the installation of cert-manager. 

This closes https://github.com/m-lab/k8s-support/issues/309.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/349)
<!-- Reviewable:end -->
