### PR TITLE
Additional support for project-decorated/flat hostnames.

### DIFF
--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -302,7 +302,7 @@ local Pusher(expName, tcpPort, datatypes, hostNetwork, bucket) = [
 local UUIDAnnotator(expName, tcpPort, hostNetwork) = [
   {
     name: 'uuid-annotator',
-    image: 'measurementlab/uuid-annotator:v0.3.0',
+    image: 'measurementlab/uuid-annotator:v0.3.1',
     args: [
       if hostNetwork then
         '-prometheusx.listen-address=127.0.0.1:' + tcpPort

--- a/manage-cluster/add_ndt_virtual_node.sh
+++ b/manage-cluster/add_ndt_virtual_node.sh
@@ -28,6 +28,13 @@ if ! [[ "${CLOUD_SITE}" =~ $SITE_REGEX ]]; then
   exit 1
 fi
 
+# The base domain to use. e.g., mlab-staging.measurement-lab.org
+BASE_DOMAIN_VAR="BASE_DOMAIN_${PROJECT//-/_}"
+BASE_DOMAIN=${!BASE_DOMAIN_VAR}
+
+# Should the host part of names be separated by a dash or dot. e.g., mlab1-den05
+NAME_SEPARATOR_VAR="NAME_SEPARATOR_${PROJECT//-/_}"
+
 # Determine the region based on $CLOUD_ZONE.
 GCE_REGION="${CLOUD_ZONE%-*}"
 GCP_ARGS=("--project=${PROJECT}" "--quiet")
@@ -40,8 +47,8 @@ else
   MLAB_MACHINE="mlab1"
 fi
 
-GCE_NAME="${MLAB_MACHINE}-${CLOUD_SITE}-measurement-lab-org"
-K8S_NAME="${MLAB_MACHINE}.${CLOUD_SITE}.measurement-lab.org"
+GCE_NAME="${MLAB_MACHINE}-${CLOUD_SITE}-${BASE_DOMAIN//./-}"
+K8S_NAME="${MLAB_MACHINE}${!NAME_SEPARATOR_VAR}${CLOUD_SITE}.${BASE_DOMAIN}"
 
 # Create the static cloud public IP, if it doesn't already exist.
 CURRENT_CLOUD_IP=$(gcloud compute addresses list \
@@ -78,4 +85,3 @@ fi
 ./add_k8s_virtual_node.sh -p "${PROJECT}" -z "${CLOUD_ZONE}" \
     -n "${GCE_NAME}" -H "${K8S_NAME}" -a "${GCE_NAME}" -t "ndt-cloud" \
     -l "mlab/type=virtual mlab/run=ndtcloud mlab/machine=${MLAB_MACHINE} mlab/metro=${CLOUD_SITE::-2} mlab/site=${CLOUD_SITE} mlab/project=${PROJECT}"
-

--- a/manage-cluster/add_ndt_virtual_node.sh
+++ b/manage-cluster/add_ndt_virtual_node.sh
@@ -28,6 +28,9 @@ if ! [[ "${CLOUD_SITE}" =~ $SITE_REGEX ]]; then
   exit 1
 fi
 
+# TODO(kinkade): Remove usage of BASE_DOMAIN and NAME_SEPARATOR once we have
+# fully migrated to v2 hostnames, at which point it won't be needed.
+#
 # The base domain to use. e.g., mlab-staging.measurement-lab.org
 BASE_DOMAIN_VAR="BASE_DOMAIN_${PROJECT//-/_}"
 BASE_DOMAIN=${!BASE_DOMAIN_VAR}

--- a/manage-cluster/create_k8s_configs.sh
+++ b/manage-cluster/create_k8s_configs.sh
@@ -8,6 +8,9 @@ PROJECT=${1:?Please specify the google cloud project: $USAGE}
 # Source the main configuration file.
 source ./k8s_deploy.conf
 
+# TODO(kinkade): Remove usage of BASE_DOMAIN and NAME_SEPARATOR once we have
+# fully migrated to v2 hostnames, at which point it won't be needed.
+#
 # The base domain to use. i.e., Does the base domain include the project.
 BASE_DOMAIN_VAR="BASE_DOMAIN_${PROJECT//-/_}"
 NAME_SEPARATOR_VAR="NAME_SEPARATOR_${PROJECT//-/_}"

--- a/manage-cluster/create_k8s_configs.sh
+++ b/manage-cluster/create_k8s_configs.sh
@@ -39,7 +39,7 @@ for r in $(jq -r 'keys[] as $k | "\($k):\(.[$k].uplink_speed)"' switches.json); 
   speed=$(echo $r | cut -d: -f2)
   for node in mlab1 mlab2 mlab3 mlab4; do
     if [[ "${speed}" == "1g" ]]; then
-      echo "${MAX_RATE_1G}" > "${MAX_RATES_DIR}/${node}${!NAMES_SEPARATOR_VAR}${site}.${!BASE_DOMAIN_VAR}"
+      echo "${MAX_RATE_1G}" > "${MAX_RATES_DIR}/${node}${!NAME_SEPARATOR_VAR}${site}.${!BASE_DOMAIN_VAR}"
     elif [[ "${speed}" == "10g" ]]; then
       echo "${MAX_RATE_10G}" > "${MAX_RATES_DIR}/${node}${!NAME_SEPARATOR_VAR}${site}.${!BASE_DOMAIN_VAR}"
     else

--- a/manage-cluster/create_k8s_configs.sh
+++ b/manage-cluster/create_k8s_configs.sh
@@ -8,6 +8,10 @@ PROJECT=${1:?Please specify the google cloud project: $USAGE}
 # Source the main configuration file.
 source ./k8s_deploy.conf
 
+# The base domain to use. i.e., Does the base domain include the project.
+BASE_DOMAIN_VAR="BASE_DOMAIN_${PROJECT//-/_}"
+NAME_SEPARATOR_VAR="NAME_SEPARATOR_${PROJECT//-/_}"
+
 # Create a string representing region and zone variable names for this project.
 GCE_REGION_VAR="GCE_REGION_${PROJECT//-/_}"
 GCE_ZONES_VAR="GCE_ZONES_${PROJECT//-/_}"
@@ -35,9 +39,9 @@ for r in $(jq -r 'keys[] as $k | "\($k):\(.[$k].uplink_speed)"' switches.json); 
   speed=$(echo $r | cut -d: -f2)
   for node in mlab1 mlab2 mlab3 mlab4; do
     if [[ "${speed}" == "1g" ]]; then
-      echo "${MAX_RATE_1G}" > "${MAX_RATES_DIR}/$node.${site}.measurement-lab.org"
+      echo "${MAX_RATE_1G}" > "${MAX_RATES_DIR}/${node}${!NAMES_SEPARATOR_VAR}${site}.${!BASE_DOMAIN_VAR}"
     elif [[ "${speed}" == "10g" ]]; then
-      echo "${MAX_RATE_10G}" > "${MAX_RATES_DIR}/$node.${site}.measurement-lab.org"
+      echo "${MAX_RATE_10G}" > "${MAX_RATES_DIR}/${node}${!NAME_SEPARATOR_VAR}${site}.${!BASE_DOMAIN_VAR}"
     else
       echo "Site ${site} does not have a valid uplink_speed set: ${speed}"
       exit 1

--- a/manage-cluster/k8s_deploy.conf
+++ b/manage-cluster/k8s_deploy.conf
@@ -50,9 +50,11 @@ K8S_CLOUD_NODE_LABELS="mlab/type=virtual"
 TOKEN_SERVER_BASE_NAME="token-server"
 TOKEN_SERVER_PORT="8800"
 
-# Depending on the GCP project we may use different regions, zones, GSC buckets.
+# Depending on the GCP project we may use different regions, zones, GSC buckets, etc.
 #
 # Sandbox
+BASE_DOMAIN_mlab_sandbox="mlab-sandbox.measurement-lab.org"
+NAME_SEPARATOR_mlab_sandbox="-"
 GCE_REGION_mlab_sandbox="us-west2"
 GCE_ZONES_mlab_sandbox="a b c"
 GCS_BUCKET_EPOXY_mlab_sandbox="epoxy-mlab-sandbox"
@@ -60,6 +62,8 @@ GCS_BUCKET_K8S_mlab_sandbox="k8s-support-mlab-sandbox"
 GCS_BUCKET_SITEINFO_mlab_sandbox="siteinfo-mlab-sandbox"
 
 # Staging
+BASE_DOMAIN_mlab_staging="mlab-staging.measurement-lab.org"
+NAME_SEPARATOR_mlab_staging="."
 GCE_REGION_mlab_staging="us-central1"
 GCE_ZONES_mlab_staging="a b c"
 GCS_BUCKET_EPOXY_mlab_staging="epoxy-mlab-staging"
@@ -67,6 +71,8 @@ GCS_BUCKET_K8S_mlab_staging="k8s-support-mlab-staging"
 GCS_BUCKET_SITEINFO_mlab_staging="siteinfo-mlab-staging"
 
 # Production
+BASE_DOMAIN_mlab_oti="measurement-lab.org"
+NAME_SEPARATOR_mlab_oti="."
 GCE_REGION_mlab_oti="us-east1"
 GCE_ZONES_mlab_oti="b c d"
 GCS_BUCKET_EPOXY_mlab_oti="epoxy-mlab-oti"

--- a/manage-cluster/k8s_deploy.conf
+++ b/manage-cluster/k8s_deploy.conf
@@ -62,7 +62,7 @@ GCS_BUCKET_K8S_mlab_sandbox="k8s-support-mlab-sandbox"
 GCS_BUCKET_SITEINFO_mlab_sandbox="siteinfo-mlab-sandbox"
 
 # Staging
-BASE_DOMAIN_mlab_staging="mlab-staging.measurement-lab.org"
+BASE_DOMAIN_mlab_staging="measurement-lab.org"
 NAME_SEPARATOR_mlab_staging="."
 GCE_REGION_mlab_staging="us-central1"
 GCE_ZONES_mlab_staging="a b c"

--- a/manage-cluster/token_server/main_test.go
+++ b/manage-cluster/token_server/main_test.go
@@ -50,7 +50,7 @@ func Test_allocateTokenHandler(t *testing.T) {
 			name:   "success",
 			method: "POST",
 			v1: &extension.V1{
-				Hostname:    "mlab1.foo01.measurement-lab.org",
+				Hostname:    "mlab1-foo01.mlab-oti.measurement-lab.org",
 				IPv4Address: "192.168.1.1",
 				LastBoot:    time.Now().UTC().Add(-5 * time.Minute),
 			},
@@ -72,7 +72,7 @@ func Test_allocateTokenHandler(t *testing.T) {
 			name:   "failure-last-boot-too-old",
 			method: "POST",
 			v1: &extension.V1{
-				Hostname:    "mlab1.foo01.measurement-lab.org",
+				Hostname:    "mlab1-foo01.mlab-oti.measurement-lab.org",
 				IPv4Address: "192.168.1.1",
 				LastBoot:    time.Now().UTC().Add(-125 * time.Minute),
 			},
@@ -82,7 +82,7 @@ func Test_allocateTokenHandler(t *testing.T) {
 			name:   "failure-failure-to-generate-token",
 			method: "POST",
 			v1: &extension.V1{
-				Hostname:    "mlab1.foo01.measurement-lab.org",
+				Hostname:    "mlab1-foo01.mlab-oti.measurement-lab.org",
 				IPv4Address: "192.168.1.1",
 				LastBoot:    time.Now().UTC().Add(-5 * time.Minute),
 			},


### PR DESCRIPTION
This PR adds better support for project-decorated/flat hostnames. With these changes in place, in the sandbox cluster one can view this node running happily:

```
# kubectl get pods -o wide | grep mlab2-lga0t
cadvisor-6hr4g                       1/1     Running            0          3d22h   192.168.2.3     mlab2-lga0t.mlab-sandbox.measurement-lab.org   <none>           <none>
dmesg-exporter-cpk2m                 1/1     Running            0          3d22h   192.168.2.9     mlab2-lga0t.mlab-sandbox.measurement-lab.org   <none>           <none>
fluentd-vfzn9                        1/1     Running            0          3d22h   192.168.2.6     mlab2-lga0t.mlab-sandbox.measurement-lab.org   <none>           <none>
host-bv8gc                           12/12   Running            0          4m20s   4.14.159.86     mlab2-lga0t.mlab-sandbox.measurement-lab.org   <none>           <none>
ndt-5xpbz                            12/12   Running            0          4m12s   192.168.2.12    mlab2-lga0t.mlab-sandbox.measurement-lab.org   <none>           <none>
neubot-nxvww                         11/11   Running            0          4m2s    192.168.2.13    mlab2-lga0t.mlab-sandbox.measurement-lab.org   <none>           <none>
node-exporter-2q8kq                  2/2     Running            0          3d22h   4.14.159.86     mlab2-lga0t.mlab-sandbox.measurement-lab.org   <none>           <none>
revtr-b66vm                          11/11   Running            0          4m12s   192.168.2.11    mlab2-lga0t.mlab-sandbox.measurement-lab.org   <none>           <none>
utilization-f2xv2                    3/3     Running            0          3d22h   4.14.159.86     mlab2-lga0t.mlab-sandbox.measurement-lab.org   <none>           <none>
wehe-cg2x6                           9/9     Running            0          4m17s   192.168.2.10    mlab2-lga0t.mlab-sandbox.measurement-lab.org   <none>           <none>
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/406)
<!-- Reviewable:end -->
