### PR TITLE
Update wehe1.10 with livenessProbe

### DIFF
--- a/k8s/daemonsets/experiments/wehe.jsonnet
+++ b/k8s/daemonsets/experiments/wehe.jsonnet
@@ -113,7 +113,7 @@ exp.Experiment(expName, 5, 'pusher-' + std.extVar('PROJECT_ID'), 'netblock', ['r
                 port: 9090,
               },
               // After startup, liveness should never fail.
-              initialDelaySeconds: 300, // TODO: eliminate with k8s v1.18+
+              initialDelaySeconds: 300, // TODO: eliminate with k8s v1.18+.
               failureThreshold: 1,
               timeoutSeconds: 10,
               periodSeconds: 30,

--- a/k8s/daemonsets/experiments/wehe.jsonnet
+++ b/k8s/daemonsets/experiments/wehe.jsonnet
@@ -96,6 +96,7 @@ exp.Experiment(expName, 5, 'pusher-' + std.extVar('PROJECT_ID'), 'netblock', ['r
             ],
             image: 'measurementlab/wehe-py3:v0.1.10',
             name: expName,
+            /* TODO: enable with k8s v1.18+
             startupProbe+: {
               httpGet: {
                 path: '/metrics',
@@ -105,13 +106,17 @@ exp.Experiment(expName, 5, 'pusher-' + std.extVar('PROJECT_ID'), 'netblock', ['r
               failureThreshold: 30,
               periodSeconds: 10,
             },
+            */
             livenessProbe+: {
               httpGet: {
                 path: '/metrics',
                 port: 9090,
               },
-              // After startup, the liveness should never fail.
-              failureThreshold: 1,
+              // After startup, liveness should never fail.
+              // NOTE: allow several failures until k8s v1.18+.
+              // TODO: once startupProbe is available, failureThreshold should be 1.
+              failureThreshold: 5,
+              timeoutSeconds: 10,
               periodSeconds: 30,
             },
             volumeMounts: [

--- a/k8s/daemonsets/experiments/wehe.jsonnet
+++ b/k8s/daemonsets/experiments/wehe.jsonnet
@@ -113,9 +113,8 @@ exp.Experiment(expName, 5, 'pusher-' + std.extVar('PROJECT_ID'), 'netblock', ['r
                 port: 9090,
               },
               // After startup, liveness should never fail.
-              // NOTE: allow several failures until k8s v1.18+.
-              // TODO: once startupProbe is available, failureThreshold should be 1.
-              failureThreshold: 5,
+              initialDelaySeconds: 300, // TODO: eliminate with k8s v1.18+
+              failureThreshold: 1,
               timeoutSeconds: 10,
               periodSeconds: 30,
             },

--- a/k8s/daemonsets/experiments/wehe.jsonnet
+++ b/k8s/daemonsets/experiments/wehe.jsonnet
@@ -34,24 +34,6 @@ exp.Experiment(expName, 5, 'pusher-' + std.extVar('PROJECT_ID'), 'netblock', ['r
             ],
           },
         ],
-        startupProbe+: {
-          httpGet: {
-            path: '/metrics',
-            port: 9090,
-          },
-          // Allow up to 5min for the service to startup: 30*10.
-          failureThreshold: 30,
-          periodSeconds: 10,
-        },
-        livenessProbe+: {
-          httpGet: {
-            path: '/metrics',
-            port: 9090,
-          },
-          // After startup, the liveness should never fail.
-          failureThreshold: 1,
-          periodSeconds: 30,
-        },
         containers+: [
           {
             args: [
@@ -114,6 +96,24 @@ exp.Experiment(expName, 5, 'pusher-' + std.extVar('PROJECT_ID'), 'netblock', ['r
             ],
             image: 'measurementlab/wehe-py3:v0.1.10',
             name: expName,
+            startupProbe+: {
+              httpGet: {
+                path: '/metrics',
+                port: 9090,
+              },
+              // Allow up to 5min for the service to startup: 30*10.
+              failureThreshold: 30,
+              periodSeconds: 10,
+            },
+            livenessProbe+: {
+              httpGet: {
+                path: '/metrics',
+                port: 9090,
+              },
+              // After startup, the liveness should never fail.
+              failureThreshold: 1,
+              periodSeconds: 30,
+            },
             volumeMounts: [
               exp.VolumeMount('wehe/replay') + {
                 mountPath: '/data/RecordReplay/ReplayDumpsTimestamped',

--- a/k8s/daemonsets/experiments/wehe.jsonnet
+++ b/k8s/daemonsets/experiments/wehe.jsonnet
@@ -34,6 +34,24 @@ exp.Experiment(expName, 5, 'pusher-' + std.extVar('PROJECT_ID'), 'netblock', ['r
             ],
           },
         ],
+        startupProbe+: {
+          httpGet: {
+            path: '/metrics',
+            port: 9090,
+          },
+          // Allow up to 5min for the service to startup: 30*10.
+          failureThreshold: 30,
+          periodSeconds: 10,
+        },
+        livenessProbe+: {
+          httpGet: {
+            path: '/metrics',
+            port: 9090,
+          },
+          // After startup, the liveness should never fail.
+          failureThreshold: 1,
+          periodSeconds: 30,
+        },
         containers+: [
           {
             args: [
@@ -94,7 +112,7 @@ exp.Experiment(expName, 5, 'pusher-' + std.extVar('PROJECT_ID'), 'netblock', ['r
                 },
               },
             ],
-            image: 'measurementlab/wehe-py3:v0.1.9',
+            image: 'measurementlab/wehe-py3:v0.1.10',
             name: expName,
             volumeMounts: [
               exp.VolumeMount('wehe/replay') + {


### PR DESCRIPTION
This change updates the wehe version to 1.10 to include changes that make the container more resilient to server failures.

This includes changes to the startserver script (that will exit if the analyzerServer exits) and a k8s livenessProbe that will restart the container if the replay server exits.

This change adds configuration for `startupProbe` in a comment that is supported by k8s v1.18, but not yet our platform cluster.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/499)
<!-- Reviewable:end -->
