### PR TITLE
Set update strategy to Recreate for nginx-ingress and cert-manager

### DIFF
--- a/config/cert-manager/helm-values-overrides.yaml
+++ b/config/cert-manager/helm-values-overrides.yaml
@@ -8,10 +8,12 @@ ingressShim:
   defaultIssuerKind: ClusterIssuer
 nodeSelector:
   "node-role.kubernetes.io/master": ""
+strategy:
+  type: Recreate
+tolerations:
+- operator: Exists
 webhook:
   nodeSelector:
     "node-role.kubernetes.io/master": ""
   tolerations:
   - operator: Exists
-tolerations:
-- operator: Exists

--- a/config/nginx-ingress/helm-values-overrides.yaml
+++ b/config/nginx-ingress/helm-values-overrides.yaml
@@ -1,0 +1,14 @@
+controller:
+  hostNetwork: true
+  nodeSelector:
+    run: prometheus-server
+  service:
+    enabled: false
+  updateStrategy:
+    type: Recreate
+defaultBackend:
+  nodeSelector:
+    run: prometheus-server
+rbac:
+  create: true
+

--- a/manage-cluster/apply_k8s_configs.sh
+++ b/manage-cluster/apply_k8s_configs.sh
@@ -55,11 +55,7 @@ kubectl create namespace nginx-ingress --dry-run -o json | kubectl apply -f -
 # Install ingress-nginx and set it to run on the same node as prometheus-server.
 ./linux-amd64/helm upgrade --install nginx-ingress \
   --namespace nginx-ingress \
-  --set rbac.create=true \
-  --set controller.nodeSelector.run=prometheus-server \
-  --set defaultBackend.nodeSelector.run=prometheus-server \
-  --set controller.service.enabled=false \
-  --set controller.hostNetwork=true \
+  --values ../config/nginx-ingress/helm-values-overrides.yaml \
   stable/nginx-ingress
 
 # Install cert-manager and configure it to use the "letsencrypt" ClusterIssuer


### PR DESCRIPTION
The default update strategy for deployments is `RollingUpdate` with `maxUnavailable: 25%`. If there is only one replica in a deployment, the the deployment can never rollout, because taking down one pod is 100% of the pods, which is more than 25%.

This used to work because we used to delete then recreate the nginx-ingress and cert-manager deployments, but in a recent PR we changed to using `helm update --install`, which is causing the deployments to fail to rollout.

This PR sets the update strategy to `Recreate` for both deployments. 

Additionally, this PR introduces a new custom values file for nginx-ingress and removes all the `--set` flags to helm.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/429)
<!-- Reviewable:end -->
