### PR TITLE
Update ndt-server version to v0.20.1

### DIFF
--- a/k8s/daemonsets/experiments/ndt.jsonnet
+++ b/k8s/daemonsets/experiments/ndt.jsonnet
@@ -30,6 +30,7 @@ exp.Experiment(expName, 2, 'pusher-' + std.extVar('PROJECT_ID'), "none", datatyp
               '-prometheusx.listen-address=$(PRIVATE_IP):9990',
               '-datadir=/var/spool/' + expName,
               '-txcontroller.device=net1',
+              '-htmldir=html/mlab',
               '-key=/certs/tls.key',
               '-cert=/certs/tls.crt',
               '-token.machine=$(NODE_NAME)',

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -1,4 +1,4 @@
-local ndtVersion = 'v0.19.0';
+local ndtVersion = 'v0.20.1';
 local PROJECT_ID = std.extVar('PROJECT_ID');
 
 local uuid = {


### PR DESCRIPTION
Updates the current version of ndt-server to include the latest changes:

Move default webpage (#305)
Add consistent ndt5 protocol metric labels (#306)
Update error log (#308)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/454)
<!-- Reviewable:end -->
