### PR TITLE
Sets the per-pod PID limit to 10,000.

### DIFF
--- a/manage-cluster/kubeadm-config.yml.template
+++ b/manage-cluster/kubeadm-config.yml.template
@@ -48,3 +48,4 @@ apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
 # https://github.com/kubernetes-sigs/kubespray/blob/master/docs/kubernetes-reliability.md#medium-update-and-average-reaction
 nodeStatusUpdateFrequency: 20s
+podPidsLimit: 10000


### PR DESCRIPTION
Intended to resolve #345.

I rebuilt the sandbox cluster with this option in place, and then tested it like this:

```
$ kubectl --content mlab-sandbox exec -ti neubot-pdld8 -c tcp-info -- /bin/sh
/home # idx=0; while true; do sleep 60 & idx=$((idx + 1)); echo $idx; done
1
2
3
4
5
6
7
8
9
10
11
12
[...]
9804
9805
9806
9807
9808
9809
9810
/bin/sh: can't fork: Resource temporarily unavailable
```

For staging and production I will manually edit the kubelet config with this option to avoid having to rebuild the clusters.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/459)
<!-- Reviewable:end -->
