### PR TITLE
Bumps disk size from 500GB to 1000GB for prometheus in staging.

### DIFF
--- a/manage-cluster/bootstrap_prometheus.sh
+++ b/manage-cluster/bootstrap_prometheus.sh
@@ -42,7 +42,7 @@ case $PROJECT in
     ;;
   mlab-staging)
     MACHINE_TYPE="n1-standard-8"
-    DISK_SIZE="500GB"
+    DISK_SIZE="1000GB"
     ;;
   mlab-oti)
     MACHINE_TYPE="n1-highmem-16"


### PR DESCRIPTION
The disk started running out late last week, and usage was steadily increasing. Seems that we just needed a bigger disk in staging. @robertodauria has already increased the size of the disk on the instance in staging.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/379)
<!-- Reviewable:end -->
