### PR TITLE
Conditionally use LetsEncrypt cert in sandbox and staging only

### DIFF
--- a/k8s/daemonsets/experiments/ndt.jsonnet
+++ b/k8s/daemonsets/experiments/ndt.jsonnet
@@ -20,17 +20,17 @@ exp.Experiment(expName, 2, 'pusher-' + std.extVar('PROJECT_ID'), "none", datatyp
               "n=$(NODE_NAME); m=$(cat /etc/" + std.extVar('MAX_RATES_CONFIGMAP') + "/$n); /ndt-server -txcontroller.max-rate=$m $@",
               "--",
             ],
-            args: if std.extVar('PROJECT_ID') != 'mlab-oti' then [
+            args: [
+              '-uuid-prefix-file=' + exp.uuid.prefixfile,
+              '-prometheusx.listen-address=$(PRIVATE_IP):9990',
+              '-datadir=/var/spool/' + expName,
+              '-txcontroller.device=net1',
+            ] + if std.extVar('PROJECT_ID') != 'mlab-oti' then [
               '-key=/certs/tls.key',
               '-cert=/certs/tls.crt',
             ] else [
               '-key=/certs/key.pem',
               '-cert=/certs/cert.pem',
-            ] + [
-              '-uuid-prefix-file=' + exp.uuid.prefixfile,
-              '-prometheusx.listen-address=$(PRIVATE_IP):9990',
-              '-datadir=/var/spool/' + expName,
-              '-txcontroller.device=net1',
             ],
             env: [
               {

--- a/k8s/daemonsets/experiments/ndt.jsonnet
+++ b/k8s/daemonsets/experiments/ndt.jsonnet
@@ -20,9 +20,13 @@ exp.Experiment(expName, 2, 'pusher-' + std.extVar('PROJECT_ID'), "none", datatyp
               "n=$(NODE_NAME); m=$(cat /etc/" + std.extVar('MAX_RATES_CONFIGMAP') + "/$n); /ndt-server -txcontroller.max-rate=$m $@",
               "--",
             ],
-            args: [
+            args: if std.extVar('PROJECT_ID') != 'mlab-oti' then [
               '-key=/certs/tls.key',
               '-cert=/certs/tls.crt',
+            ] else [
+              '-key=/certs/key.pem',
+              '-cert=/certs/cert.pem',
+            ] + [
               '-uuid-prefix-file=' + exp.uuid.prefixfile,
               '-prometheusx.listen-address=$(PRIVATE_IP):9990',
               '-datadir=/var/spool/' + expName,
@@ -94,7 +98,10 @@ exp.Experiment(expName, 2, 'pusher-' + std.extVar('PROJECT_ID'), "none", datatyp
           {
             name: 'measurement-lab-org-tls',
             secret: {
-              secretName: 'measurement-lab-org-tls',
+              secretName: if std.extVar('PROJECT_ID') != 'mlab-oti' then
+                'measurement-lab-org-tls'
+              else
+                'ndt-tls',
             },
           },
           {

--- a/k8s/daemonsets/experiments/ndtcloud.jsonnet
+++ b/k8s/daemonsets/experiments/ndtcloud.jsonnet
@@ -10,16 +10,16 @@ exp.ExperimentNoIndex(expName, 'pusher-ndtcloud-' + std.extVar('PROJECT_ID'), "n
           {
             name: 'ndt-server',
             image: 'measurementlab/ndt-server:' + exp.ndtVersion,
-            args: if std.extVar('PROJECT_ID') != 'mlab-oti' then [
+            args: [
+              '-uuid-prefix-file=' + exp.uuid.prefixfile,
+              '-prometheusx.listen-address=127.0.0.1:9990',
+              '-datadir=/var/spool/' + expName,
+            ] + if std.extVar('PROJECT_ID') != 'mlab-oti' then [
               '-key=/certs/tls.key',
               '-cert=/certs/tls.crt',
             ] else [
               '-key=/certs/key.pem',
               '-cert=/certs/cert.pem',
-            ] + [
-              '-uuid-prefix-file=' + exp.uuid.prefixfile,
-              '-prometheusx.listen-address=127.0.0.1:9990',
-              '-datadir=/var/spool/' + expName,
             ],
             volumeMounts: [
               {

--- a/k8s/daemonsets/experiments/ndtcloud.jsonnet
+++ b/k8s/daemonsets/experiments/ndtcloud.jsonnet
@@ -10,9 +10,13 @@ exp.ExperimentNoIndex(expName, 'pusher-ndtcloud-' + std.extVar('PROJECT_ID'), "n
           {
             name: 'ndt-server',
             image: 'measurementlab/ndt-server:' + exp.ndtVersion,
-            args: [
+            args: if std.extVar('PROJECT_ID') != 'mlab-oti' then [
               '-key=/certs/tls.key',
               '-cert=/certs/tls.crt',
+            ] else [
+              '-key=/certs/key.pem',
+              '-cert=/certs/cert.pem',
+            ] + [
               '-uuid-prefix-file=' + exp.uuid.prefixfile,
               '-prometheusx.listen-address=127.0.0.1:9990',
               '-datadir=/var/spool/' + expName,
@@ -55,7 +59,10 @@ exp.ExperimentNoIndex(expName, 'pusher-ndtcloud-' + std.extVar('PROJECT_ID'), "n
           {
             name: 'measurement-lab-org-tls',
             secret: {
-              secretName: 'measurement-lab-org-tls',
+              secretName: if std.extVar('PROJECT_ID') != 'mlab-oti' then
+                'measurement-lab-org-tls'
+              else
+                'ndt-tls',
             },
           },
         ],

--- a/k8s/daemonsets/experiments/neubot.jsonnet
+++ b/k8s/daemonsets/experiments/neubot.jsonnet
@@ -15,8 +15,12 @@ exp.Experiment(expName, 10, 'pusher-' + std.extVar('PROJECT_ID'), "none", dataty
               '-prometheusx.listen-address=$(PRIVATE_IP):9990',
               '-http-listen-address=:80',
               '-https-listen-address=:443',
+            ] + if std.extVar('PROJECT_ID') != 'mlab-oti' then [
               '-tls-cert=/certs/tls.crt',
               '-tls-key=/certs/tls.key',
+            ] else [
+              '-tls-cert=/certs/cert.pem',
+              '-tls-key=/certs/key.pem',
             ],
             env: [
               {
@@ -57,7 +61,10 @@ exp.Experiment(expName, 10, 'pusher-' + std.extVar('PROJECT_ID'), "none", dataty
           {
             name: 'measurement-lab-org-tls',
             secret: {
-              secretName: 'measurement-lab-org-tls',
+              secretName: if std.extVar('PROJECT_ID') != 'mlab-oti' then
+                'measurement-lab-org-tls'
+              else
+                'ndt-tls',
             },
           },
         ],


### PR DESCRIPTION
Since we are still unsure of how cert-manager/LetsEncrypt will work in mlab-oti, this PR conditionally uses the LE certs in staging and sandbox only, until we can be sure that cert-manager gets a valid cert for all the wildcard domains we expect in production.

This PR also slightly reorders the args for ndt and ndtcloud, putting TLS options at the end. It appears that if/then blocks in jsonnet can be greedy, and will eat up everything after them, including place where you want to add arrays together. Putting the if/then after the `+` operator solves this without the need for parentheses.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/403)
<!-- Reviewable:end -->
