### PR TITLE
Updates kured image + adds back --lock-ttl flag.

### DIFF
--- a/k8s/daemonsets/core/kured.jsonnet
+++ b/k8s/daemonsets/core/kured.jsonnet
@@ -27,9 +27,7 @@
             args: [
               '--reboot-sentinel=/var/run/mlab-reboot',
               '--period=1h',
-              // Annotation TTL should stay disabled until this bug is close:
-              // https://github.com/weaveworks/kured/issues/143
-              // '--annotation-ttl=4h',
+              '--lock-ttl=4h',
               // We may or may not want to enable something like the following
               // schedule for reboots. For now it is commented out until we can
               // gather more experience with Kured.
@@ -53,7 +51,7 @@
                 },
               },
             ],
-            image: 'weaveworks/kured:1.4.4',
+            image: 'weaveworks/kured:1.5.1',
             imagePullPolicy: 'IfNotPresent',
             name: 'kured',
             ports: [


### PR DESCRIPTION
Previously, we were using a flag named `--annotation-ttl` to set a timeout for a node to reboot. If the node didn't reboot within that time and remove the lock, then another node could forcefully remove and take the lock so that rolling reboots didn't get hung indefinitely because of one node failing. However, [there was a bug with that flag](https://github.com/weaveworks/kured/issues/143), and we removed it. The bug has since been resolved, apparently, and the flag renamed to `--lock-ttl`. This PR reintroduces that concept using the new flag, and updates kured to the latest version.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/533)
<!-- Reviewable:end -->
