### PR TITLE
Removes some v1-to-v2 transitional code

### DIFF
--- a/manage-cluster/bootstraplib.sh
+++ b/manage-cluster/bootstraplib.sh
@@ -360,7 +360,7 @@ EOF
 EOF
 
   # Configure root's account to be able to easily access kubectl as well as
-  # etcdctl and locksmithctl.  As we productionize this process, this code
+  # etcdctl. As we productionize this process, this code
   # should be deleted.
   gcloud compute ssh "${gce_name}" "${GCE_ARGS[@]}" <<\EOF
     set -x
@@ -390,6 +390,9 @@ EOF
 
     kubectl annotate node ${gce_name} flannel.alpha.coreos.com/public-ip-overwrite=${EXTERNAL_IP}
     kubectl label node ${gce_name} mlab/type=virtual
+
+    # As a final step, unmount the GCS bucket, as it is no longer needed.
+    umount ${K8S_PKI_DIR}
 EOF
 
   if [[ "${ETCD_CLUSTER_STATE}" == "new" ]]; then

--- a/manage-cluster/k8s_deploy.conf
+++ b/manage-cluster/k8s_deploy.conf
@@ -38,7 +38,7 @@ K8S_CERTMANAGER_VERSION="v0.15.2"
 K8S_CERTMANAGER_DNS01_SA="cert-manager-dns01-solver"
 K8S_CERTMANAGER_SA_KEY="cert-manager-credentials.json"
 K8S_CA_FILES="ca.crt ca.key sa.key sa.pub front-proxy-ca.crt front-proxy-ca.key etcd/ca.crt etcd/ca.key"
-K8S_PKI_DIR="/tmp/kubernetes-pki"
+K8S_PKI_DIR="/mnt/kubernetes-pki"
 K8S_CLUSTER_CIDR="192.168.0.0/16"
 K8S_SERVICE_CIDR="172.25.0.0/16"
 

--- a/manage-cluster/upgrade_master_platform_cluster.sh
+++ b/manage-cluster/upgrade_master_platform_cluster.sh
@@ -116,10 +116,8 @@ for zone in $GCE_ZONES; do
     kubeadm upgrade $UPGRADE_COMMAND
 
     # If this is the first API server being upgraded (i.e., UPGRADE_STATE=new),
-    # mount the GCS bucket, if it is not already mounted. When a master node is
-    # bootstrapped the GCS bucket will be mounted, but if the node gets
-    # rebooted for any reason then it will come back up without the bucket
-    # mounted and maybe even without the local directory existing.
+    # mount the GCS bucket, if it is not already mounted, which it shouldn't
+    # be, but we check just to be sure.
     if [[ $UPGRADE_STATE == "new" ]]; then
       # Create the mount point for the GCS bucket, if it doesn't already exist.
       # If the directory already exists, then this is a benign noop.

--- a/node/setup_k8s.sh.template
+++ b/node/setup_k8s.sh.template
@@ -40,35 +40,6 @@ MASTER_NODE="api-platform-cluster.${GCP_PROJECT}.measurementlab.net"
 # Capture K8S version for later usage.
 RELEASE=$(kubelet --version | awk '{print $2}')
 
-# TODO(https://github.com/m-lab/k8s-support/issues/29) This installation of
-# things into etc should be done as part of cloud-config.yml or ignition or just
-# something besides this script.
-# Startup configs for the kubelet
-# TODO(kinakde): This is transitional. The Ubuntu stage3 image has this baked
-# into the image. Once we have migrated fully to Ubuntu, this should be
-# removed.
-if ! [[ -f /etc/systemd/system/kubelet.service ]]; then
-  curl --silent --show-error --location \
-      "https://raw.githubusercontent.com/kubernetes/kubernetes/${RELEASE}/build/debs/kubelet.service" \
-      > /etc/systemd/system/kubelet.service
-fi
-
-# Add node tags to the kubelet so that node metadata is there right at the very
-# beginning.
-#
-# TODO: Add annotations to the node as well as labels. The annotations should
-#       contain most of /proc/cmdline as well as the args to this script.
-#
-# TODO(kinakde): This is transitional. The Ubuntu stage3 image has this baked
-# into the image. Once we have migrated fully to Ubuntu, this should be
-# removed.
-if ! [[ -f /etc/systemd/system/kubelet.service.d/10-kubeadm.conf ]]; then
-  mkdir --parents /etc/systemd/system/kubelet.service.d
-  curl --silent --show-error --location \
-      "https://raw.githubusercontent.com/kubernetes/kubernetes/${RELEASE}/build/debs/10-kubeadm.conf" \
-      > /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
-fi
-
 NODE_LABELS="mlab/machine=${MACHINE},mlab/site=${SITE},mlab/metro=${METRO},mlab/type=physical,mlab/project=${GCP_PROJECT}"
 DYNAMIC_CONFIG_DIR="/var/lib/kubelet/dynamic-configs"
 sed -ie "s|KUBELET_KUBECONFIG_ARGS=|KUBELET_KUBECONFIG_ARGS=--node-labels=$NODE_LABELS --dynamic-config-dir=$DYNAMIC_CONFIG_DIR |g" \
@@ -81,16 +52,6 @@ sed -ie "s|KUBELET_KUBECONFIG_ARGS=|KUBELET_KUBECONFIG_ARGS=--node-labels=$NODE_
 mkdir --parents /etc/kubernetes/manifests
 
 systemctl daemon-reload
-
-# CoreOS machines require this symlink. On Ubuntu machines, things are put in
-# the right place to begin with.
-#
-# TODO(kinakde): This is transitional. The Ubuntu stage3 image has this baked
-# into the image. Once we have migrated fully to Ubuntu, this should be
-# removed.
-if ! [[ -d "/opt/cni" ]]; then
-  ln --force --no-dereference --symbolic /usr/cni /opt/cni
-fi
 
 # Fetch k8s token via K8S_TOKEN_URL. Curl should report most errors to stderr,
 # so write stderr to a file so we can read any error code.


### PR DESCRIPTION
This PR should also resolve #29, I believe.

I'm not 100% sure, but I _believe_ this PR may also resolve #428. I can't recall now why that issue was opened, but it was definitely in response to some event. My recollection is that a node successfully joined the cluster but was not 100% functional in the way we need because some part of setup_k8s.sh failed. @stephen-soltesz: do you by chance recall the specific case that caused @pboothe to open this issue?

This PR also addresses a small potential issue with the GCS bucket being mounted in /tmp during bootstrap and upgrade. Since /tmp can be volatile, the mount is moved to /mnt.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/465)
<!-- Reviewable:end -->
