### PR TITLE
Updates Prometheus image from v2.14.0 to v2.16.0

### DIFF
--- a/k8s/deployments/prometheus.jsonnet
+++ b/k8s/deployments/prometheus.jsonnet
@@ -39,7 +39,7 @@ local prometheusConfig = import '../../config/prometheus.jsonnet';
               '--web.enable-lifecycle',
               '--storage.tsdb.retention.time=2880h',
             ],
-            image: 'prom/prometheus:v2.14.0',
+            image: 'prom/prometheus:v2.16.0',
             name: 'prometheus',
             ports: [
               {


### PR DESCRIPTION
While always good to not fall too far behind stable releases, the main impetus for this upgrade of Prometheus is to pull in TSDB enhancements (from 2.15.0) which may help improve startup times. The hope is that this may help to slightly improve the issue outlined here m-lab/k8s-support/issues/371.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/377)
<!-- Reviewable:end -->
