### PR TITLE
Migrates to non-legacy LB backend type + fixes containerd config

### DIFF
--- a/manage-cluster/README.md
+++ b/manage-cluster/README.md
@@ -33,7 +33,7 @@ These steps must be done manually before running the cluster bootstrap script.
 $ ./bootstrap_k8s_master_cluster.sh <gcp-project-name>
 ```
 
-# The ./bootstrap\_k8s\_master\_cluster.sh script
+# The ./bootstrap\_platform\_cluster.sh script
 This is a ridiculously long bash script, but it is not complicated; there are
 just a lot of steps to take and commands to be run. Additionally, line wrapping
 for readability makes is a good deal longer than it might otherwise be.  The
@@ -53,7 +53,7 @@ basic flow of the script boils down to this:
    target-pool. In essence, this forwarding-rule is the load balancer.
 5. Create a firewall rule allowing access to sshd and the k8s-api-server from
    anywhere.
- 
+
 ## Configure internal load balancing
 1. Determine/create an internal IP for the internal load balancer, and update
    Google Cloud DNS accordingly.
@@ -74,21 +74,3 @@ basic flow of the script boils down to this:
 5. Login to the GCE instance and install any necessary packages and
    configurations.
 6. Configure k8s and etcd using `kubeadm`.
-
-# gcp-loadbalancer-proxy
-Our k8s api servers only run over HTTPS, but currently the TCP network load
-balancer in GCP only supports HTTP health checks. Therefore we must run a
-container that will expose an HTTP port and will run an HTTPS request on the
-api-server on the localhost. From
-https://cloud.google.com/load-balancing/docs/network/:
-
-> Network Load Balancing relies on legacy HTTP Health checks for determining
-> instance health. Even if your service does not use HTTP, you'll need to at least
-> run a basic web server on each instance that the health check system can
-> query.
-
-https://github.com/kubernetes/kubernetes/issues/43784#issuecomment-415090237
-
-For this purpose a special purpose
-[gcp-loadbalancer-proxy](https://github.com/m-lab/gcp-loadbalancer-proxy) was
-created. It gets installed automatically in bootstrap\_k8s\_master\_cluster.sh.

--- a/manage-cluster/README.md
+++ b/manage-cluster/README.md
@@ -1,8 +1,8 @@
-All setup and startup scripts for cloud and cloud networking.
+# All setup and startup scripts for cloud and cloud networking.
 
 The scripts need to be run from this directory.
 
-To set up a high availability k8s cloud master and etcd, run the following
+To set up a high availability k8s API and etcd cluster, run the following
 command, replacing <gcp-project-name> with the name of your GCP project (e.g.,
 mlab-sandbox). NOTE: be sure look at and modify the global variables in the
 file ./k8s\_deploy.conf appropriately, else the results will not be what you
@@ -22,7 +22,7 @@ These steps must be done manually before running the cluster bootstrap script.
   name of the GCS bucket can be found in ./k8s\_deploy.conf in one of the
   variables named like `GCS\_BUCKET\_K8S\_<project>`. For example:
   ```
-  $ gsutil mb gs://k8s-platform-master-mlab-sandbox/
+  $ gsutil mb gs://k8s-support-mlab-sandbox/
   ```
 * ePoxy must be deployed before the k8s cluster is deployed, as the k8s cluster
   depends on being able to determine the ePoxy subnet so that it can
@@ -30,7 +30,7 @@ These steps must be done manually before running the cluster bootstrap script.
   and the token server.
 
 ```bash
