### PR TITLE
Reduce 1g Tx Controller rate limit

### DIFF
--- a/manage-cluster/k8s_deploy.conf
+++ b/manage-cluster/k8s_deploy.conf
@@ -85,7 +85,7 @@ REBOOT_DAYS=(Tue Wed Thu)
 # values are in bits.
 MAX_RATES_DIR="nodes-max-rate"
 MAX_RATES_CONFIGMAP="nodes-max-rate"
-MAX_RATE_1G="250000000"
+MAX_RATE_1G="150000000"
 MAX_RATE_10G="8000000000"
 
 # Whether the script should exit after deleting all existing GCP resources


### PR DESCRIPTION
Based on recent observations, we've realized that tx controller limits should be 1/3 of 40% uplink capacity for 1G sites. This change reduces the limit to 150Mbps.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/396)
<!-- Reviewable:end -->
