### PR TITLE
Increases the memory limit for flannel pods from 128MiB to 150MiB. 

### DIFF
--- a/k8s/daemonsets/core/flannel-physical.jsonnet
+++ b/k8s/daemonsets/core/flannel-physical.jsonnet
@@ -64,7 +64,7 @@
             resources: {
               limits: {
                 cpu: '100m',
-                memory: '128Mi',
+                memory: '150Mi',
               },
               requests: {
                 cpu: '100m',

--- a/k8s/daemonsets/core/flannel-virtual.jsonnet
+++ b/k8s/daemonsets/core/flannel-virtual.jsonnet
@@ -67,7 +67,7 @@
             resources: {
               limits: {
                 cpu: '100m',
-                memory: '128Mi',
+                memory: '150Mi',
               },
               requests: {
                 cpu: '100m',


### PR DESCRIPTION
The `request` amount of 128MiB remains the same. On some busy nodes, flannel occasionally seems to want more than 128MiB of memory, causing OOM events on those machines. This PR bumps the upper memory limit for flannel a little from 128MiB to 150MiB to see if this gets rids of the OOM events related to flannel attempting to use more memory than the limit. The vast majority of flannels pods are apparently comfortable within the 128MiB limit, so this change is for occasional outliers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/438)
<!-- Reviewable:end -->
