### PR TITLE
Sets Kured period to 1h (the default), down from 24h.

### DIFF
--- a/k8s/daemonsets/core/kured.jsonnet
+++ b/k8s/daemonsets/core/kured.jsonnet
@@ -26,7 +26,7 @@
           {
             args: [
               '--reboot-sentinel=/var/run/mlab-reboot',
-              '--period=24h',
+              '--period=1h',
               // We may or may not want to enable something like the following
               // schedule for reboots. For now it is commented out until we can
               // gather more experience with Kured.


### PR DESCRIPTION
Having the period at 24h does not seem to produce speedy rolling reboots. A rolling reboot that I initiated in staging on 2020-07-22 and 10:50Z is still running, with ~25 node still remaining to reboot. This PR reduced the "period" to 1h, which is Kured's default. We will see if this makes for speedier rolling reboots.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/469)
<!-- Reviewable:end -->
