### PR TITLE
Disabled Prometheus scraping of neubot/dash, since it does not support it.

### DIFF
--- a/k8s/daemonsets/experiments/neubot.jsonnet
+++ b/k8s/daemonsets/experiments/neubot.jsonnet
@@ -5,6 +5,11 @@ local expName = 'neubot';
 exp.Experiment(expName, 10, 'pusher-' + std.extVar('PROJECT_ID'), "none", datatypes) + {
   spec+: {
     template+: {
+      metadata+: {
+        annotations+: {
+          'prometheus.io/scrape': 'false',
+        },
+      },
       spec+: {
         containers+: [
             {


### PR DESCRIPTION
It would appear that neubot/dash does export any metrics. This PR tells Prometheus to not scrape it, removing a bunch of failed scrape attempts.