### PR TITLE
Use Ubuntu 20.04 LTS minimal images for k8s cloud nodes (including masters)

### DIFF
--- a/manage-cluster/bootstraplib.sh
+++ b/manage-cluster/bootstraplib.sh
@@ -362,7 +362,7 @@ EOF
 	export ETCDCTL_KEY=/etc/kubernetes/pki/etcd/peer.key
 	export ETCDCTL_ENDPOINTS=https://127.0.0.1:2379
 EOF2
-    ) >> /root/.profile"
+    ) | tee -a /root/.profile /root/.bashrc"
 EOF
 
   # Annotate and label the master node.

--- a/manage-cluster/k8s_deploy.conf
+++ b/manage-cluster/k8s_deploy.conf
@@ -1,5 +1,5 @@
 GCE_BASE_NAME="platform-cluster"
-GCE_IMAGE_FAMILY="ubuntu-minimal-1804-lts"
+GCE_IMAGE_FAMILY="ubuntu-minimal-2004-lts"
 GCE_IMAGE_PROJECT="ubuntu-os-cloud"
 GCE_DISK_SIZE="100"
 GCE_DISK_TYPE="pd-ssd"


### PR DESCRIPTION
Previously, we were using 18.04 LTS images, just waiting for 20.04 to be released. Now it is, and GCP has images for the new LTS release, so we can use them.

Also, I realized that the ETCDCTL evn variables were only being set in /root/.bashrc, but we'd like to have them in /root/.profile too for non-interactive shells.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/427)
<!-- Reviewable:end -->
