### PR TITLE
Makes terminationGracePeriodSeconds=180 a default for all experiments

### DIFF
--- a/k8s/certificates/measurement-lab.org.jsonnet
+++ b/k8s/certificates/measurement-lab.org.jsonnet
@@ -14,7 +14,7 @@
     issuerRef: {
       group: 'cert-manager.io',
       kind: 'ClusterIssuer',
-      name: if std.extVar('PROJECT_ID') == 'mlab-sandbox' then 'letsencrypt-staging' else 'letsencrypt',
+      name: 'letsencrypt',
     },
     secretName: 'measurement-lab-org-tls',
   },

--- a/k8s/daemonsets/experiments/ndt.jsonnet
+++ b/k8s/daemonsets/experiments/ndt.jsonnet
@@ -87,25 +87,6 @@ exp.Experiment(expName, 2, 'pusher-' + std.extVar('PROJECT_ID'), "none", datatyp
         ] + [
           exp.SOCATProxy('ndt-server', 9990)
         ],
-        // The default grace period after k8s sends SIGTERM is 30s. We
-        // extend the grace period to give time for the following
-        // shutdown sequence. After the grace period, kubernetes sends
-        // SIGKILL.
-        //
-        // NDT pod shutdown sequence:
-        //
-        //  * k8s sends SIGTERM to NDT server
-        //  * NDT server enables lame duck status
-        //  * monitoring reads lame duck status (60s max)
-        //  * mlab-ns updates server status (60s max)
-        //  * all currently running tests complete. (30s max)
-        //
-        // Feel free to change this to a smaller value for speedy
-        // sandbox deployments to enable faster compile-run-debug loops,
-        // but 60+60+30=150 is what it needs to be for staging and prod.
-        //
-        // Only enable grace period where production traffic is possible.
-        [if std.extVar('PROJECT_ID') != 'mlab-sandbox' then 'terminationGracePeriodSeconds']: 180,
         volumes+: [
           {
             name: 'measurement-lab-org-tls',

--- a/k8s/daemonsets/experiments/ndtcloud.jsonnet
+++ b/k8s/daemonsets/experiments/ndtcloud.jsonnet
@@ -33,7 +33,7 @@ exp.ExperimentNoIndex(expName, 'pusher-ndtcloud-' + std.extVar('PROJECT_ID'), "n
           exp.RBACProxy(expName, 9990),
 
         ],
-        [if std.extVar('PROJECT_ID') != 'mlab-sandbox' then 'terminationGracePeriodSeconds']: exp.terminationGracePeriodSeconds ,
+        [if std.extVar('PROJECT_ID') != 'mlab-sandbox' then 'terminationGracePeriodSeconds']: exp.terminationGracePeriodSeconds,
         volumes+: [
           {
             name: 'measurement-lab-org-tls',

--- a/k8s/daemonsets/experiments/ndtcloud.jsonnet
+++ b/k8s/daemonsets/experiments/ndtcloud.jsonnet
@@ -33,24 +33,7 @@ exp.ExperimentNoIndex(expName, 'pusher-ndtcloud-' + std.extVar('PROJECT_ID'), "n
           exp.RBACProxy(expName, 9990),
 
         ],
-
-        // The default grace period after k8s sends SIGTERM is 30s. We
-        // extend the grace period to give time for the following
-        // shutdown sequence. After the grace period, kubernetes sends
-        // SIGKILL.
-        //
-        // NDT pod shutdown sequence:
-        //
-        //  * k8s sends SIGTERM to NDT server
-        //  * NDT server enables lame duck status
-        //  * monitoring reads lame duck status (60s max)
-        //  * mlab-ns updates server status (60s max)
-        //  * all currently running tests complete. (30s max)
-        //
-        // Feel free to change this to a smaller value for speedy
-        // sandbox deployments to enable faster compile-run-debug loops,
-        // but 60+60+30=150 is what it needs to be for staging and prod.
-        [if std.extVar('PROJECT_ID') != 'mlab-sandbox' then 'terminationGracePeriodSeconds']: 180,
+        [if std.extVar('PROJECT_ID') != 'mlab-sandbox' then 'terminationGracePeriodSeconds']: exp.terminationGracePeriodSeconds ,
         volumes+: [
           {
             name: 'measurement-lab-org-tls',

--- a/k8s/daemonsets/experiments/neubot.jsonnet
+++ b/k8s/daemonsets/experiments/neubot.jsonnet
@@ -57,7 +57,6 @@ exp.Experiment(expName, 10, 'pusher-' + std.extVar('PROJECT_ID'), "none", dataty
             },
           },
         ],
-        [if std.extVar('PROJECT_ID') != 'mlab-sandbox' then 'terminationGracePeriodSeconds']: 180,
         volumes+: [
           {
             name: 'measurement-lab-org-tls',

--- a/k8s/daemonsets/experiments/revtr.jsonnet
+++ b/k8s/daemonsets/experiments/revtr.jsonnet
@@ -12,9 +12,9 @@ exp.Experiment('revtr', 3, 'pusher-' + std.extVar('PROJECT_ID'), 'none', ['traff
               '/root.crt',
               '/plvp.config',
             ],
-			volumeMounts: [
-			  exp.VolumeMount('revtr/traffic'),
-			],
+            volumeMounts: [
+              exp.VolumeMount('revtr/traffic'),
+            ],
           }
         ],
       }

--- a/k8s/daemonsets/experiments/revtr.jsonnet
+++ b/k8s/daemonsets/experiments/revtr.jsonnet
@@ -17,7 +17,6 @@ exp.Experiment('revtr', 3, 'pusher-' + std.extVar('PROJECT_ID'), 'none', ['traff
 			],
                     }
                 ],
-                [if std.extVar('PROJECT_ID') != 'mlab-sandbox' then 'terminationGracePeriodSeconds']: 180,
             }
         }
     }

