### PR TITLE
Fixes deployment of disco to only mlab-sandbox for now.

### DIFF
--- a/k8s/daemonsets/core/disco.jsonnet
+++ b/k8s/daemonsets/core/disco.jsonnet
@@ -3,8 +3,6 @@ local expName = 'disco';
 local config = import '../../../config/disco.jsonnet';
 local version = 'v0.1.4';
 
-// Only deploy this to mlab-sandbox for now.
-if std.extVar('PROJECT_ID') != 'mlab-sandbox' then {} else
 {
   apiVersion: 'apps/v1',
   kind: 'DaemonSet',

--- a/system.jsonnet
+++ b/system.jsonnet
@@ -13,7 +13,12 @@
     import 'k8s/custom-resource-definitions/network-attachment-definition.jsonnet',
     // Daemonsets
     import 'k8s/daemonsets/core/cadvisor.jsonnet',
-    import 'k8s/daemonsets/core/disco.jsonnet',
+  ] + (
+    // Don't deploy disco to prod or staging yet.
+    if std.extVar('PROJECT_ID') == 'mlab-sandbox'
+    then [import 'k8s/daemonsets/core/disco.jsonnet']
+    else []
+  ) + [
     import 'k8s/daemonsets/core/dmesg-exporter.jsonnet',
     import 'k8s/daemonsets/core/flannel-virtual.jsonnet',
     import 'k8s/daemonsets/core/flannel-physical.jsonnet',


### PR DESCRIPTION
The previous method I had tried caused a build failure in mlab-staging because k8s didn't know how to interpret a manifest like `{}`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/447)
<!-- Reviewable:end -->
