### PR TITLE
Enables the token-server.service.

### DIFF
--- a/manage-cluster/cloud-config_master.yml
+++ b/manage-cluster/cloud-config_master.yml
@@ -168,3 +168,5 @@ runcmd:
 - systemctl start token-server.service
 - systemctl start gcp-loadbalancer-proxy.service
 - systemctl enable reboot-node.service
+- systemctl enable token-server.service
+


### PR DESCRIPTION
Currently, the token-server.service is installed, but not actually enabled by default, so if a master server reboots the token-server service will not start.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/471)
<!-- Reviewable:end -->
