### PR TITLE
Updates the utilization image (utility-support) image to v2.0.10.

### DIFF
--- a/k8s/daemonsets/core/utilization.jsonnet
+++ b/k8s/daemonsets/core/utilization.jsonnet
@@ -27,7 +27,7 @@ local exp = import '../templates.jsonnet';
         containers: [
           {
             name: 'utility-support',
-            image: 'measurementlab/utility-support:v2.0.8',
+            image: 'measurementlab/utility-support:v2.0.10',
             env: [
               {
                 name: 'HOSTNAME',


### PR DESCRIPTION
Updates the utilization (utility-support) image version to 2.0.10, which add support for v2 node names to DISCO.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/424)
<!-- Reviewable:end -->
