### PR TITLE
Both enable _and_ start various systemd units.

### DIFF
--- a/manage-cluster/cloud-config_master.yml
+++ b/manage-cluster/cloud-config_master.yml
@@ -165,8 +165,10 @@ runcmd:
 - systemctl daemon-reload
 - systemctl enable docker
 - systemctl start docker
-- systemctl start token-server.service
+- systemctl enable gcp-loadbalancer-proxy.service
 - systemctl start gcp-loadbalancer-proxy.service
-- systemctl enable reboot-node.service
+- systemctl enable reboot-node.timer
+- systemctl start reboot-node.timer
 - systemctl enable token-server.service
+- systemctl start token-server.service
 


### PR DESCRIPTION
Currently, there are a few important systemd unit services and timers which are not enabled by default. They may start up during cloud-init, but may not be started on subsequent reboots. This PR explicitly both enables and starts any necessary services.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/472)
<!-- Reviewable:end -->
