### PR TITLE
Adds a `site` label to all metrics exported by disco

### DIFF
--- a/config/prometheus/prometheus.yml
+++ b/config/prometheus/prometheus.yml
@@ -135,9 +135,9 @@ scrape_configs:
       # metrics from each machine in a pod, and hence there is not site label
       # by default, but rather only a machine label, from which we can extract
       # the site.
-      - source_labels: [container, ifAlias, machine]
+      - source_labels: [__meta_kubernetes_pod_container_name, __meta_kubernetes_pod_node_name]
         action: replace
-        regex: disco;.+;mlab[1-4]-([a-z]{3}[0-9t]{2}).*
+        regex: disco;mlab[1-4]-([a-z]{3}[0-9t]{2}).*
         replacement: $1
         target_label: site
 

--- a/config/prometheus/prometheus.yml
+++ b/config/prometheus/prometheus.yml
@@ -131,6 +131,16 @@ scrape_configs:
         action: replace
         target_label: machine
 
+      # Add a site label for SNMP metrics from DISCO. DISCOv2 collects switch
+      # metrics from each machine in a pod, and hence there is not site label
+      # by default, but rather only a machine label, from which we can extract
+      # the site.
+      - source_labels: [container, ifAlias, machine]
+        action: replace
+        regex: disco;.+;mlab[1-4]-([a-z]{3}[0-9t]{2}).*
+        replacement: $1
+        target_label: site
+
       # Identify the deployment name for replica set or daemon set.  Pods
       # created by deployments or daemon sets are processed here. The
       # following two rules recognize these two cases.


### PR DESCRIPTION
I chose to implement this as a `relabel_config` as opposed to baking the label into disco directly. That may not be right, but it was a bit easier and seemed more like a post-processing task and not something that necessarily should be native to disco. It will be easier to change in the future, should like unlikely necessity ever present itself.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/495)
<!-- Reviewable:end -->
