### PR TITLE
Experiments can only access their own datatypes

### DIFF
--- a/k8s/daemonsets/core/host.jsonnet
+++ b/k8s/daemonsets/core/host.jsonnet
@@ -1,11 +1,12 @@
 local nodeinfoConfig = import '../../../config/nodeinfo.jsonnet';
 
 local exp = import '../templates.jsonnet';
+local expName = 'host';
 
 local nodeinfoconfig = import '../../../config/nodeinfo/config.jsonnet';
 local nodeinfo_datatypes = [d.Datatype for d in nodeinfoconfig];
 
-exp.ExperimentNoIndex('host', 'pusher-' + std.extVar('PROJECT_ID'), "none", nodeinfo_datatypes, true) + {
+exp.ExperimentNoIndex(expName, 'pusher-' + std.extVar('PROJECT_ID'), "none", nodeinfo_datatypes, true) + {
   spec+: {
     template+: {
       spec+: {
@@ -14,7 +15,7 @@ exp.ExperimentNoIndex('host', 'pusher-' + std.extVar('PROJECT_ID'), "none", node
             name: 'nodeinfo',
             image: 'measurementlab/nodeinfo:v1.2',
             args: [
-              '-datadir=/var/spool/host',
+              '-datadir=/var/spool/' + expName,
               '-wait=1h',
               '-prometheusx.listen-address=127.0.0.1:9990',
               '-config=/etc/nodeinfo/config.json',
@@ -25,7 +26,7 @@ exp.ExperimentNoIndex('host', 'pusher-' + std.extVar('PROJECT_ID'), "none", node
                 name: 'nodeinfo-config',
                 readOnly: true,
               },
-              exp.VolumeMount('host'),
+              exp.VolumeMount('', expName),
             ],
           },
           exp.RBACProxy('nodeinfo', 9990),

--- a/k8s/daemonsets/core/host.jsonnet
+++ b/k8s/daemonsets/core/host.jsonnet
@@ -26,7 +26,7 @@ exp.ExperimentNoIndex(expName, 'pusher-' + std.extVar('PROJECT_ID'), "none", nod
                 name: 'nodeinfo-config',
                 readOnly: true,
               },
-              exp.VolumeMount('', expName),
+              exp.VolumeMount(expName),
             ],
           },
           exp.RBACProxy('nodeinfo', 9990),

--- a/k8s/daemonsets/experiments/README.md
+++ b/k8s/daemonsets/experiments/README.md
@@ -1,4 +1,14 @@
+# General
 A configuration file for every experiment deployed on our fleet.
 
 Most experiments will be configured as DaemonSets that only run on nodes where
 `mlab/type=platform`.
+
+# Strict separation between experiment data and sidecar data
+In order to maintain a strict separation between experiment data and sidecar
+data, the experiment container should never mount the base experiment directory
+/cache/data/<experiment>. An experiment should only mount its datatype
+subdirectories of the base directory e.g., /cache/data/<experiment>/ndt5. In
+this way, an experiment does not have visibility of any directory outside of
+it's datatype directories and therefore cannot accidentally (or intentionally)
+modify sidecar data.

--- a/k8s/daemonsets/experiments/ndt.jsonnet
+++ b/k8s/daemonsets/experiments/ndt.jsonnet
@@ -1,6 +1,8 @@
+local datatypes = ['ndt5', 'ndt7'];
 local exp = import '../templates.jsonnet';
+local expName = 'ndt';
 
-exp.Experiment('ndt', 2, 'pusher-' + std.extVar('PROJECT_ID'), "none", ['ndt5', 'ndt7']) + {
+exp.Experiment(expName, 2, 'pusher-' + std.extVar('PROJECT_ID'), "none", datatypes) + {
   spec+: {
     template+: {
       spec+: {
@@ -13,7 +15,7 @@ exp.Experiment('ndt', 2, 'pusher-' + std.extVar('PROJECT_ID'), "none", ['ndt5', 
               '-cert=/certs/cert.pem',
               '-uuid-prefix-file=' + exp.uuid.prefixfile,
               '-prometheusx.listen-address=$(PRIVATE_IP):9990',
-              '-datadir=/var/spool/ndt',
+              '-datadir=/var/spool/' + expName,
             ],
             env: [
               {
@@ -32,7 +34,8 @@ exp.Experiment('ndt', 2, 'pusher-' + std.extVar('PROJECT_ID'), "none", ['ndt5', 
                 readOnly: true,
               },
               exp.uuid.volumemount,
-              exp.VolumeMount('ndt'),
+            ] + [
+              exp.VolumeMount(expName + '/', d) for d in datatypes
             ],
             ports: [
               {
@@ -68,6 +71,8 @@ exp.Experiment('ndt', 2, 'pusher-' + std.extVar('PROJECT_ID'), "none", ['ndt5', 
               secretName: 'ndt-tls',
             },
           },
+        ] + [
+          exp.volume(expName + '/', d) for d in datatypes
         ],
       },
     },

--- a/k8s/daemonsets/experiments/ndt.jsonnet
+++ b/k8s/daemonsets/experiments/ndt.jsonnet
@@ -71,8 +71,6 @@ exp.Experiment(expName, 2, 'pusher-' + std.extVar('PROJECT_ID'), "none", datatyp
               secretName: 'ndt-tls',
             },
           },
-        ] + [
-          exp.volume(expName + '/' + d) for d in datatypes
         ],
       },
     },

--- a/k8s/daemonsets/experiments/ndt.jsonnet
+++ b/k8s/daemonsets/experiments/ndt.jsonnet
@@ -35,7 +35,7 @@ exp.Experiment(expName, 2, 'pusher-' + std.extVar('PROJECT_ID'), "none", datatyp
               },
               exp.uuid.volumemount,
             ] + [
-              exp.VolumeMount(expName + '/', d) for d in datatypes
+              exp.VolumeMount(expName + '/' + d) for d in datatypes
             ],
             ports: [
               {
@@ -72,7 +72,7 @@ exp.Experiment(expName, 2, 'pusher-' + std.extVar('PROJECT_ID'), "none", datatyp
             },
           },
         ] + [
-          exp.volume(expName + '/', d) for d in datatypes
+          exp.volume(expName + '/' + d) for d in datatypes
         ],
       },
     },

--- a/k8s/daemonsets/experiments/ndtcloud.jsonnet
+++ b/k8s/daemonsets/experiments/ndtcloud.jsonnet
@@ -1,7 +1,8 @@
+local datatypes = ['ndt5', 'ndt7'];
 local exp = import '../templates.jsonnet';
 local expName = 'ndtcloud';
 
-exp.ExperimentNoIndex(expName, 'pusher-ndtcloud-' + std.extVar('PROJECT_ID'), "none", ['ndt5', 'ndt7'], true) + {
+exp.ExperimentNoIndex(expName, 'pusher-ndtcloud-' + std.extVar('PROJECT_ID'), "none", datatypes, true) + {
   spec+: {
     template+: {
       spec+: {
@@ -23,7 +24,8 @@ exp.ExperimentNoIndex(expName, 'pusher-ndtcloud-' + std.extVar('PROJECT_ID'), "n
                 readOnly: true,
               },
               exp.uuid.volumemount,
-              exp.VolumeMount(expName),
+            ] + [
+              exp.VolumeMount(expName + '/', d) for d in datatypes
             ],
             ports: [],
           },
@@ -56,6 +58,8 @@ exp.ExperimentNoIndex(expName, 'pusher-ndtcloud-' + std.extVar('PROJECT_ID'), "n
               secretName: 'ndt-tls',
             },
           },
+        ] + [
+          exp.volume(expName + '/', d) for d in datatypes
         ],
         nodeSelector: {
           'mlab/type': 'cloud',

--- a/k8s/daemonsets/experiments/ndtcloud.jsonnet
+++ b/k8s/daemonsets/experiments/ndtcloud.jsonnet
@@ -25,7 +25,7 @@ exp.ExperimentNoIndex(expName, 'pusher-ndtcloud-' + std.extVar('PROJECT_ID'), "n
               },
               exp.uuid.volumemount,
             ] + [
-              exp.VolumeMount(expName + '/', d) for d in datatypes
+              exp.VolumeMount(expName + '/' + d) for d in datatypes
             ],
             ports: [],
           },
@@ -59,7 +59,7 @@ exp.ExperimentNoIndex(expName, 'pusher-ndtcloud-' + std.extVar('PROJECT_ID'), "n
             },
           },
         ] + [
-          exp.volume(expName + '/', d) for d in datatypes
+          exp.volume(expName + '/' + d) for d in datatypes
         ],
         nodeSelector: {
           'mlab/type': 'cloud',

--- a/k8s/daemonsets/experiments/ndtcloud.jsonnet
+++ b/k8s/daemonsets/experiments/ndtcloud.jsonnet
@@ -58,8 +58,6 @@ exp.ExperimentNoIndex(expName, 'pusher-ndtcloud-' + std.extVar('PROJECT_ID'), "n
               secretName: 'ndt-tls',
             },
           },
-        ] + [
-          exp.volume(expName + '/' + d) for d in datatypes
         ],
         nodeSelector: {
           'mlab/type': 'cloud',

--- a/k8s/daemonsets/experiments/neubot.jsonnet
+++ b/k8s/daemonsets/experiments/neubot.jsonnet
@@ -59,8 +59,6 @@ exp.Experiment(expName, 10, 'pusher-' + std.extVar('PROJECT_ID'), "none", dataty
               secretName: 'ndt-tls',
             },
           },
