### PR TITLE
Bumps disco version to v0.1.8.

### DIFF
--- a/k8s/daemonsets/core/disco.jsonnet
+++ b/k8s/daemonsets/core/disco.jsonnet
@@ -1,7 +1,7 @@
 local exp = import '../templates.jsonnet';
 local expName = 'disco';
 local config = import '../../../config/disco.jsonnet';
-local version = 'v0.1.7';
+local version = 'v0.1.8';
 
 {
   apiVersion: 'apps/v1',


### PR DESCRIPTION
This PR updates the disco version to v0.1.8, which causes disco to include a `counter` value in every sample.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/485)
<!-- Reviewable:end -->
