### PR TITLE
Bumps token-server image to v2.9.0, which should bring in the changes from #382

### DIFF
--- a/manage-cluster/cloud-config_master.yml
+++ b/manage-cluster/cloud-config_master.yml
@@ -44,7 +44,7 @@ coreos:
                                       --volume /etc:/etc:ro \
                                       --volume /:/ro:ro \
                                       --name %N -- \
-                                      measurementlab/k8s-token-server:v0.0 \
+                                      measurementlab/k8s-token-server:v2.9.0 \
                                       -command /ro/opt/bin/kubeadm
         ExecStop=/usr/bin/docker stop %N
 


### PR DESCRIPTION
https://hub.docker.com/layers/measurementlab/k8s-token-server/v2.9.0/images/sha256-b3a99b531e163d9d967a2e71ff83c289089548e6364f8707c022caac197d28c3?context=repo

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/390)
<!-- Reviewable:end -->
