### PR TITLE
Removes BASE_DOMAIN and NAME_SEPARATOR variables

### DIFF
--- a/manage-cluster/add_ndt_virtual_node.sh
+++ b/manage-cluster/add_ndt_virtual_node.sh
@@ -28,16 +28,6 @@ if ! [[ "${CLOUD_SITE}" =~ $SITE_REGEX ]]; then
   exit 1
 fi
 
-# TODO(kinkade): Remove usage of BASE_DOMAIN and NAME_SEPARATOR once we have
-# fully migrated to v2 hostnames, at which point it won't be needed.
-#
-# The base domain to use. e.g., mlab-staging.measurement-lab.org
-BASE_DOMAIN_VAR="BASE_DOMAIN_${PROJECT//-/_}"
-BASE_DOMAIN=${!BASE_DOMAIN_VAR}
-
-# Should the host part of names be separated by a dash or dot. e.g., mlab1-den05
-NAME_SEPARATOR_VAR="NAME_SEPARATOR_${PROJECT//-/_}"
-
 # Determine the region based on $CLOUD_ZONE.
 GCE_REGION="${CLOUD_ZONE%-*}"
 GCP_ARGS=("--project=${PROJECT}" "--quiet")
@@ -50,8 +40,8 @@ else
   MLAB_MACHINE="mlab1"
 fi
 
-GCE_NAME="${MLAB_MACHINE}-${CLOUD_SITE}-${BASE_DOMAIN//./-}"
-K8S_NAME="${MLAB_MACHINE}${!NAME_SEPARATOR_VAR}${CLOUD_SITE}.${BASE_DOMAIN}"
+GCE_NAME="${MLAB_MACHINE}-${CLOUD_SITE}-${PROJECT}-measurement-lab-org"
+K8S_NAME="${MLAB_MACHINE}-${CLOUD_SITE}.${PROJECT}.measurement-lab.org"
 
 # Create the static cloud public IP, if it doesn't already exist.
 CURRENT_CLOUD_IP=$(gcloud compute addresses list \

--- a/manage-cluster/k8s_deploy.conf
+++ b/manage-cluster/k8s_deploy.conf
@@ -51,8 +51,6 @@ TOKEN_SERVER_PORT="8800"
 # Depending on the GCP project we may use different regions, zones, GSC buckets, etc.
 #
 # Sandbox
-BASE_DOMAIN_mlab_sandbox="mlab-sandbox.measurement-lab.org"
-NAME_SEPARATOR_mlab_sandbox="-"
 GCE_REGION_mlab_sandbox="us-west2"
 GCE_ZONES_mlab_sandbox="a b c"
 GCS_BUCKET_EPOXY_mlab_sandbox="epoxy-mlab-sandbox"
@@ -60,8 +58,6 @@ GCS_BUCKET_K8S_mlab_sandbox="k8s-support-mlab-sandbox"
 GCS_BUCKET_SITEINFO_mlab_sandbox="siteinfo-mlab-sandbox"
 
 # Staging
-BASE_DOMAIN_mlab_staging="mlab-staging.measurement-lab.org"
-NAME_SEPARATOR_mlab_staging="-"
 GCE_REGION_mlab_staging="us-central1"
 GCE_ZONES_mlab_staging="a b c"
 GCS_BUCKET_EPOXY_mlab_staging="epoxy-mlab-staging"
@@ -69,8 +65,6 @@ GCS_BUCKET_K8S_mlab_staging="k8s-support-mlab-staging"
 GCS_BUCKET_SITEINFO_mlab_staging="siteinfo-mlab-staging"
 
 # Production
-BASE_DOMAIN_mlab_oti="measurement-lab.org"
-NAME_SEPARATOR_mlab_oti="."
 GCE_REGION_mlab_oti="us-east1"
 GCE_ZONES_mlab_oti="b c d"
 GCS_BUCKET_EPOXY_mlab_oti="epoxy-mlab-oti"


### PR DESCRIPTION
Now that we are 100% migrated to v2 node names, these transitional crutches are no longer needed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/437)
<!-- Reviewable:end -->
