### PR TITLE
Small changes necessary to migrate CRI from Docker to containerd

### DIFF
--- a/config/flannel.jsonnet
+++ b/config/flannel.jsonnet
@@ -37,10 +37,11 @@ local virtualCNIConf = {
 // It should not contain any index2ip stuff. It is the backup config for when
 // multus isn't working or a pod is not tagged with any network annotations.
 //
-// cniVersion:0.2.0 is the CNI version that index2ip knows about.
+// cniVersion:0.3.1 is a CNI version that multus knows about. The index2ip IPAM
+// plugin only knows about 0.2.0, but multus handles this.
 local physicalCNIConf = {
   name: 'multus-network',
-  cniVersion: '0.2.0',
+  cniVersion: '0.3.1',
   type: 'multus',
   kubeconfig: '/etc/kubernetes/kubelet.conf',
   multusNamespace: 'default',

--- a/manage-cluster/kubeadm-config.yml.template
+++ b/manage-cluster/kubeadm-config.yml.template
@@ -46,6 +46,7 @@ hostnameOverride: "{{MASTER_NAME}}"
 ---
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
+cgroupDriver: systemd
 # https://github.com/kubernetes-sigs/kubespray/blob/master/docs/kubernetes-reliability.md#medium-update-and-average-reaction
 nodeStatusUpdateFrequency: 20s
 podPidsLimit: 10000


### PR DESCRIPTION
**cniVersion**
For reasons that I still don't understand, using `cniVersion: 0.2.0` in our main CNI config file does not work with containerd as the CRI. With this configuration, containerd complains:

```
failed to find network info
``` 

It was actually partly by chance that I even experimented with changing this value to `0.3.1`. That it works with this version I can only explain by presuming that multus _does_ support `0.3.1` (and probably `0.4.0`, too), and the only thing that doesn't is our IPAM plugin `index2ip`.  Likely, the CRI calls multus requesting cniVersion of 0.3.1, which is fine since multus supports this, and we still have our `network-attachment-definitions` [using a cniVersion of 0.2.0](https://github.com/m-lab/k8s-support/blob/master/k8s/networks/networks.jsonnet#L56), so multus may expect an 0.2.0 result from `index2ip`. And our [flannel config](https://github.com/m-lab/k8s-support/blob/master/k8s/networks/networks.jsonnet#L33) is already using `0.3.0`. I'm guessing that multus is taking the 0.2.0 output of `index2ip` and the `0.3.0` output of flannel and then somehow coalesces those into an `0.3.1` output for the CRI.

**cgroupDriver**
We need this to be systemd for the kubelet, since the containerd CRI (and runc OCI)  is also using this driver, and they need to match.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/526)
<!-- Reviewable:end -->
