### PR TITLE
Patches Vector DS to add standard `workload` label to DS pods

### DIFF
--- a/config/vector/values.yaml.template
+++ b/config/vector/values.yaml.template
@@ -12,9 +12,11 @@ extraVolumes:
 extraVolumeMounts:
 - name: docker
   mountPath: /cache/docker/containers
-- mountPath: /etc/vector/keys
-  name: credentials
+- name: credentials
+  mountPath: /etc/vector/keys
   readOnly: true
+podAnnotations:
+  prometheus.io/scrape: true
 sinks:
   stackdriver:
     type: gcp_stackdriver_logs

--- a/config/vector/values.yaml.template
+++ b/config/vector/values.yaml.template
@@ -16,7 +16,7 @@ extraVolumeMounts:
   mountPath: /etc/vector/keys
   readOnly: true
 podAnnotations:
-  prometheus.io/scrape: true
+  prometheus.io/scrape: "true"
 sinks:
   stackdriver:
     type: gcp_stackdriver_logs

--- a/config/vector/values.yaml.template
+++ b/config/vector/values.yaml.template
@@ -15,8 +15,6 @@ extraVolumeMounts:
 - name: credentials
   mountPath: /etc/vector/keys
   readOnly: true
-podAnnotations:
-  prometheus.io/scrape: "true"
 sinks:
   stackdriver:
     type: gcp_stackdriver_logs

--- a/manage-cluster/apply_k8s_configs.sh
+++ b/manage-cluster/apply_k8s_configs.sh
@@ -81,6 +81,13 @@ sed -e "s/{{PROJECT}}/${PROJECT}/" ../config/vector/values.yaml.template \
   --values ../config/vector/values.yaml \
   vector/vector
 
+# TODO(kinkade) Currently, the helm template for the Vector DaemonSet does not
+# allow you to modify Pod labels. This patch command adds M-Lab's standard
+# `workload` label. It would seem reasonable to consider submitting a PR
+# upstream to add the ability to modify Pod labels via values.yaml.
+kubectl patch daemonset vector --type='json' \
+  --patch='[{"op":"add", "path":"/spec/template/metadata/labels/workload", "value":"vector"}]'
+
 # Apply the configuration
 
 # The configurations of the secrets for the cluster happen in a separate

--- a/manage-cluster/apply_k8s_configs.sh
+++ b/manage-cluster/apply_k8s_configs.sh
@@ -83,8 +83,12 @@ sed -e "s/{{PROJECT}}/${PROJECT}/" ../config/vector/values.yaml.template \
 
 # TODO(kinkade) Currently, the helm template for the Vector DaemonSet does not
 # allow you to modify Pod labels. This patch command adds M-Lab's standard
-# `workload` label. It would seem reasonable to consider submitting a PR
-# upstream to add the ability to modify Pod labels via values.yaml.
+# `workload` label. A [feature # request](https://github.com/timberio/vector/issues/3568)
+# has already been submitted, but it would seem reasonable to consider submitting a PR
+# upstream to add the ability to modify Pod labels via values.yaml. NOTE: we
+# are using `patch` here (instead of the simpler `label` because we need to
+# modify the pod template specification of the DaemonSet, not the DaemonSet
+# itself.
 kubectl patch daemonset vector --type='json' \
   --patch='[{"op":"add", "path":"/spec/template/metadata/labels/workload", "value":"vector"}]'
 


### PR DESCRIPTION
Vector is installed via Helm, and the Vector Helm DaemonSet template does not currently allow one to modify pod labels (it does  allow you to modify pod annotations). This PR adds a kubectl-patch command which adds our standard `workload=<name>` pod label.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/484)
<!-- Reviewable:end -->
