### PR TITLE
Add recording rules for the NDT:EarlyWarning dashboard

### DIFF
--- a/config/prometheus/rules.yml
+++ b/config/prometheus/rules.yml
@@ -251,7 +251,7 @@ groups:
   - record: machine:node_filesystem_used_ratio_12h_prediction:90th_quantile_30m
     expr: quantile_over_time(0.9, machine:node_filesystem_ratio_bytes:predict_linear3h_12h[30m])
 
-	# 90th percentiles @ 1h.
+  # 90th percentiles @ 1h.
   - record: candidate_site:uplink:90th_quantile_1h
     expr: quantile_over_time(0.9, switch:ifHCOutOctets:bps2m{ifAlias="uplink", machine=~"mlab2.*"}[1h])
   # k8s
@@ -264,7 +264,7 @@ groups:
   - record: machine:node_filesystem_used_ratio_12h_prediction:90th_quantile_1h
     expr: quantile_over_time(0.9, machine:node_filesystem_used_ratio:predict_linear3h_12h[1h])
 
-	# 90th percentiles @ 2h.
+  # 90th percentiles @ 2h.
   - record: candidate_site:uplink:90th_quantile_2h
     expr: quantile_over_time(0.9, switch:ifHCOutOctets:bps2m{ifAlias="uplink", machine=~"mlab2.*"}[2h])
   # k8s
@@ -277,7 +277,7 @@ groups:
   - record: machine:node_filesystem_used_ratio_12h_prediction:90th_quantile_2h
     expr: quantile_over_time(0.9, machine:node_filesystem_used_ratio:predict_linear3h_12h[2h])
 
-	# 90th percentiles @ 6h.
+  # 90th percentiles @ 6h.
   - record: candidate_site:uplink:90th_quantile_6h
     expr: quantile_over_time(0.9, switch:ifHCOutOctets:bps2m{ifAlias="uplink", machine=~"mlab2.*"}[6h])
   # k8s
@@ -290,7 +290,7 @@ groups:
   - record: machine:node_filesystem_used_ratio_12h_prediction:90th_quantile_6h
     expr: quantile_over_time(0.9, machine:node_filesystem_used_ratio:predict_linear3h_12h[6h])
 
-	# 98th percentiles @ 2h.
+  # 98th percentiles @ 2h.
   - record: candidate_site:uplink:98th_quantile_2h
     expr: quantile_over_time(0.98, switch:ifHCOutOctets:bps2m{ifAlias="uplink", machine=~"mlab2.*"}[2h])
   # k8s
@@ -303,7 +303,7 @@ groups:
   - record: machine:node_filesystem_used_ratio_12h_prediction:98th_quantile_2h
     expr: quantile_over_time(0.98, machine:node_filesystem_used_ratio:predict_linear3h_12h[2h])
 
-	# 98th percentiles @ 6h.
+  # 98th percentiles @ 6h.
   - record: candidate_site:uplink:98th_quantile_6h
     expr: quantile_over_time(0.98, switch:ifHCOutOctets:bps2m{ifAlias="uplink", machine=~"mlab2.*"}[6h])
   # k8s

--- a/config/prometheus/rules.yml
+++ b/config/prometheus/rules.yml
@@ -2,9 +2,7 @@ groups:
 - name: rules.yml
   rules:
 
-## PlatformCluster
-
-  ## CPU METRICS
+## CPU METRICS
 
   #  Calculates aggregate 1h rate of CPU usage for a DaemonSet across all
   #  machines.
@@ -52,7 +50,7 @@ groups:
       / on(machine) group_left machine_cpu_cores
 
 
-  ## MEMORY METRICS
+## MEMORY METRICS
 
   #  Calculates aggregate DaemonSet memory usage across all machines.
   - record: daemonset:container_memory_working_set_bytes:sum
@@ -99,13 +97,13 @@ groups:
       / on(machine) group_left machine_memory_bytes
 
 
