### PR TITLE
Bumps the tcp-info version to v1.5.1

### DIFF
--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -142,7 +142,7 @@ local uuidannotatorServiceVolume = {
 local Tcpinfo(expName, tcpPort, hostNetwork, anonMode) = [
   {
     name: 'tcp-info',
-    image: 'measurementlab/tcp-info:v1.5.0',
+    image: 'measurementlab/tcp-info:v1.5.1',
     args: [
       if hostNetwork then
         '-prometheusx.listen-address=127.0.0.1:' + tcpPort


### PR DESCRIPTION
The new version of tcp-info includes a small bugfix which deletes a socket file before attempting to use create a new one, to prevent an unclean shutdown and stale socket file from preventing the container from starting up.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/494)
<!-- Reviewable:end -->
