### PR TITLE
Make Vector run on api-server nodes too.

### DIFF
--- a/config/vector/values.yaml.template
+++ b/config/vector/values.yaml.template
@@ -29,3 +29,6 @@ sinks:
       resource.node_id = "${VECTOR_SELF_NODE_NAME}"
       project_id = "{{PROJECT}}"
       log_id = "${VECTOR_SELF_NODE_NAME}"
+tolerations:
+- key: node-role.kubernetes.io/master
+  effect: NoSchedule


### PR DESCRIPTION
Fluentd used to have tolerations so that it would run on api-server nodes too. Those tolerations didn't make it over to the Vector DaemonSet, and this PR corrects that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/501)
<!-- Reviewable:end -->
