### PR TITLE
Makes setup_k8s.sh compatible with Ubuntu. Removes deps on Github.

### DIFF
--- a/manage-cluster/create_k8s_configs.sh
+++ b/manage-cluster/create_k8s_configs.sh
@@ -122,3 +122,4 @@ sed -e "s/{{CA_CERT_HASH}}/${ca_cert_hash}/" ../node/setup_k8s.sh.template \
 # Upload the evaluated template to GCS.
 cache_control="Cache-Control:private, max-age=0, no-transform"
 gsutil -h "$cache_control" cp ./setup_k8s.sh gs://epoxy-${PROJECT}/stage3_coreos/setup_k8s.sh
+gsutil -h "$cache_control" cp ./setup_k8s.sh gs://epoxy-${PROJECT}/stage3_ubuntu/setup_k8s.sh

--- a/node/setup_k8s.sh.template
+++ b/node/setup_k8s.sh.template
@@ -63,6 +63,7 @@ fi
 # into the image. Once we have migrated fully to Ubuntu, this should be
 # removed.
 if ! [[ -f /etc/systemd/system/kubelet.service.d/10-kubeadm.conf ]]; then
+  mkdir --parents /etc/systemd/system/kubelet.service.d
   curl --silent --show-error --location \
       "https://raw.githubusercontent.com/kubernetes/kubernetes/${RELEASE}/build/debs/10-kubeadm.conf" \
       > /etc/systemd/system/kubelet.service.d/10-kubeadm.conf

--- a/node/setup_k8s.sh.template
+++ b/node/setup_k8s.sh.template
@@ -27,7 +27,6 @@ K8S_TOKEN_ERROR_FILE="/tmp/k8s_token_error"
 # Turn the hostname into its component parts.
 MACHINE=${HOSTNAME:0:5}
 SITE=${HOSTNAME:6:5}
-DOMAIN=${HOSTNAME:12}
 METRO="${SITE/[0-9]*/}"
 
 # Adds /opt/bin (k8s binaries) and /opt/mlab/bin (mlab binaries/scripts) to PATH.
@@ -36,7 +35,7 @@ export PATH=$PATH:/sbin:/usr/sbin:/opt/bin:/opt/mlab/bin
 
 # Make sure to download any and all necessary auth tokens prior to this point.
 # It should be a simple wget from the master node to make that happen.
-MASTER_NODE="api-platform-cluster.${GCP_PROJECT}.${DOMAIN}"
+MASTER_NODE="api-platform-cluster.${GCP_PROJECT}.measurement-lab.org"
 
 # TODO(https://github.com/m-lab/k8s-support/issues/29) This installation of
 # things into etc should be done as part of cloud-config.yml or ignition or just

--- a/node/setup_k8s.sh.template
+++ b/node/setup_k8s.sh.template
@@ -111,6 +111,7 @@ kubeadm join "${MASTER_NODE}:6443" \
   --discovery-token-ca-cert-hash sha256:{{CA_CERT_HASH}}
 
 systemctl daemon-reload
+systemctl enable kubelet
 systemctl start kubelet
 
 echo 'Success: everything we did appeared to work - good luck'

--- a/node/setup_k8s.sh.template
+++ b/node/setup_k8s.sh.template
@@ -84,6 +84,9 @@ if [[ -n $ERROR_408 ]]; then
   /sbin/reboot
 fi
 
+# kubeadm complains if kubelet.service is not enabled when it runs.
+systemctl enable kubelet
+
 # TODO: Stop regenerating the CA on every call to setup_cloud_k8s_master.sh so
 # that we can hard-code the CA hash below without having to change it all the
 # time.
@@ -92,7 +95,6 @@ kubeadm join "${MASTER_NODE}:6443" \
   --discovery-token-ca-cert-hash sha256:{{CA_CERT_HASH}}
 
 systemctl daemon-reload