-  ## NETWORK METRICS
-  #
-  # These network metric expressions deliberately exclude the 'host',
-  # 'node-exporter' and 'utilization' experiments which run with
-  # hostNetwork=true. Because of this they capture essentially all node network
-  # traffic, which duplicates regular experiment metrics as well as being just
-  # generally not useful.
+## NETWORK METRICS
+#
+# These network metric expressions deliberately exclude the 'host',
+# 'node-exporter' and 'utilization' experiments which run with
+# hostNetwork=true. Because of this they capture essentially all node network
+# traffic, which duplicates regular experiment metrics as well as being just
+# generally not useful.
 
   # Calculates aggregate DaemonSet network trasmit bytes on the platform.
   - record: workload:container_network_transmit_bytes_total:sum
@@ -171,7 +169,8 @@ groups:
         [1h]) * 8
       )
 
-  ## Pusher Daily Volume metrics
+## Pusher Daily Volume metrics
+
   #
   # This rule optimizes the alert query used for PusherDailyDataVolumeTooLow.
   - record: datatype:pusher_bytes_per_tarfile:increase24h
@@ -182,3 +181,138 @@ groups:
   # This rule speeds up the probably OOM query used by the SRE overview dashboard.
   - record: err:dmesg_logs:increase_24h
     expr: increase(dmesg_logs{priority="err"}[24h]) > 0
