### PR TITLE
Sets the flag --annotation-ttl=4h for Kured.

### DIFF
--- a/k8s/daemonsets/core/kured.jsonnet
+++ b/k8s/daemonsets/core/kured.jsonnet
@@ -27,6 +27,7 @@
             args: [
               '--reboot-sentinel=/var/run/mlab-reboot',
               '--period=1h',
+              '--annotation-ttl=4h',
               // We may or may not want to enable something like the following
               // schedule for reboots. For now it is commented out until we can
               // gather more experience with Kured.


### PR DESCRIPTION
By default, the Kured lock annotation has no expiration, which means that a node could hold the lock forever, or until an operator intervenes. For example, if a node goes to reboot itself and hold the lock, but fails to come back up because of some network or hardware failure, then the entire rolling reboot will be indefinitely held up until an operator intervenes.

This PR sets a timeout on the lock annotation of 4h. If there is some fundamental issue with the boot images preventing machines from coming backup up and joining the cluster, then at most 6 machines in a 24h period could reboot themselves and not come back up. Before this situation became critical, we would get an alert that more than N% of ndt servers are down. We should additionally get alerts from ePoxy about nodes rebooting, but not coming back up.

This setting change should keep rolling reboots from completely stalling due to one or two failed nodes, while still being conservative enough to not allow too many nodes to go down before some alert would fire, notifying an operator of an issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/474)
<!-- Reviewable:end -->
