### PR TITLE
Updates Vector version

### DIFF
--- a/config/vector/values.yaml.template
+++ b/config/vector/values.yaml.template
@@ -15,6 +15,8 @@ extraVolumeMounts:
 - name: credentials
   mountPath: /etc/vector/keys
   readOnly: true
+podLabels:
+- workload: vector
 sinks:
   stackdriver:
     type: gcp_stackdriver_logs

--- a/config/vector/values.yaml.template
+++ b/config/vector/values.yaml.template
@@ -16,7 +16,7 @@ extraVolumeMounts:
   mountPath: /etc/vector/keys
   readOnly: true
 podLabels:
-- workload: vector
+  workload: vector
 sinks:
   stackdriver:
     type: gcp_stackdriver_logs

--- a/manage-cluster/apply_k8s_configs.sh
+++ b/manage-cluster/apply_k8s_configs.sh
@@ -77,20 +77,9 @@ sed -e "s/{{PROJECT}}/${PROJECT}/" ../config/vector/values.yaml.template \
 
 # TODO(roberto) update to a non-nightly version as soon as it's available.
 ./linux-amd64/helm upgrade --install vector \
-  --version 0.11.0-nightly-2020-08-18 \
+  --version 0.11.0-nightly-2020-10-12 \
   --values ../config/vector/values.yaml \
   vector/vector
-
-# TODO(kinkade) Currently, the helm template for the Vector DaemonSet does not
-# allow you to modify Pod labels. This patch command adds M-Lab's standard
-# `workload` label. A [feature # request](https://github.com/timberio/vector/issues/3568)
-# has already been submitted, but it would seem reasonable to consider submitting a PR
-# upstream to add the ability to modify Pod labels via values.yaml. NOTE: we
-# are using `patch` here (instead of the simpler `label` because we need to
-# modify the pod template specification of the DaemonSet, not the DaemonSet
-# itself.
-kubectl patch daemonset vector --type='json' \
-  --patch='[{"op":"add", "path":"/spec/template/metadata/labels/workload", "value":"vector"}]'
 
 # Apply the configuration
 


### PR DESCRIPTION
We are currently having [problems with container restarts](https://github.com/m-lab/k8s-support/issues/491) in the Vector DaemonSet. It appears as if at least [one of the issues causing the restarts has been resolved recently](https://github.com/timberio/vector/issues/3830). This PR updates the version of Vector to the latest one available at the moment.

Additionally, we are currently setting the `workload=vector` pod label by using a patch after the DaemonSet has been deployed via Helm. This PR updates our values.yaml override file to use the new `podLabels` template variable, [which was just added recently](https://github.com/timberio/vector/pull/3610).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/498)
<!-- Reviewable:end -->
