### PR TITLE
Bumps revtr to v0.1.4.

### DIFF
--- a/k8s/daemonsets/experiments/revtr.jsonnet
+++ b/k8s/daemonsets/experiments/revtr.jsonnet
@@ -6,7 +6,7 @@ exp.Experiment('revtr', 3, 'pusher-' + std.extVar('PROJECT_ID'), 'none', []) + {
       spec+: {
         containers+: [
           {
-            name: 'revtr',
+            name: 'revtrvp',
             image: 'measurementlab/revtrvp:v0.1.4',
             args: [
               '/root.crt',

--- a/k8s/daemonsets/experiments/revtr.jsonnet
+++ b/k8s/daemonsets/experiments/revtr.jsonnet
@@ -1,19 +1,16 @@
 local exp = import '../templates.jsonnet';
 
-exp.Experiment('revtr', 3, 'pusher-' + std.extVar('PROJECT_ID'), 'none', ['traffic']) + {
+exp.Experiment('revtr', 3, 'pusher-' + std.extVar('PROJECT_ID'), 'none', []) + {
   spec+: {
     template+: {
       spec+: {
         containers+: [
           {
-            name: 'revtrvp',
-            image: 'measurementlab/revtrvp:v0.1.0',
+            name: 'revtr',
+            image: 'measurementlab/revtrvp:v0.1.4',
             args: [
               '/root.crt',
               '/plvp.config',
-            ],
-            volumeMounts: [
-              exp.VolumeMount('revtr/traffic'),
             ],
           }
         ],


### PR DESCRIPTION
This PR bumps RevTr to v0.1.4, which supposedly, apparently and hopefully stops it from writing any data to /var/spool/revtr/traffic, which maps to /cache/data/revtr/traffic.

It also:
* removes the `[traffic]` datatype from the Pusher config.
* removes the volumeMount for /var/spool/revtr onto /cache/data.
* changes the container name from `revtrvp` to just `revtr`, which better complies with M-Lab naming standards.

This PR will hopefully resolve https://github.com/m-lab/revtrvp/issues/12

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/490)
<!-- Reviewable:end -->