-        ] + [
-          exp.volume(expName + '/' + d) for d in datatypes
         ],
       },
     },

--- a/k8s/daemonsets/experiments/neubot.jsonnet
+++ b/k8s/daemonsets/experiments/neubot.jsonnet
@@ -35,7 +35,7 @@ exp.Experiment(expName, 10, 'pusher-' + std.extVar('PROJECT_ID'), "none", dataty
                 readOnly: true,
               },
             ] + [
-              exp.VolumeMount(expName + '/', d) for d in datatypes
+              exp.VolumeMount(expName + '/' + d) for d in datatypes
             ],
             ports: [
               {
@@ -60,7 +60,7 @@ exp.Experiment(expName, 10, 'pusher-' + std.extVar('PROJECT_ID'), "none", dataty
             },
           },
         ] + [
-          exp.volume(expName + '/', d) for d in datatypes
+          exp.volume(expName + '/' + d) for d in datatypes
         ],
       },
     },

--- a/k8s/daemonsets/experiments/neubot.jsonnet
+++ b/k8s/daemonsets/experiments/neubot.jsonnet
@@ -1,15 +1,17 @@
+local datatypes = ['dash'];
 local exp = import '../templates.jsonnet';
+local expName = 'neubot';
 
-exp.Experiment('neubot', 10, 'pusher-' + std.extVar('PROJECT_ID'), "none", ['dash']) + {
+exp.Experiment(expName, 10, 'pusher-' + std.extVar('PROJECT_ID'), "none", datatypes) + {
   spec+: {
     template+: {
       spec+: {
         containers+: [
             {
-              name: 'neubot',
+              name: expName,
               image: 'measurementlab/neubot-dash:v0.4.0',
             args: [
-              '-datadir=/var/spool/neubot',
+              '-datadir=/var/spool/' + expName,
               '-prometheusx.listen-address=$(PRIVATE_IP):9990',
               '-http-listen-address=:80',
               '-https-listen-address=:443',
@@ -32,7 +34,8 @@ exp.Experiment('neubot', 10, 'pusher-' + std.extVar('PROJECT_ID'), "none", ['das
                 name: 'ndt-tls',
                 readOnly: true,
               },
-              exp.VolumeMount('neubot'),
+            ] + [
+              exp.VolumeMount(expName + '/', d) for d in datatypes
             ],
             ports: [
               {
@@ -56,6 +59,8 @@ exp.Experiment('neubot', 10, 'pusher-' + std.extVar('PROJECT_ID'), "none", ['das
               secretName: 'ndt-tls',
             },
           },
+        ] + [
+          exp.volume(expName + '/', d) for d in datatypes
         ],
       },
     },

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -402,9 +402,6 @@ local Experiment(name, index, bucket, anonMode, datatypes=[]) = ExperimentNoInde
   // need to add one new container.
   Experiment(name, index, bucket, anonMode, datatypes):: Experiment(name, index, bucket, anonMode, datatypes),
 
-  // Returns a volume for a given name/path.
-  volume(name):: volume(name),
-
   // Returns a volumemount for a given datatype. All produced volume mounts
   // in /var/spool/name/
   VolumeMount(name):: VolumeMount(name),

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -340,6 +340,8 @@ local ExperimentNoIndex(name, bucket, anonMode, datatypes, hostNetwork) = {
           uuid.volume,
           volume(name),
           tcpinfoServiceVolume.volume,
+        ] + [
+          volume(name + '/' + d) for d in datatypes
         ],
       },
     },

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -28,17 +28,17 @@ local uuid = {
   },
 };
 
-local volume(path, name) = {
+local volume(name) = {
   hostPath: {
-    path: '/cache/data/' + path + name,
+    path: '/cache/data/' + name,
     type: 'DirectoryOrCreate',
   },
-  name: name + '-data',
+  name: std.strReplace(name, '/', '-') + '-data',
 };
 
-local VolumeMount(path, name) = {
-  mountPath: '/var/spool/' + path + name,
-  name: name + '-data',
+local VolumeMount(name) = {
+  mountPath: '/var/spool/' + name,
+  name: std.strReplace(name, '/', '-') + '-data',
 };
 
 // SOCATProxy creates a tunnel between localhost:<port> and the private pod
@@ -119,7 +119,7 @@ local Tcpinfo(expName, tcpPort, hostNetwork, anonMode) = [
       else
         '-prometheusx.listen-address=$(PRIVATE_IP):' + tcpPort
       ,
-      '-output=' + VolumeMount('', expName).mountPath + '/tcpinfo',
+      '-output=' + VolumeMount(expName).mountPath + '/tcpinfo',
       '-uuid-prefix-file=' + uuid.prefixfile,
       '-tcpinfo.eventsocket=' + tcpinfoServiceVolume.eventsocketFilename,
       '-anonymize.ip=' + anonMode,
@@ -140,7 +140,7 @@ local Tcpinfo(expName, tcpPort, hostNetwork, anonMode) = [
       },
     ],
     volumeMounts: [
-      VolumeMount('', expName),
+      VolumeMount(expName),
       tcpinfoServiceVolume.volumemount,
       uuid.volumemount,
     ],
@@ -160,7 +160,7 @@ local Traceroute(expName, tcpPort, hostNetwork) = [
         '-prometheusx.listen-address=127.0.0.1:' + tcpPort
       else
         '-prometheusx.listen-address=$(PRIVATE_IP):' + tcpPort,
-      '-outputPath=' + VolumeMount('', expName).mountPath + '/traceroute',
+      '-outputPath=' + VolumeMount(expName).mountPath + '/traceroute',
       '-uuid-prefix-file=' + uuid.prefixfile,
       '-poll=false',
       '-tcpinfo.eventsocket=' + tcpinfoServiceVolume.eventsocketFilename,
@@ -182,7 +182,7 @@ local Traceroute(expName, tcpPort, hostNetwork) = [
       },
     ],
     volumeMounts: [
-      VolumeMount('', expName),
+      VolumeMount(expName),
       tcpinfoServiceVolume.volumemount,
       uuid.volumemount,
     ],
@@ -202,7 +202,7 @@ local Pcap(expName, tcpPort, hostNetwork) = [
         '-prometheusx.listen-address=127.0.0.1:' + tcpPort
       else
         '-prometheusx.listen-address=$(PRIVATE_IP):' + tcpPort,
-      '-datadir=' + VolumeMount('', expName).mountPath + '/pcap',
+      '-datadir=' + VolumeMount(expName).mountPath + '/pcap',
       '-tcpinfo.eventsocket=' + tcpinfoServiceVolume.eventsocketFilename,
     ] + if hostNetwork then [
       '-interface=eth0',
@@ -223,7 +223,7 @@ local Pcap(expName, tcpPort, hostNetwork) = [
       },
     ],
     volumeMounts: [
-      VolumeMount('', expName),
+      VolumeMount(expName),
       tcpinfoServiceVolume.volumemount,
       uuid.volumemount,
     ],
@@ -278,7 +278,7 @@ local Pusher(expName, tcpPort, datatypes, hostNetwork, bucket) = [
       },
     ],
     volumeMounts: [
-      VolumeMount('', expName),
+      VolumeMount(expName),
       {
         mountPath: '/etc/credentials',
         name: 'pusher-credentials',
@@ -338,7 +338,7 @@ local ExperimentNoIndex(name, bucket, anonMode, datatypes, hostNetwork) = {
             },
           },
           uuid.volume,
-          volume('', name),
+          volume(name),
           tcpinfoServiceVolume.volume,
         ],
       },
@@ -401,11 +401,11 @@ local Experiment(name, index, bucket, anonMode, datatypes=[]) = ExperimentNoInde
   Experiment(name, index, bucket, anonMode, datatypes):: Experiment(name, index, bucket, anonMode, datatypes),
 
   // Returns a volume for a given name/path.
-  volume(path, name):: volume(path, name),
+  volume(name):: volume(name),
 
   // Returns a volumemount for a given datatype. All produced volume mounts
   // in /var/spool/name/
-  VolumeMount(path, name):: VolumeMount(path, name),
+  VolumeMount(name):: VolumeMount(name),
 
   // Returns a "container" configuration for pusher that will upload the named experiment datatypes.
   // Users MUST declare a "pusher-credentials" volume as part of the deployment.


### PR DESCRIPTION
This PR is intended to resolve issue #99, in which experiment containers should not be able to see or access or modify sidecar data. This is achieved in this PR by making sure that experiment containers never mount the base experiment directory (e.g., /cache/data/ndt), but instead only mount their datatype subdirectories of that directory. What this means is that, as configured in this PR, sidecar containers have full visibility of `/cache/data/<experiment>`, but experiment containers can only see `/cache/data/experiment/<datatypes>`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/353)
<!-- Reviewable:end -->
