### PR TITLE
Removes port 9090 from the Prometheus firewall rule

### DIFF
--- a/manage-cluster/bootstrap_prometheus.sh
+++ b/manage-cluster/bootstrap_prometheus.sh
@@ -150,12 +150,11 @@ fi
 
 # Create a firewall rule allowing external access to ports:
 #   TCP 22: SSH
-#   TCP 9090: k8s API server
 #   TCP 80/443: nginx-ingress
 gcloud compute firewall-rules create "${PROM_BASE_NAME}-external" \
     --network "${GCE_NETWORK}" \
     --action "allow" \
-    --rules "tcp:22,tcp:9090,tcp:80,tcp:443" \
+    --rules "tcp:22,tcp:80,tcp:443" \
     --source-ranges "0.0.0.0/0" \
     --target-tags "${PROM_BASE_NAME}" \
     "${GCP_ARGS[@]}"


### PR DESCRIPTION
All access should now be through the nginx-ingress on port 443.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/366)
<!-- Reviewable:end -->