-systemctl enable kubelet
 systemctl start kubelet
 
 echo 'Success: everything we did appeared to work - good luck'

--- a/node/setup_k8s.sh.template
+++ b/node/setup_k8s.sh.template
@@ -106,7 +106,7 @@ fi
 # that we can hard-code the CA hash below without having to change it all the
 # time.
 kubeadm join "${MASTER_NODE}:6443" \
-  --v 8 \
+  --v 4 \
   --token "${TOKEN}" \
   --discovery-token-ca-cert-hash sha256:{{CA_CERT_HASH}}
 

--- a/node/setup_k8s.sh.template
+++ b/node/setup_k8s.sh.template
@@ -35,7 +35,7 @@ export PATH=$PATH:/sbin:/usr/sbin:/opt/bin:/opt/mlab/bin
 
 # Make sure to download any and all necessary auth tokens prior to this point.
 # It should be a simple wget from the master node to make that happen.
-MASTER_NODE="api-platform-cluster.${GCP_PROJECT}.measurement-lab.org"
+MASTER_NODE="api-platform-cluster.${GCP_PROJECT}.measurementlab.net"
 
 # TODO(https://github.com/m-lab/k8s-support/issues/29) This installation of
 # things into etc should be done as part of cloud-config.yml or ignition or just

--- a/node/setup_k8s.sh.template
+++ b/node/setup_k8s.sh.template
@@ -25,21 +25,21 @@ K8S_TOKEN_URL=${4:?k8s token URL is missing. Node cannot join k8s cluster.}
 K8S_TOKEN_ERROR_FILE="/tmp/k8s_token_error"
 
 # Turn the hostname into its component parts.
-MACHINE=$(echo "${HOSTNAME}" | tr . ' ' | awk '{ print $1 }')
-SITE=$(echo "${HOSTNAME}" | tr . ' ' | awk '{ print $2 }')
+MACHINE=${HOSTNAME:0:5}
+SITE=${HOSTNAME:6:5}
+DOMAIN=${HOSTNAME:12}
 METRO="${SITE/[0-9]*/}"
 
 # Make sure to download any and all necessary auth tokens prior to this point.
 # It should be a simple wget from the master node to make that happen.
-MASTER_NODE="api-platform-cluster.${GCP_PROJECT}.measurementlab.net"
+MASTER_NODE="api-platform-cluster.${GCP_PROJECT}.${DOMAIN}"
 
 # TODO(https://github.com/m-lab/k8s-support/issues/29) This installation of
 # things into etc should be done as part of cloud-config.yml or ignition or just
 # something besides this script.
 # Install things in /etc
 # Startup configs for the kubelet
-RELEASE=$(cat /usr/share/oem/installed_k8s_version.txt)
-mkdir --parents /etc/systemd/system
+RELEASE=$(/opt/bin/kubelet --version | awk '{print $2}')
 curl --silent --show-error --location "https://raw.githubusercontent.com/kubernetes/kubernetes/${RELEASE}/build/debs/kubelet.service" > /etc/systemd/system/kubelet.service
 
 # Add node tags to the kubelet so that node metadata is there right at the very
@@ -61,15 +61,7 @@ curl --silent --show-error --location "https://raw.githubusercontent.com/kuberne
 # it doesn't exist, polluting the logs terribly.
 mkdir --parents /etc/kubernetes/manifests
 
-# CNI binaries are baked into the boot images at /usr/cni/bin, however, the
-# kubelet expects to find them in /opt/cni/bin by default. Rather than muck
-# with default settings, we just create a symlink here.
-mkdir --parents /opt
-ln --force --no-dereference --symbolic /usr/cni /opt/cni
-
 systemctl daemon-reload
-systemctl enable docker
-systemctl start docker
 
 # Fetch k8s token via K8S_TOKEN_URL. Curl should report most errors to stderr,
 # so write stderr to a file so we can read any error code.

