### PR TITLE
Returns to using the cert-manager/LetsEncrypt TLS certs for all experiments

### DIFF
--- a/k8s/daemonsets/experiments/ndt.jsonnet
+++ b/k8s/daemonsets/experiments/ndt.jsonnet
@@ -21,8 +21,8 @@ exp.Experiment(expName, 2, 'pusher-' + std.extVar('PROJECT_ID'), "none", datatyp
               "--",
             ],
             args: [
-              '-key=/certs/key.pem',
-              '-cert=/certs/cert.pem',
+              '-key=/certs/tls.key',
+              '-cert=/certs/tls.crt',
               '-uuid-prefix-file=' + exp.uuid.prefixfile,
               '-prometheusx.listen-address=$(PRIVATE_IP):9990',
               '-datadir=/var/spool/' + expName,
@@ -94,7 +94,7 @@ exp.Experiment(expName, 2, 'pusher-' + std.extVar('PROJECT_ID'), "none", datatyp
           {
             name: 'measurement-lab-org-tls',
             secret: {
-              secretName: 'ndt-tls',
+              secretName: 'measurement-lab-org-tls',
             },
           },
           {

--- a/k8s/daemonsets/experiments/ndtcloud.jsonnet
+++ b/k8s/daemonsets/experiments/ndtcloud.jsonnet
@@ -11,8 +11,8 @@ exp.ExperimentNoIndex(expName, 'pusher-ndtcloud-' + std.extVar('PROJECT_ID'), "n
             name: 'ndt-server',
             image: 'measurementlab/ndt-server:' + exp.ndtVersion,
             args: [
-              '-key=/certs/key.pem',
-              '-cert=/certs/cert.pem',
+              '-key=/certs/tls.key',
+              '-cert=/certs/tls.crt',
               '-uuid-prefix-file=' + exp.uuid.prefixfile,
               '-prometheusx.listen-address=127.0.0.1:9990',
               '-datadir=/var/spool/' + expName,
@@ -55,7 +55,7 @@ exp.ExperimentNoIndex(expName, 'pusher-ndtcloud-' + std.extVar('PROJECT_ID'), "n
           {
             name: 'measurement-lab-org-tls',
             secret: {
-              secretName: 'ndt-tls',
+              secretName: 'measurement-lab-org-tls',
             },
           },
         ],

--- a/k8s/daemonsets/experiments/neubot.jsonnet
+++ b/k8s/daemonsets/experiments/neubot.jsonnet
@@ -15,8 +15,8 @@ exp.Experiment(expName, 10, 'pusher-' + std.extVar('PROJECT_ID'), "none", dataty
               '-prometheusx.listen-address=$(PRIVATE_IP):9990',
               '-http-listen-address=:80',
               '-https-listen-address=:443',
-              '-tls-cert=/certs/cert.pem',
-              '-tls-key=/certs/key.pem',
+              '-tls-cert=/certs/tls.crt',
+              '-tls-key=/certs/tls.key',
             ],
             env: [
               {
@@ -57,7 +57,7 @@ exp.Experiment(expName, 10, 'pusher-' + std.extVar('PROJECT_ID'), "none", dataty
           {
             name: 'measurement-lab-org-tls',
             secret: {
-              secretName: 'ndt-tls',
+              secretName: 'measurement-lab-org-tls',
             },
           },
         ],


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/402)
<!-- Reviewable:end -->
