### PR TITLE
Splits disco ifAlias values into separate ifAlias and speed labels

### DIFF
--- a/config/prometheus/prometheus.yml
+++ b/config/prometheus/prometheus.yml
@@ -173,6 +173,20 @@ scrape_configs:
         action: replace
         target_label: container
 
+    # This relabel config is the last relabel processed before ingesting data
+    # into the datastore.
+    metric_relabel_configs:
+      # 'ifAlias' labels use the format "uplink-<speed>" where speed is one of
+      # "1g" or "10g". These rules split the two fields and adds a new label
+      # for the speed.
+      - source_labels: [ifAlias]
+        regex: uplink-(.*)
+        target_label: speed
+        replacement: ${1}
+      - source_labels: [ifAlias]
+        regex: (uplink)-.*
+        target_label: ifAlias
+        replacement: ${1}
 
   # Scrape config for kubernetes service endpoints.
   - job_name: 'kubernetes-service-endpoints'

--- a/k8s/daemonsets/core/disco.jsonnet
+++ b/k8s/daemonsets/core/disco.jsonnet
@@ -1,7 +1,7 @@
 local exp = import '../templates.jsonnet';
 local expName = 'disco';
 local config = import '../../../config/disco.jsonnet';
-local version = 'v0.1.9';
+local version = 'v0.1.10';
 
 {
   apiVersion: 'apps/v1',


### PR DESCRIPTION
Switch uplink interface `ifAlias` values are set to something like `uplink-(1|10)g`. These new `metric_relabel_config` rules split that value up into two labels like `ifAlias=uplink` and `speed=10g`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/496)
<!-- Reviewable:end -->
