### PR TITLE
Use 'helm upgrade --install' + declarative namespace creation

### DIFF
--- a/manage-cluster/apply_k8s_configs.sh
+++ b/manage-cluster/apply_k8s_configs.sh
@@ -48,24 +48,24 @@ kubectl create namespace cert-manager --dry-run -o json | kubectl apply -f -
 kubectl create namespace nginx-ingress --dry-run -o json | kubectl apply -f -
 
 # Install ingress-nginx and set it to run on the same node as prometheus-server.
-./linux-amd64/helm install nginx-ingress \
+./linux-amd64/helm upgrade --install nginx-ingress \
   --namespace nginx-ingress \
   --set rbac.create=true \
   --set controller.nodeSelector.run=prometheus-server \
   --set defaultBackend.nodeSelector.run=prometheus-server \
   --set controller.service.enabled=false \
   --set controller.hostNetwork=true \
-  stable/nginx-ingress || true
+  stable/nginx-ingress
 
 # Install cert-manager and configure it to use the "letsencrypt" ClusterIssuer
 # by default.
 # https://docs.cert-manager.io/en/latest/getting-started/install/kubernetes.html
 kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/${K8S_CERTMANAGER_VERSION}/cert-manager.crds.yaml
-./linux-amd64/helm install cert-manager \
+./linux-amd64/helm upgrade --install cert-manager \
   --namespace cert-manager \
   --version ${K8S_CERTMANAGER_VERSION} \
   --values ../config/cert-manager/helm-values-overrides.yaml \
-  jetstack/cert-manager || true
+  jetstack/cert-manager
 
 # Apply the configuration
 

--- a/manage-cluster/apply_k8s_configs.sh
+++ b/manage-cluster/apply_k8s_configs.sh
@@ -44,8 +44,8 @@ tar -zxvf helm-${K8S_HELM_VERSION}-linux-amd64.tar.gz
 ./linux-amd64/helm repo update
 
 # Helm 3 does not automatically create namespaces anymore.
-kubectl create namespace cert-manager || true
-kubectl create namespace nginx-ingress || true
+kubectl create namespace cert-manager --dry-run -o json | kubectl apply -f -
+kubectl create namespace nginx-ingress --dry-run -o json | kubectl apply -f -
 
 # Install ingress-nginx and set it to run on the same node as prometheus-server.
 ./linux-amd64/helm install nginx-ingress \
@@ -84,4 +84,3 @@ kubectl apply -f system.json || true
 # not up and running.
 sleep 60
 kubectl apply -f system.json
-


### PR DESCRIPTION
Currently, when the namespaces `nginx-ingress` and `cert-manager` are created, if the namespace already exists, the command will fail and issue an error. The reason this doesn't cause the entire k8s deployment to fail is that each are trailed with `|| true`. This PR changes this to use kubectl-apply instead, which will emit a warning about only using `kubectl apply` on objects created by `apply` or `create`, but not an error. So in the event of a true error creating the namespace the script will fail as expected.

Additionally, `helm install` will fail if the object package already exists in the cluster. This error is got around again with `|| true` on the command. However, this is broken in that a legitimate upgrade will always fail because the resource already exists. This PR changes this to `helm upgrade --install`, which will upgrade the object if it already exists, or install it if it doesn't.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/422)
<!-- Reviewable:end -->
