### PR TITLE
Wraps dnsNames conditional in parentheses

### DIFF
--- a/k8s/certificates/measurement-lab.org.jsonnet
+++ b/k8s/certificates/measurement-lab.org.jsonnet
@@ -6,10 +6,10 @@
     namespace: 'default',
   },
   spec: {
-    dnsNames: if std.extVar('PROJECT_ID') == 'mlab-oti' then [
-      '*.measurement-lab.org',
-    ] else [] + [
-      '*.' + std.extVar('PROJECT_ID') + '.measurement-lab.org',
+    dnsNames: (if std.extVar('PROJECT_ID') == 'mlab-oti' then [
+      '*.measurement-lab.org'
+    ] else []) + [
+      '*.' + std.extVar('PROJECT_ID') + '.measurement-lab.org'
     ],
     issuerRef: {
       group: 'cert-manager.io',

--- a/k8s/certificates/measurement-lab.org.jsonnet
+++ b/k8s/certificates/measurement-lab.org.jsonnet
@@ -7,9 +7,9 @@
   },
   spec: {
     dnsNames: (if std.extVar('PROJECT_ID') == 'mlab-oti' then [
-      '*.measurement-lab.org'
+      '*.measurement-lab.org',
     ] else []) + [
-      '*.' + std.extVar('PROJECT_ID') + '.measurement-lab.org'
+      '*.' + std.extVar('PROJECT_ID') + '.measurement-lab.org',
     ],
     issuerRef: {
       group: 'cert-manager.io',


### PR DESCRIPTION
Without the parentheses, in project mlab-oti only the first array element is included, and the one for the project-subdomain is ignored.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/398)
<!-- Reviewable:end -->
