### PR TITLE
Adds new systemd unit to cloud-config for bmc-store-password.

### DIFF
--- a/manage-cluster/cloud-config_master.yml
+++ b/manage-cluster/cloud-config_master.yml
@@ -34,6 +34,28 @@ write_files:
     [Install]
     WantedBy=multi-user.target
 
+- path: /etc/systemd/system/bmc-store-password.service
+  permissions: 0644
+  owner: root
+  content: |
+    [Unit]
+    Description=bmc-store-password
+    After=docker.service
+    Requires=docker.service
+
+    [Service]
+    TimeoutStartSec=120
+    Restart=always
+    ExecStartPre=-/usr/bin/docker stop %N
+    ExecStartPre=-/usr/bin/docker rm %N
+    ExecStart=/usr/bin/docker run --publish 8801:8801 \
+                                  --name %N -- \
+                                  measurementlab/bmc-store-password:v0.1.1
+    ExecStop=/usr/bin/docker stop %N
+
+    [Install]
+    WantedBy=multi-user.target
+
 - path: /etc/systemd/system/gcp-loadbalancer-proxy.service
   permissions: 0644
   owner: root
@@ -171,4 +193,5 @@ runcmd:
 - systemctl start reboot-node.timer
 - systemctl enable token-server.service
 - systemctl start token-server.service
-
+- systemctl enable bmc-store-password.service
+- systemctl start bmc-store-password.service

--- a/manage-cluster/cloud-config_master.yml
+++ b/manage-cluster/cloud-config_master.yml
@@ -50,7 +50,7 @@ write_files:
     ExecStartPre=-/usr/bin/docker rm %N
     ExecStart=/usr/bin/docker run --publish 8801:8801 \
                                   --name %N -- \
-                                  measurementlab/bmc-store-password:v0.1.1
+                                  measurementlab/epoxy-extensions:bmc-store-password-v0.1.1
     ExecStop=/usr/bin/docker stop %N
 
     [Install]


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/506)
<!-- Reviewable:end -->
