### PR TITLE
Removes deprecated UsePrivilegeSeparation flag for sshd config

### DIFF
--- a/manage-cluster/cloud-config_master.yml
+++ b/manage-cluster/cloud-config_master.yml
@@ -108,7 +108,6 @@ write_files:
   permissions: 0600
   owner: root:root
   content: |
-    UsePrivilegeSeparation sandbox
     Subsystem sftp internal-sftp
     ClientAliveInterval 180
     UseDNS no

--- a/manage-cluster/cloud-config_node.yml
+++ b/manage-cluster/cloud-config_node.yml
@@ -14,7 +14,6 @@ write_files:
   permissions: 0600
   owner: root:root
   content: |
-    UsePrivilegeSeparation sandbox
     Subsystem sftp internal-sftp
     ClientAliveInterval 180
     UseDNS no


### PR DESCRIPTION
I happened to be looking at logs one one of the API servers in staging and noticed this message repeated constantly:

```
sshd[87757]: rexec line 1: Deprecated option UsePrivilegeSeparation
```

Looking into it, [that flag was deprecated several years ago](https://www.openssh.com/txt/release-7.5):

>  * This release deprecates the sshd_config UsePrivilegeSeparation
   option, thereby making privilege separation mandatory. Privilege
   separation has been on by default for almost 15 years and
   sandboxing has been on by default for almost the last five.

This PR just removes the explicit use of that flag for our cloud nodes (including API nodes).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/534)
<!-- Reviewable:end -->
