### PR TITLE
Add rules for SRE overview dashboard

### DIFF
--- a/config/prometheus/rules.yml
+++ b/config/prometheus/rules.yml
@@ -171,8 +171,14 @@ groups:
         [1h]) * 8
       )
 
-## Pusher Daily Volume metrics
-#
-# This rule optimizes the alert query used for PusherDailyDataVolumeTooLow.
+  ## Pusher Daily Volume metrics
+  #
+  # This rule optimizes the alert query used for PusherDailyDataVolumeTooLow.
   - record: datatype:pusher_bytes_per_tarfile:increase24h
     expr: sum by(datatype) (increase(pusher_bytes_per_tarfile_sum[1d]))
+
+  ## Ops: Tactical & SRE Overview Dashboard.
+  #
+  # This rule speeds up the probably OOM query used by the SRE overview dashboard.
+  - record: err:dmesg_logs:increase_24h
+    expr: increase(dmesg_logs{priority="err"}[24h]) > 0


### PR DESCRIPTION
Based on a suggestion from https://github.com/m-lab/prometheus-support/pull/681 this change adds a recording rule to improve the efficiency of a query in the Ops Tactical & SRE Overview dashboard.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/434)
<!-- Reviewable:end -->
