### PR TITLE
Converts experiments to use LetsEncrypt wildcard certificates, unconditionally.

### DIFF
--- a/k8s/daemonsets/experiments/ndt.jsonnet
+++ b/k8s/daemonsets/experiments/ndt.jsonnet
@@ -25,12 +25,8 @@ exp.Experiment(expName, 2, 'pusher-' + std.extVar('PROJECT_ID'), "none", datatyp
               '-prometheusx.listen-address=$(PRIVATE_IP):9990',
               '-datadir=/var/spool/' + expName,
               '-txcontroller.device=net1',
-            ] + if std.extVar('PROJECT_ID') != 'mlab-oti' then [
               '-key=/certs/tls.key',
               '-cert=/certs/tls.crt',
-            ] else [
-              '-key=/certs/key.pem',
-              '-cert=/certs/cert.pem',
             ],
             env: [
               {
@@ -98,10 +94,7 @@ exp.Experiment(expName, 2, 'pusher-' + std.extVar('PROJECT_ID'), "none", datatyp
           {
             name: 'measurement-lab-org-tls',
             secret: {
-              secretName: if std.extVar('PROJECT_ID') != 'mlab-oti' then
-                'measurement-lab-org-tls'
-              else
-                'ndt-tls',
+              secretName: 'measurement-lab-org-tls',
             },
           },
           {

--- a/k8s/daemonsets/experiments/ndtcloud.jsonnet
+++ b/k8s/daemonsets/experiments/ndtcloud.jsonnet
@@ -14,12 +14,8 @@ exp.ExperimentNoIndex(expName, 'pusher-ndtcloud-' + std.extVar('PROJECT_ID'), "n
               '-uuid-prefix-file=' + exp.uuid.prefixfile,
               '-prometheusx.listen-address=127.0.0.1:9990',
               '-datadir=/var/spool/' + expName,
-            ] + if std.extVar('PROJECT_ID') != 'mlab-oti' then [
               '-key=/certs/tls.key',
               '-cert=/certs/tls.crt',
-            ] else [
-              '-key=/certs/key.pem',
-              '-cert=/certs/cert.pem',
             ],
             volumeMounts: [
               {
@@ -59,10 +55,7 @@ exp.ExperimentNoIndex(expName, 'pusher-ndtcloud-' + std.extVar('PROJECT_ID'), "n
           {
             name: 'measurement-lab-org-tls',
             secret: {
-              secretName: if std.extVar('PROJECT_ID') != 'mlab-oti' then
-                'measurement-lab-org-tls'
-              else
-                'ndt-tls',
+              secretName: 'measurement-lab-org-tls',
             },
           },
         ],

--- a/k8s/daemonsets/experiments/neubot.jsonnet
+++ b/k8s/daemonsets/experiments/neubot.jsonnet
@@ -15,12 +15,8 @@ exp.Experiment(expName, 10, 'pusher-' + std.extVar('PROJECT_ID'), "none", dataty
               '-prometheusx.listen-address=$(PRIVATE_IP):9990',
               '-http-listen-address=:80',
               '-https-listen-address=:443',
-            ] + if std.extVar('PROJECT_ID') != 'mlab-oti' then [
               '-tls-cert=/certs/tls.crt',
               '-tls-key=/certs/tls.key',
-            ] else [
-              '-tls-cert=/certs/cert.pem',
-              '-tls-key=/certs/key.pem',
             ],
             env: [
               {
@@ -61,10 +57,7 @@ exp.Experiment(expName, 10, 'pusher-' + std.extVar('PROJECT_ID'), "none", dataty
           {
             name: 'measurement-lab-org-tls',
             secret: {
-              secretName: if std.extVar('PROJECT_ID') != 'mlab-oti' then
-                'measurement-lab-org-tls'
-              else
-                'ndt-tls',
+              secretName: 'measurement-lab-org-tls',
             },
           },
         ],


### PR DESCRIPTION
This reverts the changes from yesterday that conditionally only applied the LetsEncrypt certificates in sandbox and staging. Now that we have verified that the wildcard LE certificate in production is working, we should deploy the LE certificate everywhere.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/404)
<!-- Reviewable:end -->
