### PR TITLE
Only deploy uuid-annotator to sandbox and staging for now

### DIFF
--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -381,7 +381,9 @@ local ExperimentNoIndex(name, bucket, anonMode, datatypes, hostNetwork) = {
             if anonMode == "none" then
               Traceroute(name, 9992, hostNetwork) else [],
             Pcap(name, 9993, hostNetwork),
-            UUIDAnnotator(name, 9994, hostNetwork),
+            if std.extVar('PROJECT_ID') != 'mlab-oti' then
+              UUIDAnnotator(name, 9994, hostNetwork)
+            else [],
             Pusher(name, 9995, allDatatypes, hostNetwork, bucket),
           ]),
         [if hostNetwork then 'serviceAccountName']: 'kube-rbac-proxy',


### PR DESCRIPTION
This PR wraps the `UUIDAnnotator()` container in a conditional such that it should only deploy to sandbox and staging. This will allow us to continue merging PRs to master and deploying to production until that service is deemed ready for production.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/375)
<!-- Reviewable:end -->
