### PR TITLE
Create GCP resources for the new bmc-store-password ePoxy extension service

### DIFF
--- a/manage-cluster/add_k8s_master_node.sh
+++ b/manage-cluster/add_k8s_master_node.sh
@@ -95,7 +95,8 @@ gcloud compute ssh "${BOOTSTRAP_MASTER}" "${GCP_ARGS[@]}" --zone "${BOOTSTRAP_MA
 EOF
 
 # If they exist, delete the node name from various loadbalancer group resources.
-delete_token_server_backend "${GCE_NAME}" "${GCE_ZONE}"
+delete_server_backend "${GCE_NAME}" "${GCE_ZONE}" "${TOKEN_SERVER_BASE_NAME}"
+delete_server_backend "${GCE_NAME}" "${GCE_ZONE}" "${BMC_STORE_PASSWORD_BASE_NAME}"
 delete_target_pool_instance "${GCE_NAME}" "${GCE_ZONE}"
 delete_instance_group "${GCE_NAME}" "${GCE_ZONE}"
 

--- a/manage-cluster/k8s_deploy.conf
+++ b/manage-cluster/k8s_deploy.conf
@@ -47,6 +47,8 @@ K8S_CLOUD_NODE_LABELS="mlab/type=virtual"
 
 TOKEN_SERVER_BASE_NAME="token-server"
 TOKEN_SERVER_PORT="8800"
+BMC_STORE_PASSWORD_BASE_NAME="bmc-store-password"
+BMC_STORE_PASSWORD_PORT="8801"
 
 # Depending on the GCP project we may use different regions, zones, GSC buckets, etc.
 #


### PR DESCRIPTION
This PR is part of https://github.com/m-lab/epoxy/issues/94. 

We are deploying a new ePoxy extension service running on each api-server. The extension will store node BMC passwords in GCD. This PR updates our platform bootstrap scripts to create all the necessary GCP resources to allow the extension to function properly. 

A quick way of summarizing what was done in this PR: copy all of the pieces that configured support for the token-server ePoxy extension and rename them with "bmc-store-password". Additionally, because the token-server was previously the only extension, this PR modifies the names of some token-server-related variables to distinguish them from the bmc-store-password variables.

Additionally, this PR updates the Go Docker image to 1.15 for building gcsfuse, which apparently no longer likes Go 1.13.

These changes were tested by tearing down the sandbox cluster and rebuilding it. Everything deployed fine, and it *appears* that all of the necessary GCP resources were created as expected.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/508)
<!-- Reviewable:end -->
