### PR TITLE
Max timeout and new envelope version

### DIFF
--- a/k8s/daemonsets/experiments/wehe.jsonnet
+++ b/k8s/daemonsets/experiments/wehe.jsonnet
@@ -43,11 +43,10 @@ exp.Experiment(expName, 5, 'pusher-' + std.extVar('PROJECT_ID'), 'netblock', ['r
               '-envelope.device=net1',
               // TODO: require tokens after clients support envelope.
               '-envelope.token-required=false',
-              // NOTE: only support ipv4 connections to the envelope.
-              // NOTE: TODO: this does not block ipv6 connections to the service.
-              '-httpx.tcp-network=tcp4',
+              // Maximum timeout for a client to hold the envelope open.
+              '-timeout=10m',
             ],
-            image: 'measurementlab/access:v0.0.1',
+            image: 'measurementlab/access:v0.0.2',
             name: 'access',
             securityContext: {
               capabilities: {


### PR DESCRIPTION
This change updates the envelope version to v0.0.2 which adds dualstack support to the envelope and sets a max timeout of 10m to allow very long measurement runs by wehe clients.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/481)
<!-- Reviewable:end -->
