### PR TITLE
Name flannel daemonsets after the workload names.

### DIFF
--- a/k8s/daemonsets/core/flannel-physical.jsonnet
+++ b/k8s/daemonsets/core/flannel-physical.jsonnet
@@ -12,7 +12,7 @@
   apiVersion: 'apps/v1',
   kind: 'DaemonSet',
   metadata: {
-    name: 'kube-flannel-ds-physical',
+    name: 'flannel-physical',
     namespace: 'kube-system',
   },
   spec: {
@@ -60,7 +60,7 @@
               },
             ],
             image: 'quay.io/coreos/flannel:' + std.extVar('K8S_FLANNEL_VERSION') + '-amd64',
-            name: 'kube-flannel',
+            name: 'flannel-physical',
             resources: {
               limits: {
                 cpu: '100m',

--- a/k8s/daemonsets/core/flannel-physical.jsonnet
+++ b/k8s/daemonsets/core/flannel-physical.jsonnet
@@ -60,7 +60,7 @@
               },
             ],
             image: 'quay.io/coreos/flannel:' + std.extVar('K8S_FLANNEL_VERSION') + '-amd64',
-            name: 'flannel-physical',
+            name: 'flannel',
             resources: {
               limits: {
                 cpu: '100m',

--- a/k8s/daemonsets/core/flannel-virtual.jsonnet
+++ b/k8s/daemonsets/core/flannel-virtual.jsonnet
@@ -63,7 +63,7 @@
               },
             ],
             image: 'quay.io/coreos/flannel:' + std.extVar('K8S_FLANNEL_VERSION') + '-amd64',
-            name: 'flannel-virtual',
+            name: 'flannel',
             resources: {
               limits: {
                 cpu: '100m',

--- a/k8s/daemonsets/core/flannel-virtual.jsonnet
+++ b/k8s/daemonsets/core/flannel-virtual.jsonnet
@@ -15,7 +15,7 @@
   apiVersion: 'apps/v1',
   kind: 'DaemonSet',
   metadata: {
-    name: 'kube-flannel-ds-virtual',
+    name: 'flannel-virtual',
     namespace: 'kube-system',
   },
   spec: {
@@ -63,7 +63,7 @@
               },
             ],
             image: 'quay.io/coreos/flannel:' + std.extVar('K8S_FLANNEL_VERSION') + '-amd64',
-            name: 'kube-flannel',
+            name: 'flannel-virtual',
             resources: {
               limits: {
                 cpu: '100m',


### PR DESCRIPTION
For all other DaemonSets, the DaemonSet name is the same as the "workload" label name, but it wasn't for flannel. This was causing some problems with selecting pods based on workload name in K8s:SiteOverview dashboard.

**NOTE**: This change requires that the old flannel DaemonSets be manually deleted shortly after the PR is merged.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/432)
<!-- Reviewable:end -->
