### PR TITLE
Disables the --annotation-ttl flag in Kured + plus update Wehe and Disco

### DIFF
--- a/k8s/daemonsets/core/disco.jsonnet
+++ b/k8s/daemonsets/core/disco.jsonnet
@@ -1,7 +1,7 @@
 local exp = import '../templates.jsonnet';
 local expName = 'disco';
 local config = import '../../../config/disco.jsonnet';
-local version = 'v0.1.4';
+local version = 'v0.1.6';
 
 {
   apiVersion: 'apps/v1',

--- a/k8s/daemonsets/core/kured.jsonnet
+++ b/k8s/daemonsets/core/kured.jsonnet
@@ -27,7 +27,9 @@
             args: [
               '--reboot-sentinel=/var/run/mlab-reboot',
               '--period=1h',
-              '--annotation-ttl=4h',
+              // Annotation TTL should stay disabled until this bug is close:
+              // https://github.com/weaveworks/kured/issues/143
+              // '--annotation-ttl=4h',
               // We may or may not want to enable something like the following
               // schedule for reboots. For now it is commented out until we can
               // gather more experience with Kured.

--- a/k8s/daemonsets/experiments/wehe.jsonnet
+++ b/k8s/daemonsets/experiments/wehe.jsonnet
@@ -33,6 +33,7 @@ exp.Experiment(expName, 5, 'pusher-' + std.extVar('PROJECT_ID'), 'netblock', ['r
           {
             args: [
               'wehe.$(MLAB_NODE_NAME)',
+              'net1',
             ],
             env: [
               {
@@ -44,7 +45,7 @@ exp.Experiment(expName, 5, 'pusher-' + std.extVar('PROJECT_ID'), 'netblock', ['r
                 },
               },
             ],
-            image: 'measurementlab/wehe-py3:v0.1.0',
+            image: 'measurementlab/wehe-py3:v0.1.7',
             name: expName,
             volumeMounts: [
               exp.VolumeMount('wehe/replay') + {


### PR DESCRIPTION
Today, while monitoring a rolling reboot of the production cluster I noticed that there were around 30 nodes in a `Ready,SchedulingDisabled` state. All of the nodes in that state rebooted at around the same time, which shouldn't happen since Kured is supposed to ensure that only a single node is rebooting at a time. Additionally, all of the nodes appeared to reboot themselves right at the termination of the `--annotation-ttl` period of 4h. A quick search turned up an issue on the Kured repo revealing a bug with the flag:

https://github.com/weaveworks/kured/issues/143

This PR reverts using the `--annotation-ttl` flag until that bug is resolved.

On the coattails of this PR is a bump to the latest stable versions of Wehe and Disco.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/476)
<!-- Reviewable:end -->
