### PR TITLE
Add SOCAT proxy for ndt-server

### DIFF
--- a/k8s/daemonsets/experiments/ndt.jsonnet
+++ b/k8s/daemonsets/experiments/ndt.jsonnet
@@ -68,6 +68,8 @@ exp.Experiment(expName, 2, 'pusher-' + std.extVar('PROJECT_ID'), "none", datatyp
             ],
 
           },
+        ] + [
+          exp.SOCATProxy('ndt-server', 9990)
         ],
         // The default grace period after k8s sends SIGTERM is 30s. We
         // extend the grace period to give time for the following


### PR DESCRIPTION
Currently SOCAT Proxy is deployed automatically for all core services that run as side-cars with experiments. This change adds the SOCAT proxy to the ndt-server as well. This change will help investigate memory usage spikes in the NDT server in response to bursts of client connections. We think the memory used is disproportionate to what should be required.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/388)
<!-- Reviewable:end -->