+
+## NDT Early Warning aggregation rules.
+#
+# Rules are evaluated every global.evaluation_interval seconds. When
+# scrape_interval equals the evaluation_interval, there are potential races for
+# short range operators, e.g. 2m when the eval and scrape intervals are 1m. At
+# evaluation time, not every timeseries will contain 2 points in a 2m window.
+#
+# If we want to calculate the rate over 2m and increase the likelihood that we
+# see at least two points we must use irate with a larger window, e.g. 4x the
+# scrape interval. In our case this is 4m. irate only uses the last two samples
+# to calculate an instantaneous rate.
+
+  # TODO: aggregate on per-machine interface aliases when available.
+  # Per-switch "Out" (i.e. Download) bits per second. We use irate to calculate
+  # rates over the last two samples only.
+  # Units: bits per second.
+  - record: switch:ifHCOutOctets:bps2m
+    expr: 8 * irate(ifHCOutOctets{ifAlias="uplink", machine=~"mlab2.*"}[4m])
+
+  ## NDT Early Warning aggregation rules for Kubernetes platform.
+
+  # Per-machine successful NDT5 tests counted by the server.
+  # Units: requests per minute.
+  - record: machine:ndt5_client_test_results:rpm2m
+    expr: 60 * sum by(machine) (irate(ndt5_client_test_results_total{result!="error-without-rate"}[4m]))
+  # Per-machine successful NDT7 tests counted by the server.
+  # Units: requests per minute.
+  - record: machine:ndt7_client_test_results:rpm2m
+    expr: 60 * sum by(machine) (irate(ndt7_client_test_results_total{result!="error-without-rate"}[4m]))
+  # Per-machine maximum ratio of time spent performing I/O on all devices.
+  # Units: none (sec/sec)
+  - record: machine:node_disk_io_time_seconds:max2m
+    expr: max without(device) (irate(node_disk_io_time_seconds_total{deployment="node-exporter"}[4m]))
+  # Machine disk quota utilization, 12 hour estimate. Base 12h estimate on a
+  # time range at least 25% of the time forward.
+  # Units: none (bytes/bytes)
+  - record: machine:node_filesystem_used_bytes:ratio
+    expr: 1 - node_filesystem_avail_bytes{mountpoint="/cache/data"} / node_filesystem_size_bytes{mountpoint="/cache/data"}
+  # NOTE: this expression uses the recording rule above. This may add an extra
+  # minute to current data, but the time scale of the prediction is much longer.
+  - record: machine:node_filesystem_used_ratio:predict_linear3h_12h
+    expr: predict_linear(machine:node_filesystem_used_bytes:ratio[3h], 12 * 60 * 60)
+
+  ## Switch SNMP metrics
+
+  # Discarded packets
+  - record: switch:ifOutDiscards:irate4m_gt_0
+    expr: irate(ifOutDiscards{ifAlias="uplink"}[4m]) > 0
+  - record: switch:ifOutDiscards:irate4m
+    expr: irate(ifOutDiscards{ifAlias="uplink"}[4m])
+
+  ## NDT Early Warning 2x site capacity thresholds.
+  #
+  # Shorter time ranges are chosen to favor higher sensitivity and longer time
+  # ranges are chosen for lower sensitivity.
+
+  # 90th percentiles @ 30m
+  - record: candidate_site:uplink:90th_quantile_30m
+    expr: quantile_over_time(0.9, switch:ifHCOutOctets:bps2m{ifAlias="uplink", machine=~"mlab2.*"}[30m])
+  # k8s
+  - record: machine:ndt5_client_test_results_rpm:90th_quantile_30m
+    expr: quantile_over_time(0.9, machine:ndt5_client_test_results:rpm2m[30m])
+  - record: machine:ndt7_client_test_results_rpm:90th_quantile_30m
+    expr: quantile_over_time(0.9, machine:ndt7_client_test_results:rpm2m[30m])
+  - record: machine:node_disk_io_time_seconds_max:90th_quantile_30m
+    expr: quantile_over_time(0.9, machine:node_disk_io_time_seconds:max2m[30m])
+  - record: machine:node_filesystem_used_ratio_12h_prediction:90th_quantile_30m
+    expr: quantile_over_time(0.9, machine:node_filesystem_ratio_bytes:predict_linear3h_12h[30m])
+
+	# 90th percentiles @ 1h.
+  - record: candidate_site:uplink:90th_quantile_1h
+    expr: quantile_over_time(0.9, switch:ifHCOutOctets:bps2m{ifAlias="uplink", machine=~"mlab2.*"}[1h])
+  # k8s
+  - record: machine:ndt5_client_test_results_rpm:90th_quantile_1h
+    expr: quantile_over_time(0.9, machine:ndt5_client_test_results:rpm2m[1h])
+  - record: machine:ndt7_client_test_results_rpm:90th_quantile_1h
+    expr: quantile_over_time(0.9, machine:ndt7_client_test_results:rpm2m[1h])
+  - record: machine:node_disk_io_time_seconds_max:90th_quantile_1h
+    expr: quantile_over_time(0.9, machine:node_disk_io_time_seconds:max2m[1h])
+  - record: machine:node_filesystem_used_ratio_12h_prediction:90th_quantile_1h
+    expr: quantile_over_time(0.9, machine:node_filesystem_used_ratio:predict_linear3h_12h[1h])
+
+	# 90th percentiles @ 2h.
+  - record: candidate_site:uplink:90th_quantile_2h
+    expr: quantile_over_time(0.9, switch:ifHCOutOctets:bps2m{ifAlias="uplink", machine=~"mlab2.*"}[2h])
+  # k8s
+  - record: machine:ndt5_client_test_results_rpm:90th_quantile_2h
+    expr: quantile_over_time(0.9, machine:ndt5_client_test_results:rpm2m[2h])
+  - record: machine:ndt7_client_test_results_rpm:90th_quantile_2h
+    expr: quantile_over_time(0.9, machine:ndt7_client_test_results:rpm2m[2h])
+  - record: machine:node_disk_io_time_seconds_max:90th_quantile_2h
+    expr: quantile_over_time(0.9, machine:node_disk_io_time_seconds:max2m[2h])
+  - record: machine:node_filesystem_used_ratio_12h_prediction:90th_quantile_2h
+    expr: quantile_over_time(0.9, machine:node_filesystem_used_ratio:predict_linear3h_12h[2h])
+
+	# 90th percentiles @ 6h.
+  - record: candidate_site:uplink:90th_quantile_6h
+    expr: quantile_over_time(0.9, switch:ifHCOutOctets:bps2m{ifAlias="uplink", machine=~"mlab2.*"}[6h])
+  # k8s
+  - record: machine:ndt5_client_test_results_rpm:90th_quantile_6h
+    expr: quantile_over_time(0.9, machine:ndt5_client_test_results:rpm2m[6h])
+  - record: machine:ndt7_client_test_results_rpm:90th_quantile_6h
+    expr: quantile_over_time(0.9, machine:ndt7_client_test_results:rpm2m[6h])
+  - record: machine:node_disk_io_time_seconds_max:90th_quantile_6h
+    expr: quantile_over_time(0.9, machine:node_disk_io_time_seconds:max2m[6h])
+  - record: machine:node_filesystem_used_ratio_12h_prediction:90th_quantile_6h
+    expr: quantile_over_time(0.9, machine:node_filesystem_used_ratio:predict_linear3h_12h[6h])
+
+	# 98th percentiles @ 2h.
+  - record: candidate_site:uplink:98th_quantile_2h
+    expr: quantile_over_time(0.98, switch:ifHCOutOctets:bps2m{ifAlias="uplink", machine=~"mlab2.*"}[2h])
+  # k8s
+  - record: machine:ndt5_client_test_results_rpm:98th_quantile_2h
+    expr: quantile_over_time(0.98, machine:ndt5_client_test_results:rpm2m[2h])
+  - record: machine:ndt7_client_test_results_rpm:98th_quantile_2h
+    expr: quantile_over_time(0.98, machine:ndt7_client_test_results:rpm2m[2h])
+  - record: machine:node_disk_io_time_seconds_max:98th_quantile_2h
+    expr: quantile_over_time(0.98, machine:node_disk_io_time_seconds:max2m[2h])
+  - record: machine:node_filesystem_used_ratio_12h_prediction:98th_quantile_2h
+    expr: quantile_over_time(0.98, machine:node_filesystem_used_ratio:predict_linear3h_12h[2h])
+
+	# 98th percentiles @ 6h.
+  - record: candidate_site:uplink:98th_quantile_6h
+    expr: quantile_over_time(0.98, switch:ifHCOutOctets:bps2m{ifAlias="uplink", machine=~"mlab2.*"}[6h])
+  # k8s
+  - record: machine:ndt5_client_test_results_rpm:98th_quantile_6h
+    expr: quantile_over_time(0.98, machine:ndt5_client_test_results:rpm2m[6h])
+  - record: machine:ndt7_client_test_results_rpm:98th_quantile_6h
+    expr: quantile_over_time(0.98, machine:ndt7_client_test_results:rpm2m[6h])
+  - record: machine:node_disk_io_time_seconds_max:98th_quantile_6h
+    expr: quantile_over_time(0.98, machine:node_disk_io_time_seconds:max2m[6h])
+  - record: machine:node_filesystem_used_ratio_12h_prediction:98th_quantile_6h
+    expr: quantile_over_time(0.98, machine:node_filesystem_used_ratio:predict_linear3h_12h[6h])
+

