### PR TITLE
Add dmesg_exporter DS to export count of kernel log messages

### DIFF
--- a/k8s/daemonsets/core/dmesg-exporter.jsonnet
+++ b/k8s/daemonsets/core/dmesg-exporter.jsonnet
@@ -25,7 +25,7 @@
           {
             args: [
               'start',
-              '--address=${PRIVATE_IP}:9900',
+              '--address=$(PRIVATE_IP):9900',
               '--path=/metrics',
             ],
             image: 'cirocosta/dmesg_exporter',

--- a/k8s/daemonsets/core/dmesg-exporter.jsonnet
+++ b/k8s/daemonsets/core/dmesg-exporter.jsonnet
@@ -25,11 +25,21 @@
           {
             args: [
               'start',
-              '--address=127.0.0.1:9900',
+              '--address=${PRIVATE_IP}:9900',
               '--path=/metrics',
             ],
             image: 'cirocosta/dmesg_exporter',
             name: 'dmesg-exporter',
+            env: [
+              {
+                name: 'PRIVATE_IP',
+                valueFrom: {
+                  fieldRef: {
+                    fieldPath: 'status.podIP',
+                  },
+                },
+              },
+            ],
             ports: [
               {
                 containerPort: 9900,
@@ -53,6 +63,11 @@
                 readOnly: true,
               },
             ],
+            // This exporter needs to access /dev/kmsg on the host, which
+            // requires it to be privileged.
+            securityContext: {
+              privileged: true,
+            },
           },
         ],
         volumes: [

--- a/k8s/daemonsets/core/dmesg-exporter.jsonnet
+++ b/k8s/daemonsets/core/dmesg-exporter.jsonnet
@@ -49,10 +49,18 @@
             volumeMounts: [
               {
                 mountPath: '/dev/kmsg',
-                name: 'proc',
+                name: 'kmsg',
                 readOnly: true,
               },
             ],
+          },
+        ],
+        volumes: [
+          {
+            name: 'kmsg',
+            hostPath: {
+              path: '/dev/kmsg',
+            },
           },
         ],
       },

--- a/k8s/daemonsets/core/dmesg-exporter.jsonnet
+++ b/k8s/daemonsets/core/dmesg-exporter.jsonnet
@@ -28,7 +28,7 @@
               '--address=$(PRIVATE_IP):9900',
               '--path=/metrics',
             ],
-            image: 'cirocosta/dmesg_exporter',
+            image: 'cirocosta/dmesg_exporter:0.0.1',
             name: 'dmesg-exporter',
             env: [
               {

--- a/k8s/daemonsets/core/dmesg-exporter.jsonnet
+++ b/k8s/daemonsets/core/dmesg-exporter.jsonnet
@@ -1,0 +1,61 @@
+{
+  apiVersion: 'apps/v1',
+  kind: 'DaemonSet',
+  metadata: {
+    name: 'dmesg-exporter',
+  },
+  spec: {
+    selector: {
+      matchLabels: {
+        workload: 'dmesg-exporter',
+      },
+    },
+    template: {
+      metadata: {
+        annotations: {
+          'prometheus.io/scrape': 'true',
+          'prometheus.io/scheme': 'http',
+        },
+        labels: {
+          workload: 'dmesg-exporter',
+        },
+      },
+      spec: {
+        containers: [
+          {
+            args: [
+              'start',
+              '--address=127.0.0.1:9900',
+              '--path=/metrics',
+            ],
+            image: 'cirocosta/dmesg_exporter',
+            name: 'dmesg-exporter',
+            ports: [
+              {
+                containerPort: 9900,
+                name: 'prometheus',
+              },
+            ],
+            resources: {
+              limits: {
+                cpu: '100m',
+                memory: '100Mi',
+              },
+              requests: {
+                cpu: '50m',
+                memory: '50Mi',
+              },
+            },
+            volumeMounts: [
+              {
+                mountPath: '/dev/kmsg',
+                name: 'proc',
+                readOnly: true,
+              },
+            ],
+          },
+        ],
+      },
+    },
+  },
+}

--- a/system.jsonnet
+++ b/system.jsonnet
@@ -12,6 +12,7 @@
     import 'k8s/custom-resource-definitions/network-attachment-definition.jsonnet',
     // Daemonsets
     import 'k8s/daemonsets/core/cadvisor.jsonnet',
+    import 'k8s/daemonsets/core/dmesg-exporter.jsonnet',
     import 'k8s/daemonsets/core/flannel-cloud.jsonnet',
     import 'k8s/daemonsets/core/flannel-platform.jsonnet',
     import 'k8s/daemonsets/core/fluentd.jsonnet',


### PR DESCRIPTION
This PR adds a [dmesg_exporter](https://github.com/cirocosta/dmesg_exporter) DaemonSet which exports counters for the kernel logs. E.g.

```
dmesg_logs{facility="daemon",priority="info"} 10
dmesg_logs{facility="kern",priority="debug"} 69
dmesg_logs{facility="kern",priority="err"} 4
dmesg_logs{facility="kern",priority="info"} 380
dmesg_logs{facility="kern",priority="notice"} 47
dmesg_logs{facility="kern",priority="warning"} 38
dmesg_logs{facility="syslog",priority="info"} 1
dmesg_logs{facility="user",priority="warning"} 4
```

The values of the `facility` and `priority` labels are as follows (from dmesg's help):
```
Supported log facilities:
    kern - kernel messages
    user - random user-level messages
    mail - mail system
  daemon - system daemons
    auth - security/authorization messages
  syslog - messages generated internally by syslogd
     lpr - line printer subsystem
    news - network news subsystem

Supported log levels (priorities):
   emerg - system is unusable
   alert - action must be taken immediately
    crit - critical conditions
     err - error conditions
    warn - warning conditions
  notice - normal but significant condition
    info - informational
   debug - debug-level messages
```

Please note that this pod needs to run with `privileged: true` to be able to access `/dev/kmsg` on the host.

Closes https://github.com/m-lab/k8s-support/issues/380.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/384)
<!-- Reviewable:end -->
