### PR TITLE
Bumps flannel-cloud memory limit from 50Mi to 128Mi to resolve oomkiller issue

### DIFF
--- a/k8s/daemonsets/core/flannel-cloud.jsonnet
+++ b/k8s/daemonsets/core/flannel-cloud.jsonnet
@@ -67,11 +67,11 @@
             resources: {
               limits: {
                 cpu: '100m',
-                memory: '50Mi',
+                memory: '128Mi',
               },
               requests: {
                 cpu: '100m',
-                memory: '50Mi',
+                memory: '128Mi',
               },
             },
             securityContext: {


### PR DESCRIPTION
This same thing was done to flannel-platform a year ago: https://github.com/m-lab/k8s-support/pull/102. This just brings the flannel-cloud DS into parity the platform one to get around this sort of thing:

`kube-flannel-ds-cloud-mwc2z    0/1   CrashLoopBackOff  4441  [...]  prometheus-platform-cluster`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/352)
<!-- Reviewable:end -->