--- a/config/prometheus/rules.yml
+++ b/config/prometheus/rules.yml
@@ -195,11 +195,15 @@ groups:
 # to calculate an instantaneous rate.
 
   # TODO: aggregate on per-machine interface aliases when available.
+  #
   # Per-switch "Out" (i.e. Download) bits per second. We use irate to calculate
-  # rates over the last two samples only.
+  # rates over the last two samples only. DISCOv2 collects uplink metrics from
+  # every machine at a site, using max-by-(site) allow us to return only a
+  # single value, the highest one reported by any of the machines.
+  #
   # Units: bits per second.
   - record: switch:ifHCOutOctets:bps2m
-    expr: 8 * irate(ifHCOutOctets{ifAlias="uplink", machine=~"mlab2.*"}[4m])
+    expr: max by (site) (8 * irate(ifHCOutOctets{ifAlias="uplink"}[4m]))
 
   ## NDT Early Warning aggregation rules for Kubernetes platform.
 
@@ -229,9 +233,9 @@ groups:
 
   # Discarded packets
   - record: switch:ifOutDiscards:irate4m_gt_0
-    expr: irate(ifOutDiscards{ifAlias="uplink"}[4m]) > 0
+    expr: max by (site) (irate(ifOutDiscards{ifAlias="uplink"}[4m]) > 0)
   - record: switch:ifOutDiscards:irate4m
-    expr: irate(ifOutDiscards{ifAlias="uplink"}[4m])
+    expr: max by (site) (irate(ifOutDiscards{ifAlias="uplink"}[4m]))
 
   ## NDT Early Warning 2x site capacity thresholds.
   #
