### PR TITLE
Bumps revtr version to v0.1.0.

### DIFF
--- a/k8s/daemonsets/experiments/revtr.jsonnet
+++ b/k8s/daemonsets/experiments/revtr.jsonnet
@@ -7,7 +7,7 @@ exp.Experiment('revtr', 3, 'pusher-' + std.extVar('PROJECT_ID'), 'none', ['traff
         containers+: [
           {
             name: 'revtrvp',
-            image: 'measurementlab/revtrvp:v0.0.5',
+            image: 'measurementlab/revtrvp:v0.1.0',
             args: [
               '/root.crt',
               '/plvp.config',


### PR DESCRIPTION
This is a no-op PR, since v0.0.13 and v0.1.0 are identical. v0.0.13 felt too alpha to deploy to production, so I tagged a new release versioned v0.1.0, a good base from which we can proceed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/473)
<!-- Reviewable:end -->
