### PR TITLE
Drop socat proxy metrics

### DIFF
--- a/config/prometheus/prometheus.yml
+++ b/config/prometheus/prometheus.yml
@@ -100,6 +100,14 @@ scrape_configs:
         regex: https
         action: drop
 
+      # socat proxy enables easy access to pprof targets but accidentally
+      # duplicates metric collection. The annotation mechanism applies at the pod
+      # level not at individual containers. So, this rule drops metrics with
+      # socat containers.
+      - source_labels: [__meta_kubernetes_pod_container_name]
+        regex: socat-.*
+        action: drop
+
       # For inventory, record whether a pod is ready. This helps distinguish
       # between: missing from inventory, not ready and failing, ready but
       # failing, ready and working.


### PR DESCRIPTION
When enabling socat on most core services, this accidentally allowed collecting metrics twice. The socat metrics should be dropped.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/361)
<!-- Reviewable:end -->
