### PR TITLE
Mounts /etc/os-release into nodeinfo pod

### DIFF
--- a/k8s/daemonsets/core/host.jsonnet
+++ b/k8s/daemonsets/core/host.jsonnet
@@ -48,8 +48,8 @@ exp.ExperimentNoIndex(expName, 'pusher-' + std.extVar('PROJECT_ID'), "none", nod
           },
           {
             hostPath: {
-              path: /etc/os-release,
-              type: File,
+              path: '/etc/os-release',
+              type: 'File',
             },
             name: 'etc-os-release',
           },

--- a/k8s/daemonsets/core/host.jsonnet
+++ b/k8s/daemonsets/core/host.jsonnet
@@ -26,6 +26,11 @@ exp.ExperimentNoIndex(expName, 'pusher-' + std.extVar('PROJECT_ID'), "none", nod
                 name: 'nodeinfo-config',
                 readOnly: true,
               },
+              {
+                mountPath: '/etc/os-release',
+                name: 'etc-os-release',
+                readOnly: true,
+              },
               exp.VolumeMount(expName),
             ],
           },
@@ -40,6 +45,13 @@ exp.ExperimentNoIndex(expName, 'pusher-' + std.extVar('PROJECT_ID'), "none", nod
               name: nodeinfoConfig.metadata.name,
             },
             name: 'nodeinfo-config',
+          },
+          {
+            hostPath: {
+              path: /etc/os-release,
+              type: File,
+            },
+            name: 'etc-os-release',
           },
         ],
       },


### PR DESCRIPTION
Resolves #519.

```
$ kubesandbox get pods -l workload=host
NAME         READY   STATUS    RESTARTS   AGE
host-66q29   12/12   Running   0          9m53s
host-fqt6k   12/12   Running   0          10m
host-gxttg   12/12   Running   0          9m50s
host-hnjkg   12/12   Running   0          10m
host-vj5fb   12/12   Running   0          9m13s
$ kubesandbox exec -t -c nodeinfo host-66q29 -- cat /etc/os-release
NAME="Ubuntu"
VERSION="20.04 LTS (Focal Fossa)"
ID=ubuntu
ID_LIKE=debian
PRETTY_NAME="Ubuntu 20.04 LTS"
VERSION_ID="20.04"
HOME_URL="https://www.ubuntu.com/"
SUPPORT_URL="https://help.ubuntu.com/"
BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
VERSION_CODENAME=focal
UBUNTU_CODENAME=focal
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/524)
<!-- Reviewable:end -->
