### PR TITLE
Advertise prometheus metrics for access envelope

### DIFF
--- a/k8s/daemonsets/experiments/wehe.jsonnet
+++ b/k8s/daemonsets/experiments/wehe.jsonnet
@@ -78,6 +78,12 @@ exp.Experiment(expName, 5, 'pusher-' + std.extVar('PROJECT_ID'), 'netblock', ['r
                 readOnly: true,
               },
             ],
+            // Advertise the prometheus port so it can be discovered by Prometheus.
+            ports: [
+              {
+                containerPort: 9990,
+              },
+            ],
           },
           {
             args: [
@@ -125,12 +131,6 @@ exp.Experiment(expName, 5, 'pusher-' + std.extVar('PROJECT_ID'), 'netblock', ['r
               {
                 mountPath: '/wehe/ssl/',
                 name: 'wehe-ca-cache',
-              },
-            ],
-            // Advertise the prometheus port so it can be discovered by Prometheus.
-            ports: [
-              {
-                containerPort: 9990,
               },
             ],
           },

--- a/k8s/daemonsets/experiments/wehe.jsonnet
+++ b/k8s/daemonsets/experiments/wehe.jsonnet
@@ -127,6 +127,12 @@ exp.Experiment(expName, 5, 'pusher-' + std.extVar('PROJECT_ID'), 'netblock', ['r
                 name: 'wehe-ca-cache',
               },
             ],
+            // Advertise the prometheus port so it can be discovered by Prometheus.
+            ports: [
+              {
+                containerPort: 9990,
+              },
+            ],
           },
         ],
         volumes+: [


### PR DESCRIPTION
This change adds a port advertisement to the wehe access envelope config that allows the Prometheus service discovery to find and scrape the metrics.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/527)
<!-- Reviewable:end -->
