### PR TITLE
Reverts PR #441, and instead modifies containerPort to be the right one.

### DIFF
--- a/k8s/daemonsets/experiments/neubot.jsonnet
+++ b/k8s/daemonsets/experiments/neubot.jsonnet
@@ -5,11 +5,6 @@ local expName = 'neubot';
 exp.Experiment(expName, 10, 'pusher-' + std.extVar('PROJECT_ID'), "none", datatypes) + {
   spec+: {
     template+: {
-      metadata+: {
-        annotations+: {
-          'prometheus.io/scrape': 'false',
-        },
-      },
       spec+: {
         containers+: [
             {
@@ -44,7 +39,7 @@ exp.Experiment(expName, 10, 'pusher-' + std.extVar('PROJECT_ID'), "none", dataty
             ],
             ports: [
               {
-                containerPort: 80,
+                containerPort: 9990,
               },
             ],
             livenessProbe+: {


### PR DESCRIPTION
PR #441 was wrong! When I noticed that all scraping of neubot/dash was broken, I mistakenly assumed that dash did not expose any metrics. Upon closer inspection I noticed that dash was exposing port 9990 for prometheus metrics, but the only `containerPort` exposed was 80, so Prometheus was mistakenly trying to scrape port 80. This PR reverts #441, and changes `containerPort` to be the right one.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/442)
<!-- Reviewable:end -->