--- a/node/setup_k8s.sh.template
+++ b/node/setup_k8s.sh.template
@@ -30,6 +30,10 @@ SITE=${HOSTNAME:6:5}
 DOMAIN=${HOSTNAME:12}
 METRO="${SITE/[0-9]*/}"
 
+# Adds /opt/bin (k8s binaries) and /opt/mlab/bin (mlab binaries/scripts) to PATH.
+# Also, be 100% sure /sbin and /usr/sbin are in PATH.
+export PATH=$PATH:/sbin:/usr/sbin:/opt/bin:/opt/mlab/bin
+
 # Make sure to download any and all necessary auth tokens prior to this point.
 # It should be a simple wget from the master node to make that happen.
 MASTER_NODE="api-platform-cluster.${GCP_PROJECT}.${DOMAIN}"
@@ -39,7 +43,7 @@ MASTER_NODE="api-platform-cluster.${GCP_PROJECT}.${DOMAIN}"
 # something besides this script.
 # Install things in /etc
 # Startup configs for the kubelet
-RELEASE=$(/opt/bin/kubelet --version | awk '{print $2}')
+RELEASE=$(kubelet --version | awk '{print $2}')
 curl --silent --show-error --location "https://raw.githubusercontent.com/kubernetes/kubernetes/${RELEASE}/build/debs/kubelet.service" > /etc/systemd/system/kubelet.service
 
 # Add node tags to the kubelet so that node metadata is there right at the very
@@ -63,6 +67,12 @@ mkdir --parents /etc/kubernetes/manifests
 
 systemctl daemon-reload
 
