### PR TITLE
Use project builder images for gcloud+jsonnet

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,28 +1,21 @@
 steps:
-
-# Create the image builder for later steps.
-- name: gcr.io/cloud-builders/docker
+# Create the configs
+- name: gcr.io/$PROJECT_ID/gcloud-jsonnet-cbif
+  dir: '/workspace/manage-cluster'
   args: [
-    'build', '-t', 'k8s_support_builder', '-f',
-    '/workspace/manage-cluster/Dockerfile.k8s_support_builder', '/workspace/'
+    '/workspace/manage-cluster/create_k8s_configs.sh $PROJECT_ID'
   ]
 
-# Create the configs
-- name: k8s_support_builder
-  dir: '/workspace/manage-cluster'
-  entrypoint: '/workspace/manage-cluster/create_k8s_configs.sh'
-  args:
-  - $PROJECT_ID
-
 # Fetch the KUBECONFIG file from GCS.
-- name: gcr.io/cloud-builders/gsutil
+- name: gcr.io/$PROJECT_ID/gcloud-jsonnet-cbif
   dir: '/workspace/manage-cluster'
-  args: ['cp', 'gs://k8s-support-$PROJECT_ID/admin.conf', '/workspace/admin.conf' ]
+  args: [
+    'gsutil cp gs://k8s-support-$PROJECT_ID/admin.conf /workspace/admin.conf'
+  ]
 
 # Push the configs.
-- name: 'gcr.io/cloud-builders/kubectl'
+- name: gcr.io/$PROJECT_ID/gcloud-jsonnet-cbif
   dir: '/workspace/manage-cluster'
-  entrypoint: '/workspace/manage-cluster/apply_k8s_configs.sh'
-  args:
-  - $PROJECT_ID
-  - /workspace/admin.conf
+  args: [
+    '/workspace/manage-cluster/apply_k8s_configs.sh $PROJECT_ID /workspace/admin.conf'
+  ]

--- a/manage-cluster/Dockerfile.k8s_support_builder
+++ b/manage-cluster/Dockerfile.k8s_support_builder
@@ -1,8 +1,0 @@
-FROM golang:1.12 as jsonnet-builder
-ENV CGO_ENABLED=0
-RUN go get github.com/google/go-jsonnet/cmd/jsonnet
-
-FROM gcr.io/cloud-builders/gsutil
-COPY --from=jsonnet-builder /go/bin/jsonnet /bin
-RUN yes | /builder/google-cloud-sdk/bin/gcloud components install kubectl
-RUN apt-get -y update && apt-get -y install jq

--- a/manage-cluster/create_k8s_configs.sh
+++ b/manage-cluster/create_k8s_configs.sh
@@ -29,6 +29,7 @@ GCS_BUCKET_SITEINFO="GCS_BUCKET_SITEINFO_${PROJECT//-/_}"
 # This is a roundabout way of informing a container about the uplink capacity.
 curl --silent --output switches.json "https://siteinfo.mlab-oti.measurementlab.net/v1/sites/switches.json"
 mkdir -p "${MAX_RATES_DIR}"
+which jq &> /dev/null # Check that command exists.
 for r in $(jq -r 'keys[] as $k | "\($k):\(.[$k].uplink_speed)"' switches.json); do
   site=$(echo $r | cut -d: -f1)
   speed=$(echo $r | cut -d: -f2)


### PR DESCRIPTION
This change uses the gcp-config generated project builder images that combine gcloud+jsonnet in favor of a locally built image. The net result should be faster deploy times.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/395)
<!-- Reviewable:end -->
