### PR TITLE
Remove the kubernetes-metadata filter

### DIFF
--- a/config/fluentd/kubernetes.conf
+++ b/config/fluentd/kubernetes.conf
@@ -14,20 +14,3 @@
     time_format %Y-%m-%dT%H:%M:%S.%NZ
   </parse>
 </source>
-
-<source>
-  @type tail
-  @id in_tail_docker
-  path /var/log/docker.log
-  pos_file /var/log/fluentd-docker.log.pos
-  tag docker
-  <parse>
-    @type regexp
-    expression /^time="(?<time>[^)]*)" level=(?<severity>[^ ]*) msg="(?<message>[^"]*)"( err="(?<error>[^"]*)")?( statusCode=($<status_code>\d+))?/
-  </parse>
-</source>
-
-<filter kubernetes.**>
-  @type kubernetes_metadata
-  @id filter_kube_metadata
-</filter>


### PR DESCRIPTION
This apparently overloads the kubernetes-apiserver and/or etcd to the point it cannot serve other requests anymore *and* it makes the kernel repeatedly OOMKill fluentd after a minute or so.

Also, /var/log/docker.log is not written to disk on our nodes, so the corresponding configuration did not do much.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/363)
<!-- Reviewable:end -->