--- a/k8s/daemonsets/experiments/revtr.jsonnet
+++ b/k8s/daemonsets/experiments/revtr.jsonnet
@@ -1,23 +1,23 @@
 local exp = import '../templates.jsonnet';
 
 exp.Experiment('revtr', 3, 'pusher-' + std.extVar('PROJECT_ID'), 'none', ['traffic']) + {
-    spec+: {
-        template+: {
-            spec+: {
-                containers+: [
-                    {
-                        name: 'revtrvp',
-                        image: 'measurementlab/revtrvp:v0.0.5',
-                        args: [
-                            '/root.crt',
-                            '/plvp.config',
-                        ],
+  spec+: {
+    template+: {
+      spec+: {
+        containers+: [
+          {
+            name: 'revtrvp',
+            image: 'measurementlab/revtrvp:v0.0.5',
+            args: [
+              '/root.crt',
+              '/plvp.config',
+            ],
 			volumeMounts: [
 			  exp.VolumeMount('revtr/traffic'),
 			],
-                    }
-                ],
-            }
-        }
+          }
+        ],
+      }
     }
+  }
 }

--- a/k8s/daemonsets/experiments/wehe.jsonnet
+++ b/k8s/daemonsets/experiments/wehe.jsonnet
@@ -57,7 +57,6 @@ exp.Experiment(expName, 5, 'pusher-' + std.extVar('PROJECT_ID'), 'netblock', ['r
             ],
           },
         ],
-        [if std.extVar('PROJECT_ID') != 'mlab-sandbox' then 'terminationGracePeriodSeconds']: 180,
         volumes+: [
           {
             emptyDir: {},

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -1,5 +1,6 @@
 local ndtVersion = 'v0.20.1';
 local PROJECT_ID = std.extVar('PROJECT_ID');
+local terminationGracePeriodSeconds = 180;
 
 local uuid = {
   initContainer: {
@@ -266,7 +267,7 @@ local Pusher(expName, tcpPort, datatypes, hostNetwork, bucket) = [
       '-bucket=' + bucket,
       '-experiment=' + expName,
       '-archive_size_threshold=50MB',
-      '-sigterm_wait_time=120s',
+      '-sigterm_wait_time=' + std.toString(terminationGracePeriodSeconds - 60) + 's',
       '-directory=/var/spool/' + expName,
       '-metadata=MLAB.server.name=$(MLAB_NODE_NAME)',
       '-metadata=MLAB.experiment.name=' + expName,
@@ -477,6 +478,23 @@ local Experiment(name, index, bucket, anonMode, datatypes=[]) = ExperimentNoInde
             ],
           },
         ],
+        // The default grace period after k8s sends SIGTERM is 30s. We
+        // extend the grace period to give time for the following
+        // shutdown sequence. After the grace period, kubernetes sends
+        // SIGKILL.
+        //
+        // Expected container shutdown sequence:
+        //
+        //  * k8s sends SIGTERM to container
+        //  * container enables lame duck status
+        //  * monitoring reads lame duck status (60s max)
+        //  * mlab-ns updates server status (60s max)
+        //  * all currently running tests complete. (30s max)
+        //  * give everything an additional 30s to be safe
+        //  * 60s + 60s + 30s + 30s = 180s grace period
+        //
+        // Only enable extended grace period where production traffic is possible.
+        [if std.extVar('PROJECT_ID') != 'mlab-sandbox' then 'terminationGracePeriodSeconds']: terminationGracePeriodSeconds,
       },
     },
   },
@@ -515,4 +533,7 @@ local Experiment(name, index, bucket, anonMode, datatypes=[]) = ExperimentNoInde
 
   // The NDT tag to use for containers.
   ndtVersion: ndtVersion,
+
+  // How long k8s shoudl give a pod to shut itself down cleanly.
+  terminationGracePeriodSeconds: terminationGracePeriodSeconds,
 }


### PR DESCRIPTION
Currently, each experiment defines its own `terminationGracePeriodSeconds` for its pods. In all cases it is 180s. To simplify and standardize this, this PR sets the default `terminationGracePeriodSeconds` to 180 in the template for all experiments. Also of note is that the pusher container's `-sigterm_wait_time` flag is now automatically calculated as `terminationGracePeriodSeconds - 60` instead of being hardcoded at 120s.

This PR also modifies the revtr jsonnet file to use 2-space indents to conform with every other jsonnet file we have.

This PR should resolve issue #354.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/466)
<!-- Reviewable:end -->
