### PR TITLE
Add experimental iperf3 envelope

### DIFF
--- a/k8s/daemonsets/experiments/iperf3.jsonnet
+++ b/k8s/daemonsets/experiments/iperf3.jsonnet
@@ -20,8 +20,6 @@ exp.Experiment(expName, 6, 'pusher-' + std.extVar('PROJECT_ID'), 'netblock', ['t
               '-envelope.subject=iperf3',
               '-envelope.machine=$(MLAB_NODE_NAME)',
               '-envelope.verify-key=/verify/jwk_sig_EdDSA_locate_20200409.pub',
-              // TODO: require tokens after clients support envelope.
-              // '-envelope.token-required=false',
               // Maximum timeout for a client to hold the envelope open.
               '-timeout=2m',
             ],

--- a/k8s/daemonsets/experiments/iperf3.jsonnet
+++ b/k8s/daemonsets/experiments/iperf3.jsonnet
@@ -19,6 +19,7 @@ exp.Experiment(expName, 6, 'pusher-' + std.extVar('PROJECT_ID'), 'netblock', ['t
               '-envelope.device=net1',
               '-envelope.subject=iperf3',
               '-envelope.machine=$(MLAB_NODE_NAME)',
+              '-envelope.verify-key=/verify/jwk_sig_EdDSA_locate_20200409.pub',
               // TODO: require tokens after clients support envelope.
               // '-envelope.token-required=false',
               // Maximum timeout for a client to hold the envelope open.
@@ -49,6 +50,11 @@ exp.Experiment(expName, 6, 'pusher-' + std.extVar('PROJECT_ID'), 'netblock', ['t
                 name: 'measurement-lab-org-tls',
                 readOnly: true,
               },
+              {
+                mountPath: '/verify',
+                name: 'locate-verify-keys',
+                readOnly: true,
+              },
             ],
           },
           {
@@ -63,6 +69,12 @@ exp.Experiment(expName, 6, 'pusher-' + std.extVar('PROJECT_ID'), 'netblock', ['t
             name: 'measurement-lab-org-tls',
             secret: {
               secretName: 'measurement-lab-org-tls',
+            },
+          },
+          {
+            name: 'locate-verify-keys',
+            secret: {
+              secretName: 'locate-verify-keys',
             },
           },
         ],

--- a/k8s/daemonsets/experiments/iperf3.jsonnet
+++ b/k8s/daemonsets/experiments/iperf3.jsonnet
@@ -17,10 +17,22 @@ exp.Experiment(expName, 6, 'pusher-' + std.extVar('PROJECT_ID'), 'netblock', ['t
               '-envelope.cert=/certs/tls.crt',
               '-envelope.listen-address=:443',
               '-envelope.device=net1',
+              '-envelope.subject=iperf3',
+              '-envelope.machine=$(MLAB_NODE_NAME)',
               // TODO: require tokens after clients support envelope.
               // '-envelope.token-required=false',
               // Maximum timeout for a client to hold the envelope open.
               '-timeout=2m',
+            ],
+            env: [
+              {
+                name: 'MLAB_NODE_NAME',
+                valueFrom: {
+                  fieldRef: {
+                    fieldPath: 'spec.nodeName',
+                  },
+                },
+              },
             ],
             image: 'measurementlab/access:v0.0.2',
             name: 'access',

--- a/k8s/daemonsets/experiments/iperf3.jsonnet
+++ b/k8s/daemonsets/experiments/iperf3.jsonnet
@@ -18,7 +18,7 @@ exp.Experiment(expName, 6, 'pusher-' + std.extVar('PROJECT_ID'), 'netblock', ['t
               '-envelope.listen-address=:443',
               '-envelope.device=net1',
               // TODO: require tokens after clients support envelope.
-              '-envelope.token-required=false',
+              // '-envelope.token-required=false',
               // Maximum timeout for a client to hold the envelope open.
               '-timeout=2m',
             ],

--- a/k8s/daemonsets/experiments/iperf3.jsonnet
+++ b/k8s/daemonsets/experiments/iperf3.jsonnet
@@ -18,7 +18,7 @@ exp.Experiment(expName, 6, 'pusher-' + std.extVar('PROJECT_ID'), 'netblock', ['t
               '-envelope.listen-address=:443',
               '-envelope.device=net1',
               // TODO: require tokens after clients support envelope.
-              // '-envelope.token-required=false',
+              '-envelope.token-required=false',
               // Maximum timeout for a client to hold the envelope open.
               '-timeout=2m',
             ],

--- a/k8s/daemonsets/experiments/iperf3.jsonnet
+++ b/k8s/daemonsets/experiments/iperf3.jsonnet
@@ -1,0 +1,60 @@
+local exp = import '../templates.jsonnet';
+local expName = 'iperf3';
+
+exp.Experiment(expName, 6, 'pusher-' + std.extVar('PROJECT_ID'), 'netblock', ['test']) + {
+  spec+: {
+    template+: {
+      metadata+: {
+        annotations+: {
+          'secret.reloader.stakater.com/reload': 'measurement-lab-org-tls',
+        },
+      },
+      spec+: {
+        containers+: [
+          {
+            args: [
+              '-envelope.key=/certs/tls.key',
+              '-envelope.cert=/certs/tls.crt',
+              '-envelope.listen-address=:443',
+              '-envelope.device=net1',
+              // TODO: require tokens after clients support envelope.
+              '-envelope.token-required=false',
+              // Maximum timeout for a client to hold the envelope open.
+              '-timeout=2m',
+            ],
+            image: 'measurementlab/access:v0.0.2',
+            name: 'access',
+            securityContext: {
+              capabilities: {
+                add: [
+                  'NET_ADMIN',
+                ],
+              },
+            },
+            volumeMounts: [
+              {
+                mountPath: '/certs',
+                name: 'measurement-lab-org-tls',
+                readOnly: true,
+              },
+            ],
+          },
+          {
+            # Start the iperf3 server.
+            args: [ '-s' ],
+            image: 'soltesz/iperf3:v0.0',
+            name: expName,
+          },
+        ],
+        volumes+: [
+          {
+            name: 'measurement-lab-org-tls',
+            secret: {
+              secretName: 'measurement-lab-org-tls',
+            },
+          },
+        ],
+      },
+    },
+  },
+}

--- a/k8s/daemonsets/experiments/iperf3.jsonnet
+++ b/k8s/daemonsets/experiments/iperf3.jsonnet
@@ -33,7 +33,7 @@ exp.Experiment(expName, 6, 'pusher-' + std.extVar('PROJECT_ID'), 'netblock', ['t
                 },
               },
             ],
-            image: 'measurementlab/access:v0.0.2',
+            image: 'measurementlab/access:v0.0.3',
             name: 'access',
             securityContext: {
               capabilities: {

--- a/k8s/daemonsets/experiments/iperf3.jsonnet
+++ b/k8s/daemonsets/experiments/iperf3.jsonnet
@@ -33,7 +33,7 @@ exp.Experiment(expName, 6, 'pusher-' + std.extVar('PROJECT_ID'), 'netblock', ['t
                 },
               },
             ],
-            image: 'measurementlab/access:v0.0.3',
+            image: 'soltesz/access:v0.4',
             name: 'access',
             securityContext: {
               capabilities: {

--- a/system.jsonnet
+++ b/system.jsonnet
@@ -35,6 +35,11 @@
     if std.extVar('PROJECT_ID') != 'mlab-oti'
     then [import 'k8s/daemonsets/experiments/wehe.jsonnet']
     else []
+  ) + (
+    // Only deploy iperf3 to sandbox.
+    if std.extVar('PROJECT_ID') == 'mlab-sandbox'
+    then [import 'k8s/daemonsets/experiments/iperf3.jsonnet']
+    else []
   ) + [
     // Deployments
     import 'k8s/deployments/kube-state-metrics.jsonnet',


### PR DESCRIPTION
This change adds an experimental configuration for iperf3 server behind the access envelope. Note: this depends on uncommitted sandbox changes to siteinfo and locate configs. So, this will not work in general without permanent changes to those repos. This change is an example of a complete envelope config. It can be improved by creating a new experiment template for running things within an `exp.EnvelopeExperiment()` or similar.

This should not move out of sandbox until the iperf server allows setting a hard deadline after starting a measurement. As currently constituted, a client could start a very long measurement and if the connection is never closed, could remain open indefinitely to the iperf server.

At the moment the following is possible (measuring the upload path from my home system):

```
$ iperf3 -c iperf3-mlab4-lga0t.mlab-sandbox.measurement-lab.org
iperf3: error - unable to connect to server: Connection refused

$ envelope-exec -envelope-key wss:///v0/envelope/access -service iperf3/test -timeout=2m  -logx.debug=true -- bash -c 'iperf3 -c $SERVICE_HOSTNAME'
2020/08/12 22:06:13 DEBUG: Issue request to: iperf3-mlab4-lga0t.mlab-sandbox.measurement-lab.org
2020/08/12 22:06:13 DEBUG: Exec: [bash -c iperf3 -c $SERVICE_HOSTNAME]
Connecting to host iperf3-mlab4-lga0t.mlab-sandbox.measurement-lab.org, port 5201
[  8] local 192.168.2.167 port 59611 connected to 4.14.159.118 port 5201
[ ID] Interval           Transfer     Bitrate
[  8]   0.00-1.00   sec  2.82 MBytes  23.6 Mbits/sec                  
[  8]   1.00-2.00   sec  2.61 MBytes  21.9 Mbits/sec                  
[  8]   2.00-3.00   sec  2.79 MBytes  23.4 Mbits/sec                  
[  8]   3.00-4.00   sec  2.71 MBytes  22.7 Mbits/sec                  
[  8]   4.00-5.00   sec  2.75 MBytes  23.0 Mbits/sec                  
[  8]   5.00-6.00   sec  2.82 MBytes  23.6 Mbits/sec                  
[  8]   6.00-7.00   sec  2.83 MBytes  23.7 Mbits/sec                  
[  8]   7.00-8.00   sec  2.60 MBytes  21.7 Mbits/sec                  
[  8]   8.00-9.00   sec  2.74 MBytes  23.0 Mbits/sec                  
[  8]   9.00-10.00  sec  2.80 MBytes  23.5 Mbits/sec                  
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bitrate
[  8]   0.00-10.00  sec  27.5 MBytes  23.0 Mbits/sec                  sender
[  8]   0.00-10.01  sec  27.3 MBytes  22.9 Mbits/sec                  receiver

iperf Done.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/482)
<!-- Reviewable:end -->
