### PR TITLE
Adds instructions on how to resize the Prometheus VM's disk

### DIFF
--- a/manage-cluster/PROMETHEUS.md
+++ b/manage-cluster/PROMETHEUS.md
@@ -7,10 +7,14 @@ etc. are added, the disk space requirements may go up, requiring someone to
 resize the disk, adding more space. Prometheus is part of the platform
 cluster, and is always scheduled to run on a dedicated GCE VM named
 [prometheus-platform-cluster](https://console.cloud.google.com/compute/instancesDetail/zones/us-east1-b/instances/prometheus-platform-cluster?project=mlab-oti).
-Resizing a VM's persistent disk in GCP is very easy, and the [Google
+The VM has a dedicated persistent disk (PD) which is only used for Prometheus
+data. The PD is _not_ a boot disk. The disk should be exposed to the OS as
+`/dev/sdb` and is mounted at `/mnt/local`. Resizing a PD attached to VM in
+GCP is very easy, and the [Google
 documentation](https://cloud.google.com/compute/docs/disks/regional-persistent-disk#resize_repd)
-for how to do this is very straightforward. Once the disk has been resized in
-the GCP console for the VM, you will need to resize the partition in the VM
-itself. Again, [Google's
+for how to do this is very straightforward. Once the PD has been resized in
+the GCP console for the VM, you will need to SSH to the VM and resize the
+filesystem in the VM itself. Again, [Google's
 documentation](https://cloud.google.com/compute/docs/disks/add-persistent-disk#resize_partitions)
-for how to do this is quite detailed and clear.
+for how to do this is quite detailed and clear (i.e., resize2fs). All of this
+can be done without interrupting the VM or any running processes.

--- a/manage-cluster/PROMETHEUS.md
+++ b/manage-cluster/PROMETHEUS.md
@@ -7,10 +7,12 @@ etc. are added, the disk space requirements may go up, requiring someone to
 resize the disk, adding more space. Prometheus is part of the platform
 cluster, and is always scheduled to run on a dedicated GCE VM named
 [prometheus-platform-cluster](https://console.cloud.google.com/compute/instancesDetail/zones/us-east1-b/instances/prometheus-platform-cluster?project=mlab-oti).
-The VM has a dedicated persistent disk (PD) which is only used for Prometheus
-data. The PD is _not_ a boot disk. The disk should be exposed to the OS as
-`/dev/sdb` and is mounted at `/mnt/local`. Resizing a PD attached to a VM in
-GCP is very easy, and the [Google
+The VM has a dedicated persistent disk (PD) named like
+`prometheus-platform-cluster-<zone>`, which is only used for Prometheus data.
+The PD is _not_ a boot disk, nor is it partitioned. The disk should be
+exposed to the OS as `/dev/sdb` and is mounted at `/mnt/local`, with an ext4
+filesystem. Resizing a PD attached to a VM in GCP is very easy, and the
+[Google
 documentation](https://cloud.google.com/compute/docs/disks/regional-persistent-disk#resize_repd)
 for how to do this is very straightforward. Once the PD has been resized in
 the GCP console for the VM, you will need to SSH to the VM and resize the

--- a/manage-cluster/PROMETHEUS.md
+++ b/manage-cluster/PROMETHEUS.md
@@ -17,4 +17,6 @@ the GCP console for the VM, you will need to SSH to the VM and resize the
 filesystem in the VM itself. Again, [Google's
 documentation](https://cloud.google.com/compute/docs/disks/add-persistent-disk#resize_partitions)
 for how to do this is quite detailed and clear (i.e., resize2fs). All of this
-can be done without interrupting the VM or any running processes.
+can be done without interrupting the VM or any running processes. When done,
+be sure to update the default disk size in the [Prometheus bootstrap
+script](https://github.com/m-lab/k8s-support/blob/master/manage-cluster/bootstrap_prometheus.sh#L49)

--- a/manage-cluster/PROMETHEUS.md
+++ b/manage-cluster/PROMETHEUS.md
@@ -1,0 +1,16 @@
+# Prometheus
+
+## Resizing the Prometheus VM's disk
+
+Prometheus uses a lot of disk space. As new metrics, recording rules, alerts,
+etc. are added, the disk space requirements may go up, requiring someone to
+resize the disk, adding more space. Prometheus is part of the platform
+cluster, and is always scheduled to run on a dedicated GCE VM named
+[prometheus-platform-cluster](https://console.cloud.google.com/compute/instancesDetail/zones/us-east1-b/instances/prometheus-platform-cluster?project=mlab-oti).
+Resizing a VM's persistent disk in GCP is very easy, and the [Google
+documentation](https://cloud.google.com/compute/docs/disks/regional-persistent-disk#resize_repd)
+for how to do this is very straightforward. Once the disk has been resized in
+the GCP console for the VM, you will need to resize the partition in the VM
+itself. Again, [Google's
+documentation](https://cloud.google.com/compute/docs/disks/add-persistent-disk#resize_partitions)
+for how to do this is quite detailed and clear.

--- a/manage-cluster/PROMETHEUS.md
+++ b/manage-cluster/PROMETHEUS.md
@@ -9,7 +9,7 @@ cluster, and is always scheduled to run on a dedicated GCE VM named
 [prometheus-platform-cluster](https://console.cloud.google.com/compute/instancesDetail/zones/us-east1-b/instances/prometheus-platform-cluster?project=mlab-oti).
 The VM has a dedicated persistent disk (PD) which is only used for Prometheus
 data. The PD is _not_ a boot disk. The disk should be exposed to the OS as
-`/dev/sdb` and is mounted at `/mnt/local`. Resizing a PD attached to VM in
+`/dev/sdb` and is mounted at `/mnt/local`. Resizing a PD attached to a VM in
 GCP is very easy, and the [Google
 documentation](https://cloud.google.com/compute/docs/disks/regional-persistent-disk#resize_repd)
 for how to do this is very straightforward. Once the PD has been resized in


### PR DESCRIPTION
This PR adds a new `PROMETHEUS.md` "readme" file with instructions on how to resize the persistent disk on a platform cluster Prometheus VM.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/511)
<!-- Reviewable:end -->