-$ ./bootstrap_k8s_master_cluster.sh <gcp-project-name>
+$ ./bootstrap_platform_cluster.sh <gcp-project-name>
 ```
 
 # The ./bootstrap\_platform\_cluster.sh script
@@ -45,30 +45,29 @@ basic flow of the script boils down to this:
 ## Configure external load balancing
 1. Determine/create a public IP for the external load balancer, and update
    Google Cloud DNS accordingly.
-2. Create an http-health-check for the GCE instances, which will be used by the
+2. Create an https health-check for the GCE instances, which will be used by the
    external load balancer.
-3. Create a target-pool for the external load balancer. Our GCE instances will
-   be added to this target-pool.
+3. Create a backend-service for the external load balancer. Our GCE instances
+   will be added to this backend-service.
 4. Create a forwarding-rule that uses our external load balancer IP and our
-   target-pool. In essence, this forwarding-rule is the load balancer.
+   backend-service.
 5. Create a firewall rule allowing access to sshd and the k8s-api-server from
    anywhere.
 
 ## Configure internal load balancing
 1. Determine/create an internal IP for the internal load balancer, and update
    Google Cloud DNS accordingly.
-2. Create a basic TCP health-check for the token-servers, which run on each GCE
-   instance.
-3. Create a backend-service for the internal load balancer.
-4. Create a forwarding-rule that uses our internal load balancer IP and our
-   backend-service.
+2. Create a basic TCP health-check for ePoxy extensions, which run on each GCE
+   API cluster instance.
+3. Create backend-services for the internal load balancers.
+4. Create forwarding-rules that use our internal load balancers' IPs and our
+   backend-services.
 5. Create a firewall rule allowing unrestricted access between instances in our
    VPC subnet.
 
 ## Create one GCE instance for each zone in $GCE\_ZONES
 1. Determine/create a public IP for the GCE instance, and update Google Cloud
    DNS accordingly.
-2. Add the GCE instance to the target-pool created earlier.
 3. Create an instance-group for the zone, and add the GCE instance to it.
 4. Add the instance-group to the backend-service we created earlier.
 5. Login to the GCE instance and install any necessary packages and

--- a/manage-cluster/add_k8s_master_node.sh
+++ b/manage-cluster/add_k8s_master_node.sh
@@ -97,7 +97,7 @@ EOF
 # If they exist, delete the node name from various loadbalancer group resources.
 delete_server_backend "${GCE_NAME}" "${GCE_ZONE}" "${TOKEN_SERVER_BASE_NAME}"
 delete_server_backend "${GCE_NAME}" "${GCE_ZONE}" "${BMC_STORE_PASSWORD_BASE_NAME}"
-delete_server_backend "${GCE_NAME}" "${GCE_ZONE}" "${GCE_BASE_NAME"
+delete_server_backend "${GCE_NAME}" "${GCE_ZONE}" "${GCE_BASE_NAME}"
 delete_instance_group "${GCE_NAME}" "${GCE_ZONE}"
 
 # Now add the new master.

--- a/manage-cluster/add_k8s_master_node.sh
+++ b/manage-cluster/add_k8s_master_node.sh
@@ -97,7 +97,7 @@ EOF
 # If they exist, delete the node name from various loadbalancer group resources.
 delete_server_backend "${GCE_NAME}" "${GCE_ZONE}" "${TOKEN_SERVER_BASE_NAME}"
 delete_server_backend "${GCE_NAME}" "${GCE_ZONE}" "${BMC_STORE_PASSWORD_BASE_NAME}"
-delete_target_pool_instance "${GCE_NAME}" "${GCE_ZONE}"
+delete_server_backend "${GCE_NAME}" "${GCE_ZONE}" "${GCE_BASE_NAME"
 delete_instance_group "${GCE_NAME}" "${GCE_ZONE}"
 
 # Now add the new master.

--- a/manage-cluster/bootstrap_platform_cluster.sh
+++ b/manage-cluster/bootstrap_platform_cluster.sh
@@ -439,7 +439,7 @@ gcloud compute backend-services create "${GCE_BASE_NAME}" \
 
 # Create the forwarding rule for the API load balancer.
 gcloud compute forwarding-rules create "${GCE_BASE_NAME}" \
-    --address "${EXTERNAL_LB_IP}" \
+    --address "${GCE_BASE_NAME}-lb" \
     --ports 6443 \
     --region "${GCE_REGION}" \
     --backend-service "${GCE_BASE_NAME}" \

--- a/manage-cluster/bootstraplib.sh
+++ b/manage-cluster/bootstraplib.sh
@@ -203,14 +203,6 @@ function create_master {
     cp etcd-${ETCDCTL_VERSION}-linux-amd64/etcdctl /opt/bin
     rm -rf etcd-${ETCDCTL_VERSION}-linux-amd64
 
-    # Configure containerd. We only need to make one change to the default
-    # configuration, which is to configure runc to use the systemd cgroup
-    # driver.
-    mkdir /etc/containerd
-    containerd config default | \
-      sed -e '/containerd\.runtimes\.runc/a \          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]\n            SystemdCgroup = true' \
-      > /etc/containerd/config.toml
-
     # Enable and start the kubelet service
     systemctl enable --now kubelet.service
     systemctl daemon-reload

--- a/manage-cluster/cloud-config_master.yml
+++ b/manage-cluster/cloud-config_master.yml
@@ -27,7 +27,7 @@ write_files:
                                   --volume /etc:/etc:ro \
                                   --volume /:/ro:ro \
                                   --name %N -- \
-                                  measurementlab/epoxy-extensions:token_server-v0.2.0 \
+                                  measurementlab/epoxy-extensions:token_server-v0.2.1 \
                                   -command /ro/opt/bin/kubeadm
     ExecStop=/usr/bin/docker stop %N
 
@@ -50,7 +50,7 @@ write_files:
     ExecStartPre=-/usr/bin/docker rm %N
     ExecStart=/usr/bin/docker run --publish 8801:8801 \
                                   --name %N -- \
-                                  measurementlab/epoxy-extensions:bmc_store_password-v0.2.0
+                                  measurementlab/epoxy-extensions:bmc_store_password-v0.2.1
     ExecStop=/usr/bin/docker stop %N
 
     [Install]

--- a/manage-cluster/cloud-config_master.yml
+++ b/manage-cluster/cloud-config_master.yml
@@ -56,30 +56,6 @@ write_files:
     [Install]
     WantedBy=multi-user.target
 
-- path: /etc/systemd/system/gcp-loadbalancer-proxy.service
-  permissions: 0644
-  owner: root
-  content: |
-    [Unit]
-    Description=gcp-loadbalancer-proxy
-    After=docker.service
-    Requires=docker.service
-
-    [Service]
-    TimeoutStartSec=120
-    Restart=always
-    ExecStartPre=-/usr/bin/docker stop %N
-    ExecStartPre=-/usr/bin/docker rm %N
-    ExecStart=/usr/bin/docker run --publish 8080:8080 \
-                                  --network host \
-                                  --name %N -- \
-                                  measurementlab/gcp-loadbalancer-proxy:v1.0 \
-                                  -url https://localhost:6443
-    ExecStop=/usr/bin/docker stop %N
-
-    [Install]
-    WantedBy=multi-user.target
-
 - path: /etc/systemd/system/reboot-node.service
   permissions: 0644
   owner: root
@@ -186,8 +162,6 @@ runcmd:
 - systemctl daemon-reload
 - systemctl enable docker
 - systemctl start docker
-- systemctl enable gcp-loadbalancer-proxy.service
-- systemctl start gcp-loadbalancer-proxy.service
 - systemctl enable reboot-node.timer
 - systemctl start reboot-node.timer
 - systemctl enable token-server.service

--- a/manage-cluster/cloud-config_master.yml
+++ b/manage-cluster/cloud-config_master.yml
@@ -94,6 +94,137 @@ write_files:
     ChallengeResponseAuthentication no
     PermitRootLogin no
 
+# This is the default containerd config, as produced by `container config
+# default` with two small changes. It changes the runc "runtime_type" to
+# "io.containerd.runc.v2" and adds:
+# [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+#    SystemdCgroup = true
+- path: /etc/containerd/config.toml
+  permissions: 0644
+  owner: root:root
+  content: |
+    version = 2
+    root = "/var/lib/containerd"
+    state = "/run/containerd"
+    plugin_dir = ""
+    disabled_plugins = []
+    required_plugins = []
+    oom_score = 0
+
+    [grpc]
+      address = "/run/containerd/containerd.sock"
+      tcp_address = ""
+      tcp_tls_cert = ""
+      tcp_tls_key = ""
+      uid = 0
+      gid = 0
+      max_recv_message_size = 16777216
+      max_send_message_size = 16777216
+
+    [ttrpc]
+      address = ""
+      uid = 0
+      gid = 0
+
+    [debug]
+      address = ""
+      uid = 0
+      gid = 0
+      level = ""
+
+    [metrics]
+      address = ""
+      grpc_histogram = false
+
+    [cgroup]
+      path = ""
+
+    [timeouts]
+      "io.containerd.timeout.shim.cleanup" = "5s"
+      "io.containerd.timeout.shim.load" = "5s"
+      "io.containerd.timeout.shim.shutdown" = "3s"
+      "io.containerd.timeout.task.state" = "2s"
+
+    [plugins]
+      [plugins."io.containerd.gc.v1.scheduler"]
+        pause_threshold = 0.02
+        deletion_threshold = 0
+        mutation_threshold = 100
+        schedule_delay = "0s"
+        startup_delay = "100ms"
+      [plugins."io.containerd.grpc.v1.cri"]
+        disable_tcp_service = true
+        stream_server_address = "127.0.0.1"
+        stream_server_port = "0"
+        stream_idle_timeout = "4h0m0s"
+        enable_selinux = false
+        sandbox_image = "k8s.gcr.io/pause:3.1"
+        stats_collect_period = 10
+        systemd_cgroup = false
+        enable_tls_streaming = false
+        max_container_log_line_size = 16384
+        disable_cgroup = false
+        disable_apparmor = false
+        restrict_oom_score_adj = false
+        max_concurrent_downloads = 3
+        disable_proc_mount = false
+        [plugins."io.containerd.grpc.v1.cri".containerd]
+          snapshotter = "overlayfs"
+          default_runtime_name = "runc"
+          no_pivot = false
+          [plugins."io.containerd.grpc.v1.cri".containerd.default_runtime]
+            runtime_type = ""
+            runtime_engine = ""
+            runtime_root = ""
+            privileged_without_host_devices = false
+          [plugins."io.containerd.grpc.v1.cri".containerd.untrusted_workload_runtime]
+            runtime_type = ""
+            runtime_engine = ""
+            runtime_root = ""
+            privileged_without_host_devices = false
+          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
+            [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+              runtime_type = "io.containerd.runc.v2"
+              runtime_engine = ""
+              runtime_root = ""
+              privileged_without_host_devices = false
+              [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+                SystemdCgroup = true
+        [plugins."io.containerd.grpc.v1.cri".cni]
+          bin_dir = "/opt/cni/bin"
+          conf_dir = "/etc/cni/net.d"
+          max_conf_num = 1
+          conf_template = ""
+        [plugins."io.containerd.grpc.v1.cri".registry]
+          [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
+            [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
+              endpoint = ["https://registry-1.docker.io"]
+        [plugins."io.containerd.grpc.v1.cri".x509_key_pair_streaming]
+          tls_cert_file = ""
+          tls_key_file = ""
+      [plugins."io.containerd.internal.v1.opt"]
+        path = "/opt/containerd"
+      [plugins."io.containerd.internal.v1.restart"]
+        interval = "10s"
+      [plugins."io.containerd.metadata.v1.bolt"]
+        content_sharing_policy = "shared"
+      [plugins."io.containerd.monitor.v1.cgroups"]
+        no_prometheus = false
+      [plugins."io.containerd.runtime.v1.linux"]
+        shim = "containerd-shim"
+        runtime = "runc"
+        runtime_root = ""
+        no_shim = false
+        shim_debug = false
+      [plugins."io.containerd.runtime.v2.task"]
+        platforms = ["linux/amd64"]
+      [plugins."io.containerd.service.v1.diff-service"]
+        default = ["walking"]
+      [plugins."io.containerd.snapshotter.v1.devmapper"]
+        root_path = ""
+        pool_name = ""
+        base_image_size = ""
+
 # We have run up against "no space left on device" errors, when clearly
 # there is plenty of free disk space. It seems this could likely be related
 # to this:


### PR DESCRIPTION
While investigating https://github.com/m-lab/k8s-support/issues/535, I realized that we were using a legacy load balancer backend type ("target pool"). In a first attempt to resolve #535 I tried migrating our LB to use a "backend service" backend type instead. It didn't fix the issue, but it had one good result, in that the new backend-service type supports all sorts of health checks (target pools only support "legacy" HTTP checks). This means that we no longer need the [gcp-loadbalancer-proxy](https://github.com/m-lab/gcp-loadbalancer-proxy) container for health checks. The vast majority of this PR is migrating from the legacy "target-pool" backed to the "backend-service" backend.

Additionally, I discovered that in TOML indentation doesn't matter, hence the way I was configuring containerd was incorrect. This PR moves away from using a somewhat cryptic `sed` statement to actually writing the entire config file out using the cloud-init config.

This PR should resolve #535, too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/538)
<!-- Reviewable:end -->
