### PR TITLE
Migrate API cluster to using containerd instead of Docker for the CRI

### DIFF
--- a/manage-cluster/bootstraplib.sh
+++ b/manage-cluster/bootstraplib.sh
@@ -392,7 +392,7 @@ EOF
 	export ETCDCTL_CERT=/etc/kubernetes/pki/etcd/peer.crt
 	export ETCDCTL_KEY=/etc/kubernetes/pki/etcd/peer.key
 	export ETCDCTL_ENDPOINTS=https://127.0.0.1:2379
-  export CONTAINER_RUNTIME_ENDPOINT=unix:///run/containerd/containerd.sock
+	export CONTAINER_RUNTIME_ENDPOINT=unix:///run/containerd/containerd.sock
 EOF2
     ) | tee -a /root/.profile /root/.bashrc"
 EOF

--- a/manage-cluster/bootstraplib.sh
+++ b/manage-cluster/bootstraplib.sh
@@ -205,8 +205,10 @@ function create_master {
     # Configure containerd. We only need to make one change to the default
     # configuration, which is to configure runc to use the systemd cgroup
     # driver.
+    mkdir /etc/containerd
     containerd config default | \
-      sed -e '/containerd\.runtimes\.runc/a \          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]\n            SystemdCgroup = true'
+      sed -e '/containerd\.runtimes\.runc/a \          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]\n            SystemdCgroup = true' \
+      > /etc/containerd/config.toml
 
     # Enable and start the kubelet service
     systemctl enable --now kubelet.service
@@ -390,6 +392,7 @@ EOF
 	export ETCDCTL_CERT=/etc/kubernetes/pki/etcd/peer.crt
 	export ETCDCTL_KEY=/etc/kubernetes/pki/etcd/peer.key
 	export ETCDCTL_ENDPOINTS=https://127.0.0.1:2379
+  export CONTAINER_RUNTIME_ENDPOINT=unix:///run/containerd/containerd.sock
 EOF2
     ) | tee -a /root/.profile /root/.bashrc"
 EOF

--- a/manage-cluster/bootstraplib.sh
+++ b/manage-cluster/bootstraplib.sh
@@ -202,6 +202,12 @@ function create_master {
     cp etcd-${ETCDCTL_VERSION}-linux-amd64/etcdctl /opt/bin
     rm -rf etcd-${ETCDCTL_VERSION}-linux-amd64
 
+    # Configure containerd. We only need to make one change to the default
+    # configuration, which is to configure runc to use the systemd cgroup
+    # driver.
+    containerd config default | \
+      sed -e '/containerd\.runtimes\.runc/a \          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]\n            SystemdCgroup = true'
+
     # Enable and start the kubelet service
     systemctl enable --now kubelet.service
     systemctl daemon-reload

--- a/manage-cluster/cloud-config_node.yml
+++ b/manage-cluster/cloud-config_node.yml
@@ -1,7 +1,7 @@
 #cloud-config
 
 packages:
-- docker.io
+- containerd
 - ebtables
 - iptables
 - socat
@@ -29,23 +29,21 @@ write_files:
   permissions: 0644
   owner: root:root
   content: |
+    overlay
     br_netfilter
 
-- path: /etc/docker/daemon.json
+# The odd number of 999 because GCE nodes already have a file named
+# 99-gce.conf, which, among other things, disables ip forwarding.
+- path: /etc/sysctl.d/999-containerd.conf
   permissions: 0644
   owner: root:root
   content: |
-    {
-      "exec-opts": [
-        "native.cgroupdriver=systemd"
-      ],
-      "log-driver": "json-file",
-      "log-opts": {
-        "max-size": "100m"
-      },
-      "storage-driver": "overlay2"
-    }
+    net.ipv4.ip_forward                 = 1
+    net.bridge.bridge-nf-call-iptables  = 1
+    net.bridge.bridge-nf-call-ip6tables = 1
 
 runcmd:
-- systemctl enable docker
-- systemctl start docker
+- sysctl --system
+- systemctl restart systemd-modules-load.service
+- systemctl enable containerd
+- systemctl start containerd

--- a/manage-cluster/kubeadm-config.yml.template
+++ b/manage-cluster/kubeadm-config.yml.template
@@ -21,6 +21,10 @@ controlPlane:
     bindPort: 6443
 nodeRegistration:
   name: "{{MASTER_NAME}}"
+  kubeletExtraArgs:
+    container-runtime: "remote"
+    container-runtime-endpoint: "/run/containerd/containerd.sock"
+    resolv-conf: "/run/systemd/resolve/resolv.conf"
 ---
 apiVersion: kubeadm.k8s.io/v1beta2
 kind: ClusterConfiguration

--- a/manage-cluster/kubeadm-config.yml.template
+++ b/manage-cluster/kubeadm-config.yml.template
@@ -2,6 +2,10 @@ apiVersion: kubeadm.k8s.io/v1beta2
 kind: InitConfiguration
 nodeRegistration:
   name: "{{MASTER_NAME}}"
+  kubeletExtraArgs:
+    container-runtime: "remote"
+    container-runtime-endpoint: "unix:///run/containerd/containerd.sock"
+    resolv-conf: "/run/systemd/resolve/resolv.conf"
 localAPIEndpoint:
   advertiseAddress: "{{INTERNAL_IP}}"
   bindPort: 6443

--- a/manage-cluster/kubeadm-config.yml.template
+++ b/manage-cluster/kubeadm-config.yml.template
@@ -23,7 +23,7 @@ nodeRegistration:
   name: "{{MASTER_NAME}}"
   kubeletExtraArgs:
     container-runtime: "remote"
-    container-runtime-endpoint: "/run/containerd/containerd.sock"
+    container-runtime-endpoint: "unix:///run/containerd/containerd.sock"
     resolv-conf: "/run/systemd/resolve/resolv.conf"
 ---
 apiVersion: kubeadm.k8s.io/v1beta2
@@ -51,6 +51,7 @@ hostnameOverride: "{{MASTER_NAME}}"
 apiVersion: kubelet.config.k8s.io/v1beta1
 kind: KubeletConfiguration
 cgroupDriver: systemd
+containerLogMaxSize: 100Mi
 # https://github.com/kubernetes-sigs/kubespray/blob/master/docs/kubernetes-reliability.md#medium-update-and-average-reaction
 nodeStatusUpdateFrequency: 20s
 podPidsLimit: 10000


### PR DESCRIPTION
The changes will cause the bootstrap scripts to produce API nodes/clusters using containerd as the CRI instead of Docker.

In sandbox I was able to completely redeploy the cluster. In staging and production this can be accomplished by deleting and replacing one master node at a time and using the `k8s_add_master_node.sh` script to readd them incrementally.

Now that we are using a "remote" CRI, instead of Docker, the kubelet will take over watching container log sizes. There is one configuration in this PR to set the same log size limit we had with Docker.

**NOTE**: We are still using Docker on the api-server nodes to launch ePoxy extensions and the gcp-loadbalancer-proxy service.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/528)
<!-- Reviewable:end -->
