### PR TITLE
Uses underscores for bmc_store_password image name

### DIFF
--- a/manage-cluster/cloud-config_master.yml
+++ b/manage-cluster/cloud-config_master.yml
@@ -50,7 +50,7 @@ write_files:
     ExecStartPre=-/usr/bin/docker rm %N
     ExecStart=/usr/bin/docker run --publish 8801:8801 \
                                   --name %N -- \
-                                  measurementlab/epoxy-extensions:bmc-store-password-v0.2.0
+                                  measurementlab/epoxy-extensions:bmc_store_password-v0.2.0
     ExecStop=/usr/bin/docker stop %N
 
     [Install]


### PR DESCRIPTION
This PR makes the use of underscores for ePoxy extension images the standard for bmc_store_password, and we should follow this same convention for future extensions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/531)
<!-- Reviewable:end -->
