### PR TITLE
Name k8s container after the docker image & Update neubot image

### DIFF
--- a/k8s/daemonsets/core/utilization.jsonnet
+++ b/k8s/daemonsets/core/utilization.jsonnet
@@ -26,7 +26,7 @@ local exp = import '../templates.jsonnet';
       spec: {
         containers: [
           {
-            name: 'collectd',
+            name: 'utility-support',
             image: 'measurementlab/utility-support:v2.0.8',
             env: [
               {

--- a/k8s/daemonsets/experiments/neubot.jsonnet
+++ b/k8s/daemonsets/experiments/neubot.jsonnet
@@ -9,7 +9,7 @@ exp.Experiment(expName, 10, 'pusher-' + std.extVar('PROJECT_ID'), "none", dataty
         containers+: [
             {
               name: expName,
-              image: 'measurementlab/neubot-dash:v0.4.0',
+              image: 'measurementlab/neubot:v0.4.1',
             args: [
               '-datadir=/var/spool/' + expName,
               '-prometheusx.listen-address=$(PRIVATE_IP):9990',

--- a/k8s/daemonsets/experiments/neubot.jsonnet
+++ b/k8s/daemonsets/experiments/neubot.jsonnet
@@ -8,8 +8,8 @@ exp.Experiment(expName, 10, 'pusher-' + std.extVar('PROJECT_ID'), "none", dataty
       spec+: {
         containers+: [
             {
-              name: expName,
-              image: 'measurementlab/neubot:v0.4.1',
+              name: 'dash',
+              image: 'measurementlab/dash:v0.4.1',
             args: [
               '-datadir=/var/spool/' + expName,
               '-prometheusx.listen-address=$(PRIVATE_IP):9990',

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -111,7 +111,7 @@ local tcpinfoServiceVolume = {
 
 local Tcpinfo(expName, tcpPort, hostNetwork, anonMode) = [
   {
-    name: 'tcpinfo',
+    name: 'tcp-info',
     image: 'measurementlab/tcp-info:v1.4.0',
     args: [
       if hostNetwork then
@@ -153,7 +153,7 @@ local Tcpinfo(expName, tcpPort, hostNetwork, anonMode) = [
 
 local Traceroute(expName, tcpPort, hostNetwork) = [
   {
-    name: 'traceroute',
+    name: 'traceroute-caller',
     image: 'measurementlab/traceroute-caller:v0.6.0',
     args: [
       if hostNetwork then
@@ -195,7 +195,7 @@ local Traceroute(expName, tcpPort, hostNetwork) = [
 
 local Pcap(expName, tcpPort, hostNetwork) = [
   {
-    name: 'pcap',
+    name: 'packet-headers',
     image: 'measurementlab/packet-headers:v0.5.4',
     args: [
       if hostNetwork then


### PR DESCRIPTION
Conversationally, we've adopted a convention to allow any names for docker images b/c those should be derived from git repos which we won't be able to control from third-parties. We've agreed on the form of datatype names from the Uniform Naming convention.

We have had an ad-hoc convention for naming the k8s container. Typically this appears as the `container=` label in prometheus metrics.

Recently, I was trying to find the packet-header metrics from the last month and didn't realize that 'pcap' was the actual container name. I think that is confusing (I named it that originally). This change implements that convention for all experiments.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/367)
<!-- Reviewable:end -->
