### PR TITLE
Changes max threshold for a node to boot and still get a k8s token.

### DIFF
--- a/manage-cluster/token_server/main.go
+++ b/manage-cluster/token_server/main.go
@@ -110,8 +110,8 @@ func allocateTokenHandler(w http.ResponseWriter, r *http.Request) {
 		// Write no response.
 		return
 	}
-	if time.Now().UTC().Sub(ext.V1.LastBoot) > 15*time.Minute {
-		// According to ePoxy the machine booted over 15 minutes ago,
+	if time.Now().UTC().Sub(ext.V1.LastBoot) > 120*time.Minute {
+		// According to ePoxy the machine booted over 2 hours ago,
 		// which is longer than we're willing to support.
 		w.WriteHeader(http.StatusRequestTimeout)
 		// Write no response.

--- a/manage-cluster/token_server/main_test.go
+++ b/manage-cluster/token_server/main_test.go
@@ -74,7 +74,7 @@ func Test_allocateTokenHandler(t *testing.T) {
 			v1: &extension.V1{
 				Hostname:    "mlab1.foo01.measurement-lab.org",
 				IPv4Address: "192.168.1.1",
-				LastBoot:    time.Now().UTC().Add(-16 * time.Minute),
+				LastBoot:    time.Now().UTC().Add(-125 * time.Minute),
 			},
 			status: http.StatusRequestTimeout,
 		},


### PR DESCRIPTION
Was 15m, and will now be 120m (2h).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/382)
<!-- Reviewable:end -->