@@ -240,7 +244,7 @@ groups:
 
   # 90th percentiles @ 30m
   - record: candidate_site:uplink:90th_quantile_30m
-    expr: quantile_over_time(0.9, switch:ifHCOutOctets:bps2m{ifAlias="uplink", machine=~"mlab2.*"}[30m])
+    expr: quantile_over_time(0.9, switch:ifHCOutOctets:bps2m[30m])
   # k8s
   - record: machine:ndt5_client_test_results_rpm:90th_quantile_30m
     expr: quantile_over_time(0.9, machine:ndt5_client_test_results:rpm2m[30m])
@@ -253,7 +257,7 @@ groups:
 
   # 90th percentiles @ 1h.
   - record: candidate_site:uplink:90th_quantile_1h
-    expr: quantile_over_time(0.9, switch:ifHCOutOctets:bps2m{ifAlias="uplink", machine=~"mlab2.*"}[1h])
+    expr: quantile_over_time(0.9, switch:ifHCOutOctets:bps2m[1h])
   # k8s
   - record: machine:ndt5_client_test_results_rpm:90th_quantile_1h
     expr: quantile_over_time(0.9, machine:ndt5_client_test_results:rpm2m[1h])
@@ -266,7 +270,7 @@ groups:
 
   # 90th percentiles @ 2h.
   - record: candidate_site:uplink:90th_quantile_2h
-    expr: quantile_over_time(0.9, switch:ifHCOutOctets:bps2m{ifAlias="uplink", machine=~"mlab2.*"}[2h])
+    expr: quantile_over_time(0.9, switch:ifHCOutOctets:bps2m[2h])
   # k8s
   - record: machine:ndt5_client_test_results_rpm:90th_quantile_2h
     expr: quantile_over_time(0.9, machine:ndt5_client_test_results:rpm2m[2h])
@@ -279,7 +283,7 @@ groups:
 
   # 90th percentiles @ 6h.
   - record: candidate_site:uplink:90th_quantile_6h
-    expr: quantile_over_time(0.9, switch:ifHCOutOctets:bps2m{ifAlias="uplink", machine=~"mlab2.*"}[6h])
+    expr: quantile_over_time(0.9, switch:ifHCOutOctets:bps2m[6h])
   # k8s
   - record: machine:ndt5_client_test_results_rpm:90th_quantile_6h
     expr: quantile_over_time(0.9, machine:ndt5_client_test_results:rpm2m[6h])
@@ -292,7 +296,7 @@ groups:
 
   # 98th percentiles @ 2h.
   - record: candidate_site:uplink:98th_quantile_2h
-    expr: quantile_over_time(0.98, switch:ifHCOutOctets:bps2m{ifAlias="uplink", machine=~"mlab2.*"}[2h])
+    expr: quantile_over_time(0.98, switch:ifHCOutOctets:bps2m[2h])
   # k8s
   - record: machine:ndt5_client_test_results_rpm:98th_quantile_2h
     expr: quantile_over_time(0.98, machine:ndt5_client_test_results:rpm2m[2h])
@@ -305,7 +309,7 @@ groups:
 
   # 98th percentiles @ 6h.
   - record: candidate_site:uplink:98th_quantile_6h
-    expr: quantile_over_time(0.98, switch:ifHCOutOctets:bps2m{ifAlias="uplink", machine=~"mlab2.*"}[6h])
+    expr: quantile_over_time(0.98, switch:ifHCOutOctets:bps2m[6h])
   # k8s
   - record: machine:ndt5_client_test_results_rpm:98th_quantile_6h
     expr: quantile_over_time(0.98, machine:ndt5_client_test_results:rpm2m[6h])


### PR DESCRIPTION
Now that DISCOv2 is running in production in the platform cluster, SNMP metrics are located in that cluster, not the prometheus-federation cluster. This PR copies all of the Prometheus recording rules used on the NDT:EarlyWarning dashboard to the platform cluster instance of Prometheus. They are copied verbatim from the prometheus-support repository, with the only modifications being a few changes to the indentation of comments.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/497)
<!-- Reviewable:end -->
