### PR TITLE
Update ndt-server version and prepare to require ndt7 access tokens

### DIFF
--- a/k8s/daemonsets/experiments/ndt.jsonnet
+++ b/k8s/daemonsets/experiments/ndt.jsonnet
@@ -29,6 +29,9 @@ exp.Experiment(expName, 2, 'pusher-' + std.extVar('PROJECT_ID'), "none", datatyp
               '-cert=/certs/tls.crt',
               '-token.machine=$(NODE_NAME)',
               '-token.verify-key=/verify/jwk_sig_EdDSA_locate_20200409.pub',
+              # TODO(ooni/probe-engine/issues/562): require access tokens from NDT7
+              #  clients after ooni is migrated to locate/v2.
+              # '-ndt7.token.required=true',
             ],
             env: [
               {

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -1,4 +1,4 @@
-local ndtVersion = 'v0.16.0';
+local ndtVersion = 'v0.17.0';
 local PROJECT_ID = std.extVar('PROJECT_ID');
 
 local uuid = {


### PR DESCRIPTION
This change is in preparation of requiring access tokens from ndt7 clients.

This change also includes a modification to the ndt-server s2c test to eliminate a failure mode currently impacting e2e ndt5-client measurements. This will allow the e2e monitoring migration to gke to continue if this change reduces net error rates.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/430)
<!-- Reviewable:end -->
