### PR TITLE
deploy uuid annotator to prod

### DIFF
--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -302,7 +302,7 @@ local Pusher(expName, tcpPort, datatypes, hostNetwork, bucket) = [
 local UUIDAnnotator(expName, tcpPort, hostNetwork) = [
   {
     name: 'uuid-annotator',
-    image: 'measurementlab/uuid-annotator:v0.2.0',
+    image: 'measurementlab/uuid-annotator:v0.3.0',
     args: [
       if hostNetwork then
         '-prometheusx.listen-address=127.0.0.1:' + tcpPort


### PR DESCRIPTION
https://github.com/m-lab/uuid-annotator/releases/tag/v0.3.0

"Current" dir for downloader bucket:

https://pantheon.corp.google.com/storage/browser/downloader-mlab-oti/Maxmind/current?forceOnBucketsSortingFiltering=false&organizationId=433637338589&project=mlab-oti

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/389)
<!-- Reviewable:end -->
