### PR TITLE
Writes DISCOv2 data at utilization/switch

### DIFF
--- a/k8s/daemonsets/core/disco.jsonnet
+++ b/k8s/daemonsets/core/disco.jsonnet
@@ -70,7 +70,7 @@ local version = 'v0.1.7';
               },
             ],
             volumeMounts: [
-              exp.VolumeMount(expName),
+              exp.VolumeMount('utilization'),
               {
                 mountPath: '/etc/' + expName,
                 name: expName + '-config',
@@ -92,9 +92,9 @@ local version = 'v0.1.7';
             },
           },
           {
-            name: expName + '-data',
+            name: 'utilization' + '-data',
             hostPath: {
-              path: '/cache/data/' + expName,
+              path: '/cache/data/utilization',
               type: 'DirectoryOrCreate',
             },
           },

--- a/k8s/daemonsets/core/disco.jsonnet
+++ b/k8s/daemonsets/core/disco.jsonnet
@@ -30,7 +30,7 @@ local version = 'v0.1.7';
         containers: [
           {
             args: [
-              '-datadir=/var/spool/utilization,
+              '-datadir=/var/spool/utilization',
               '-write-interval=5m',
               '-prometheusx.listen-address=$(PRIVATE_IP):9990',
               '-metrics=/etc/' + expName + '/metrics.yaml',

--- a/k8s/daemonsets/core/disco.jsonnet
+++ b/k8s/daemonsets/core/disco.jsonnet
@@ -30,7 +30,7 @@ local version = 'v0.1.7';
         containers: [
           {
             args: [
-              '-datadir=/var/spool/' + expName,
+              '-datadir=/var/spool/utilization,
               '-write-interval=5m',
               '-prometheusx.listen-address=$(PRIVATE_IP):9990',
               '-metrics=/etc/' + expName + '/metrics.yaml',
@@ -78,7 +78,7 @@ local version = 'v0.1.7';
               },
             ],
           }] + std.flattenArrays([
-            exp.Pusher(expName, 9995, ['switch'], false, 'pusher-' + std.extVar('PROJECT_ID')),
+            exp.Pusher('utilization', 9995, ['switch'], false, 'pusher-' + std.extVar('PROJECT_ID')),
           ]),
         nodeSelector: {
           'mlab/type': 'physical',


### PR DESCRIPTION
Currently, DISCOv2 writes data to `disco/switch`, which is different than where the current utilization experiment writes data, which is `utilization/switch`. For the sake of continuity of data, names and locations, this PR changes the DISCOv2 experiment to write data to `utilization/switch`.  The experiment, container and DaemonSet are still known as `disco`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/480)
<!-- Reviewable:end -->
