### PR TITLE
Increment pusher version, possible ram leak fix

### DIFF
--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -253,7 +253,7 @@ local Pcap(expName, tcpPort, hostNetwork) = [
 
 local Pusher(expName, tcpPort, datatypes, hostNetwork, bucket) = [
   {
-    local version='v1.17',
+    local version='v1.18',
     name: 'pusher',
     image: 'measurementlab/pusher:'+version,
     args: [


### PR DESCRIPTION
This change updates pusher in an effort to address a memory leak that is most active in the host context by updating the upstream versions of dependent packages.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/423)
<!-- Reviewable:end -->