+# CoreOS machines require this symlink. On Ubuntu machines, things are put in
+# the right place to begin with.
+if ! [[ -d "/opt/cni" ]]; then
+  ln --force --no-dereference --symbolic /usr/cni /opt/cni
+fi
+
 # Fetch k8s token via K8S_TOKEN_URL. Curl should report most errors to stderr,
 # so write stderr to a file so we can read any error code.
 TOKEN=$( curl --fail --silent --show-error -XPOST --data-binary "{}" \
@@ -74,7 +84,6 @@ if [[ -n $ERROR_408 ]]; then
   /sbin/reboot
 fi
 
-export PATH=/sbin:/usr/sbin:/opt/bin:${PATH}
 # TODO: Stop regenerating the CA on every call to setup_cloud_k8s_master.sh so
 # that we can hard-code the CA hash below without having to change it all the
 # time.

--- a/node/setup_k8s.sh.template
+++ b/node/setup_k8s.sh.template
@@ -90,6 +90,7 @@ systemctl enable kubelet
 # that we can hard-code the CA hash below without having to change it all the
 # time.
 kubeadm join "${MASTER_NODE}:6443" \
+  --v 8 \
   --token "${TOKEN}" \
   --discovery-token-ca-cert-hash sha256:{{CA_CERT_HASH}}
 

--- a/node/setup_k8s.sh.template
+++ b/node/setup_k8s.sh.template
@@ -37,26 +37,41 @@ export PATH=$PATH:/sbin:/usr/sbin:/opt/bin:/opt/mlab/bin
 # It should be a simple wget from the master node to make that happen.
 MASTER_NODE="api-platform-cluster.${GCP_PROJECT}.measurementlab.net"
 
+# Capture K8S version for later usage.
+RELEASE=$(kubelet --version | awk '{print $2}')
+
 # TODO(https://github.com/m-lab/k8s-support/issues/29) This installation of
 # things into etc should be done as part of cloud-config.yml or ignition or just
 # something besides this script.
-# Install things in /etc
 # Startup configs for the kubelet
-RELEASE=$(kubelet --version | awk '{print $2}')
-curl --silent --show-error --location "https://raw.githubusercontent.com/kubernetes/kubernetes/${RELEASE}/build/debs/kubelet.service" > /etc/systemd/system/kubelet.service
+# TODO(kinakde): This is transitional. The Ubuntu stage3 image has this baked
+# into the image. Once we have migrated fully to Ubuntu, this should be
+# removed.
+if ! [[ -f /etc/systemd/system/kubelet.service ]]; then
+  curl --silent --show-error --location \
+      "https://raw.githubusercontent.com/kubernetes/kubernetes/${RELEASE}/build/debs/kubelet.service" \
+      > /etc/systemd/system/kubelet.service
+fi
 
 # Add node tags to the kubelet so that node metadata is there right at the very
 # beginning.
 #
 # TODO: Add annotations to the node as well as labels. The annotations should
 #       contain most of /proc/cmdline as well as the args to this script.
+#
+# TODO(kinakde): This is transitional. The Ubuntu stage3 image has this baked
+# into the image. Once we have migrated fully to Ubuntu, this should be
+# removed.
+if ! [[ -f /etc/systemd/system/kubelet.service.d/10-kubeadm.conf ]]; then
+  curl --silent --show-error --location \
+      "https://raw.githubusercontent.com/kubernetes/kubernetes/${RELEASE}/build/debs/10-kubeadm.conf" \
+      > /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
+fi
 
 NODE_LABELS="mlab/machine=${MACHINE},mlab/site=${SITE},mlab/metro=${METRO},mlab/type=physical,mlab/project=${GCP_PROJECT}"
 DYNAMIC_CONFIG_DIR="/var/lib/kubelet/dynamic-configs"
-mkdir --parents /etc/systemd/system/kubelet.service.d
-curl --silent --show-error --location "https://raw.githubusercontent.com/kubernetes/kubernetes/${RELEASE}/build/debs/10-kubeadm.conf" \
-  | sed -e "s|KUBELET_KUBECONFIG_ARGS=|KUBELET_KUBECONFIG_ARGS=--node-labels=$NODE_LABELS --dynamic-config-dir=$DYNAMIC_CONFIG_DIR |g" \
-  > /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
+sed -ie "s|KUBELET_KUBECONFIG_ARGS=|KUBELET_KUBECONFIG_ARGS=--node-labels=$NODE_LABELS --dynamic-config-dir=$DYNAMIC_CONFIG_DIR |g" \
+  /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
 
 # Make the directory /etc/kubernetes/manifests. The declaration staticPodPath in
 # `staticPodPath` /var/lib/kubelet/config.yaml defines this and is a standard
@@ -68,6 +83,10 @@ systemctl daemon-reload
 
 # CoreOS machines require this symlink. On Ubuntu machines, things are put in
 # the right place to begin with.
+#
+# TODO(kinakde): This is transitional. The Ubuntu stage3 image has this baked
+# into the image. Once we have migrated fully to Ubuntu, this should be
+# removed.
 if ! [[ -d "/opt/cni" ]]; then
   ln --force --no-dereference --symbolic /usr/cni /opt/cni
 fi
@@ -82,9 +101,6 @@ ERROR_408=$(grep '408 Request Timeout' $K8S_TOKEN_ERROR_FILE || :)
 if [[ -n $ERROR_408 ]]; then
   /sbin/reboot
 fi
-
-# kubeadm complains if kubelet.service is not enabled when it runs.
-systemctl enable kubelet
 
 # TODO: Stop regenerating the CA on every call to setup_cloud_k8s_master.sh so
 # that we can hard-code the CA hash below without having to change it all the


### PR DESCRIPTION
This PR introduces changes to setup_k8s.sh which make it compatible with setting up Ubuntu nodes, in addition to CoreOS nodes. Once we have migrated fully to Ubuntu several change introduced to this file can be removed.

For Ubuntu nodes, this PR also removes any dependencies on Github. We have seen nodes fail to boot because of a Github outage, which is wrong. This PR, again for Ubuntu nodes only, moves that dependency to the build process.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/412)
<!-- Reviewable:end -->
