### PR TITLE
Require access tokens for ndt7

### DIFF
--- a/k8s/daemonsets/experiments/ndt.jsonnet
+++ b/k8s/daemonsets/experiments/ndt.jsonnet
@@ -35,9 +35,7 @@ exp.Experiment(expName, 2, 'pusher-' + std.extVar('PROJECT_ID'), "none", datatyp
               '-cert=/certs/tls.crt',
               '-token.machine=$(NODE_NAME)',
               '-token.verify-key=/verify/jwk_sig_EdDSA_locate_20200409.pub',
-              # TODO(ooni/probe-engine/issues/562): require access tokens from NDT7
-              #  clients after ooni is migrated to locate/v2.
-              # '-ndt7.token.required=true',
+              '-ndt7.token.required=true',
             ],
             env: [
               {


### PR DESCRIPTION
This change sets the `-ndt7.token.required=true` flag for all ndt7 requests. This change is scheduled to be deployed to production on 11/04.

After two month notice, 98.5% of all requests are providing access tokens. Only an earlier build of a windows client is still running measurements without access tokens. This change will break that user.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/510)
<!-- Reviewable:end -->
