### PR TITLE
Add locate verify key to ndt-server

### DIFF
--- a/k8s/daemonsets/experiments/ndt.jsonnet
+++ b/k8s/daemonsets/experiments/ndt.jsonnet
@@ -27,6 +27,8 @@ exp.Experiment(expName, 2, 'pusher-' + std.extVar('PROJECT_ID'), "none", datatyp
               '-txcontroller.device=net1',
               '-key=/certs/tls.key',
               '-cert=/certs/tls.crt',
+              '-token.machine=$(NODE_NAME)',
+              '-token.verify-key=/verify/jwk_sig_EdDSA_locate_20200409.pub',
             ],
             env: [
               {
@@ -55,6 +57,11 @@ exp.Experiment(expName, 2, 'pusher-' + std.extVar('PROJECT_ID'), "none", datatyp
               {
                 mountPath: '/etc/' + std.extVar('MAX_RATES_CONFIGMAP'),
                 name: std.extVar('MAX_RATES_CONFIGMAP'),
+                readOnly: true,
+              },
+              {
+                mountPath: '/verify',
+                name: 'locate-verify-keys',
                 readOnly: true,
               },
               exp.uuid.volumemount,
@@ -101,6 +108,12 @@ exp.Experiment(expName, 2, 'pusher-' + std.extVar('PROJECT_ID'), "none", datatyp
             name: std.extVar('MAX_RATES_CONFIGMAP'),
             configMap: {
               name: std.extVar('MAX_RATES_CONFIGMAP'),
+            },
+          },
+          {
+            name: 'locate-verify-keys',
+            secret: {
+              secretName: 'locate-verify-keys',
             },
           },
         ],

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -1,4 +1,4 @@
-local ndtVersion = 'v0.15.0';
+local ndtVersion = 'v0.16.0';
 local PROJECT_ID = std.extVar('PROJECT_ID');
 
 local uuid = {

--- a/manage-cluster/apply_k8s_configs.sh
+++ b/manage-cluster/apply_k8s_configs.sh
@@ -34,6 +34,11 @@ else
   export KUBECONFIG=./kube-config
 fi
 
+# Upload the evaluated setup_k8s.sh template to GCS.
+cache_control="Cache-Control:private, max-age=0, no-transform"
+gsutil -h "$cache_control" cp ./setup_k8s.sh gs://epoxy-${PROJECT}/stage3_coreos/setup_k8s.sh
+gsutil -h "$cache_control" cp ./setup_k8s.sh gs://epoxy-${PROJECT}/stage3_ubuntu/setup_k8s.sh
+
 # Download helm and use it to install cert-manager and ingress-nginx
 curl -O https://get.helm.sh/helm-${K8S_HELM_VERSION}-linux-amd64.tar.gz
 tar -zxvf helm-${K8S_HELM_VERSION}-linux-amd64.tar.gz


### PR DESCRIPTION
This change updates the ndt-server version to v0.16.0 and enables verification of access tokens provided by the locate service (i.e. from monitoring or early locate service).

This change adds a new secret that contains the verify keys that the ndt-server loads on start. At this time, access tokens remain optional. However, if an access token is provided it must be valid.

Note this change also moves the gsutil copy of `setup_k8s.sh` from `create_k8s_configs.sh` to `apply_k8s_configs.sh` so that the create script does not have side effects.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/426)
<!-- Reviewable:end -->
