### PR TITLE
Update ndt-server version and max 1g rate

### DIFF
--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -1,4 +1,4 @@
-local ndtVersion = 'v0.14.1';
+local ndtVersion = 'v0.14.2';
 local PROJECT_ID = std.extVar('PROJECT_ID');
 
 local uuid = {

--- a/manage-cluster/k8s_deploy.conf
+++ b/manage-cluster/k8s_deploy.conf
@@ -78,12 +78,12 @@ GCS_BUCKET_SITEINFO_mlab_oti="siteinfo-mlab-oti"
 REBOOT_DAYS=(Tue Wed Thu)
 
 # Configurations for setting the --max-rate flag in ndt-server.  For 1g sites
-# we are starting with a conservative value of 40% of the uplink, as this will
+# we are starting with a conservative value of 25% of the uplink, as this will
 # be applied per-node. For 10g sites we use a more liberal value of 80%. The
 # values are in bits.
 MAX_RATES_DIR="nodes-max-rate"
 MAX_RATES_CONFIGMAP="nodes-max-rate"
-MAX_RATE_1G="400000000"
+MAX_RATE_1G="250000000"
 MAX_RATE_10G="8000000000"
 
 # Whether the script should exit after deleting all existing GCP resources


### PR DESCRIPTION
This change incorporates changes to the ndt-server txcontroller with the latest version. In particular, version v0.14.2 will apply the txcontroller to the plain ndt5 control port, thereby applying the limit to "raw" clients as well as json, wss, and ndt7 clients.

As well, this change reduces the 1G max rate setting to 250Mbps based on experience with yyz02 so far.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/385)
<!-- Reviewable:end -->
