### PR TITLE
Scrape the token-server in the API cluster.

### DIFF
--- a/config/prometheus.jsonnet
+++ b/config/prometheus.jsonnet
@@ -2,7 +2,7 @@ local cmutil = import 'configmap.jsonnet';
 
 local data = {
     'rules.yml': importstr 'prometheus/rules.yml',
-    'prometheus.yml': importstr 'prometheus/prometheus.yml',
+    'prometheus.yml': std.strReplace(importstr 'prometheus/prometheus.yml', '{{PROJECT}}', std.extVar('PROJECT_ID')),
 };
 
 {

--- a/config/prometheus/prometheus.yml
+++ b/config/prometheus/prometheus.yml
@@ -284,3 +284,13 @@ scrape_configs:
       - source_labels: [__meta_kubernetes_pod_container_name]
         action: replace
         target_label: container
+
+  # Scrape the token-server. The address we are scraping is actually a GCP
+  # internal load balancer. Scraping the load balancer address won't guarantee
+  # that all token-server instances are up and running, but more importantly
+  # will let us know whether enough are up to satisfy a booting machine.
+  - job_name: 'token-server'
+    scheme: http
+    static_configs:
+      - targets: ['token-server.{{PROJECT}}.measurementlab.net:8800']
+


### PR DESCRIPTION
The PR implements scraping the token-server load balancer in each project for the purposes of alerting on when token-server functionality is missing in a cluster. It will not guarantee that every token-server instance is up and running, but that enough are up and running to satisfy the requirements of a booting machine.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/470)
<!-- Reviewable:end -->
