### PR TITLE
Update NDT server version to v0.18.1

### DIFF
--- a/k8s/daemonsets/experiments/ndt.jsonnet
+++ b/k8s/daemonsets/experiments/ndt.jsonnet
@@ -24,7 +24,7 @@ exp.Experiment(expName, 2, 'pusher-' + std.extVar('PROJECT_ID'), "none", datatyp
               '-uuid-prefix-file=' + exp.uuid.prefixfile,
               '-prometheusx.listen-address=$(PRIVATE_IP):9990',
               '-datadir=/var/spool/' + expName,
-              '-txcontroller.device=net1',
+              # '-txcontroller.device=net1', -- TODO: re-enable after load testing.
               '-key=/certs/tls.key',
               '-cert=/certs/tls.crt',
               '-token.machine=$(NODE_NAME)',

--- a/k8s/daemonsets/experiments/ndt.jsonnet
+++ b/k8s/daemonsets/experiments/ndt.jsonnet
@@ -24,7 +24,7 @@ exp.Experiment(expName, 2, 'pusher-' + std.extVar('PROJECT_ID'), "none", datatyp
               '-uuid-prefix-file=' + exp.uuid.prefixfile,
               '-prometheusx.listen-address=$(PRIVATE_IP):9990',
               '-datadir=/var/spool/' + expName,
-              # '-txcontroller.device=net1', -- TODO: re-enable after load testing.
+              '-txcontroller.device=net1',
               '-key=/certs/tls.key',
               '-cert=/certs/tls.crt',
               '-token.machine=$(NODE_NAME)',

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -1,4 +1,4 @@
-local ndtVersion = 'v0.18.2';
+local ndtVersion = 'v0.18.1';
 local PROJECT_ID = std.extVar('PROJECT_ID');
 
 local uuid = {

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -1,4 +1,4 @@
-local ndtVersion = 'v0.18.0';
+local ndtVersion = 'v0.18.2';
 local PROJECT_ID = std.extVar('PROJECT_ID');
 
 local uuid = {

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -1,4 +1,4 @@
-local ndtVersion = 'v0.17.0';
+local ndtVersion = 'v0.18.0';
 local PROJECT_ID = std.extVar('PROJECT_ID');
 
 local uuid = {


### PR DESCRIPTION
NOTE: after four hours the docker build is still pending, so v0.18.1 was build locally using:

    docker build --no-cache --pull -t measurementlab/ndt-server:v0.18.1 .

And, manually pushed using the tag from: https://github.com/m-lab/ndt-server/releases/tag/v0.18.1

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/443)
<!-- Reviewable:end -->
