### PR TITLE
Updates wehe to latest version in new repo

### DIFF
--- a/k8s/daemonsets/experiments/wehe.jsonnet
+++ b/k8s/daemonsets/experiments/wehe.jsonnet
@@ -57,9 +57,7 @@ exp.Experiment(expName, 5, 'pusher-' + std.extVar('PROJECT_ID'), 'netblock', ['r
               },
             ],
           },
-        ] + std.flattenArrays([
-          exp.Pusher(expName, 9995, ['replay'], false, 'pusher-' + std.extVar('PROJECT_ID')),
-        ]),
+        ],
         [if std.extVar('PROJECT_ID') != 'mlab-sandbox' then 'terminationGracePeriodSeconds']: 180,
         volumes+: [
           {

--- a/k8s/daemonsets/experiments/wehe.jsonnet
+++ b/k8s/daemonsets/experiments/wehe.jsonnet
@@ -1,78 +1,92 @@
 local exp = import '../templates.jsonnet';
+local expName = 'wehe';
 
-exp.Experiment('wehe', 5, 'pusher-' + std.extVar('PROJECT_ID'), 'netblock', ['replay']) + {
-    spec+: {
-        template+: {
-            spec+: {
-                initContainers+: [
-                    {
-                        // Wehe expects the ca.key and ca.crt to be in a
-                        // directory to which it can write the resulting keys
-                        // produced. Secrets can't be mounted read/write, so
-                        // before we start we copy those files from the mounted
-                        // secret (read-only) to a cache directory (read-write).
-                        name: 'ca-copy',
-                        image: 'busybox',
-                        args: [
-                            'cp', '/wehe-ca/ca.key', '/wehe-ca/ca.crt', '/wehe/ssl/',
-                        ],
-                        volumeMounts: [
-                            {
-                                mountPath: '/wehe/ssl/',
-                                name: 'wehe-ca-cache',
-                            },
-                            {
-                                mountPath: '/wehe-ca/',
-                                name: 'wehe-ca',
-                            },
-                        ]
-                    },
-                ],
-                containers+: [
-                    {
-                        name: 'wehe',
-                        image: 'measurementlab/wehe:v0.1',
-                        args: [
-                            'wehe.$(MLAB_NODE_NAME)',
-                        ],
-                        env: [
-                            {
-                                name: 'MLAB_NODE_NAME',
-                                valueFrom: {
-                                    fieldRef: {
-                                        fieldPath: 'spec.nodeName',
-                                    },
-                                },
-                            },
-                        ],
-                        volumeMounts: [
-                            {
-                                mountPath: '/wehe/ssl/',
-                                name: 'wehe-ca-cache',
-                            },
-                            // This volume exists in the volumes entry because
-                            // 'replay' was one of the passed-in datatypes.
-                            exp.VolumeMount('wehe/replay') + {
-                                // Mount it where wehe expects to write it
-                                mountPath: '/data/RecordReplay/ReplayDumps',
-                            },
-                        ],
-                    }
-                ],
-                [if std.extVar('PROJECT_ID') != 'mlab-sandbox' then 'terminationGracePeriodSeconds']: 180,
-                volumes+: [
-                    {
-                        name: 'wehe-ca-cache',
-                        emptyDir: {},
-                    },
-                    {
-                        name: 'wehe-ca',
-                        secret: {
-                            secretName: 'wehe-ca',
-                        },
-                    },
-                ],
-            }
-        }
-    }
+exp.Experiment(expName, 5, 'pusher-' + std.extVar('PROJECT_ID'), 'netblock', ['replay']) + {
+  spec+: {
+    template+: {
+      spec+: {
+        initContainers+: [
+          {
+            args: [
+              'cp', '/wehe-ca/ca.key', '/wehe-ca/ca.crt', '/wehe/ssl/',
+            ],
+            image: 'busybox',
+            // Wehe expects the ca.key and ca.crt to be in a
+            // directory to which it can write the resulting keys
+            // produced. Secrets can't be mounted read/write, so
+            // before we start we copy those files from the mounted
+            // secret (read-only) to a cache directory (read-write).
+            name: 'ca-copy',
+            volumeMounts: [
+              {
+                mountPath: '/wehe/ssl/',
+                name: 'wehe-ca-cache',
+              },
+              {
+                mountPath: '/wehe-ca/',
+                name: 'wehe-ca',
+              },
+            ],
+          },
+        ],
+        containers+: [
+          {
+            args: [
+              'wehe.$(MLAB_NODE_NAME)',
+            ],
+            env: [
+              {
+                name: 'MLAB_NODE_NAME',
+                valueFrom: {
+                  fieldRef: {
+                    fieldPath: 'spec.nodeName',
+                  },
+                },
+              },
+            ],
+            image: 'measurementlab/wehe-py3:v0.1.0',
+            name: expName,
+            volumeMounts: [
+              {
+                mountPath: '/data',
+                name: 'wehe-data',
+              },
+              {
+                mountPath: '/wehe/ssl/',
+                name: 'wehe-ca-cache',
+              },
+            ],
+          },
+        ] + std.flattenArrays([
+          exp.Pusher(expName, 9995, ['replay'], false, 'pusher-' + std.extVar('PROJECT_ID')),
+        ]),
+        [if std.extVar('PROJECT_ID') != 'mlab-sandbox' then 'terminationGracePeriodSeconds']: 180,
+        volumes+: [
+          {
+            name: 'pusher-credentials',
+            secret: {
+              secretName: 'pusher-credentials',
+            },
+          },
+          {
+            hostPath: {
+              path: '/cache/data/' + expName,
+              type: 'DirectoryOrCreate',
+            },
+            name: expName + '-data',
+          },
+          {
+            emptyDir: {},
+            name: 'wehe-ca-cache',
+          },
+          {
+            name: 'wehe-ca',
+            secret: {
+              secretName: 'wehe-ca',
+            },
+          },
+        ],
+      },
+    },
+  },
 }

--- a/k8s/daemonsets/experiments/wehe.jsonnet
+++ b/k8s/daemonsets/experiments/wehe.jsonnet
@@ -48,7 +48,7 @@ exp.Experiment(expName, 5, 'pusher-' + std.extVar('PROJECT_ID'), 'netblock', ['r
             name: expName,
             volumeMounts: [
               exp.VolumeMount('wehe/replay') + {
-                mountPath: '/data/RecordReplay/ReplayDumps',
+                mountPath: '/data/RecordReplay/ReplayDumpsTimestamped',
               },
               {
                 mountPath: '/wehe/ssl/',

--- a/k8s/daemonsets/experiments/wehe.jsonnet
+++ b/k8s/daemonsets/experiments/wehe.jsonnet
@@ -47,9 +47,8 @@ exp.Experiment(expName, 5, 'pusher-' + std.extVar('PROJECT_ID'), 'netblock', ['r
             image: 'measurementlab/wehe-py3:v0.1.0',
             name: expName,
             volumeMounts: [
-              {
-                mountPath: '/data',
-                name: 'wehe-data',
+              exp.VolumeMount('wehe/replay') + {
+                mountPath: '/data/RecordReplay/ReplayDumps',
               },
               {
                 mountPath: '/wehe/ssl/',
@@ -60,19 +59,6 @@ exp.Experiment(expName, 5, 'pusher-' + std.extVar('PROJECT_ID'), 'netblock', ['r
         ],
         [if std.extVar('PROJECT_ID') != 'mlab-sandbox' then 'terminationGracePeriodSeconds']: 180,
         volumes+: [
-          {
-            name: 'pusher-credentials',
-            secret: {
-              secretName: 'pusher-credentials',
-            },
-          },
-          {
-            hostPath: {
-              path: '/cache/data/' + expName,
-              type: 'DirectoryOrCreate',
-            },
-            name: expName + '-data',
-          },
           {
             emptyDir: {},
             name: 'wehe-ca-cache',


### PR DESCRIPTION
There appear to be more changes in this PR that there really are because I chose to reduced the indention from 4 space to 2 spaces, which means every line changed. In retrospect I should have at least made the indention improvement a separate commit to make it easier to see what really changed.

Pretty much the only things that changed are:

* `measurementlab/wehe:v0.1` became `measurementlab/wehe-py3:v0.1.0`
* `mountPath: '/data/RecordReplay/ReplayDumps'` became `mountPath: '/data/RecordReplay/ReplayDumpsTimestamped'`
* I added an `expName` variable, used in just a couple places.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/452)
<!-- Reviewable:end -->
