### PR TITLE
Allow up to 5 concurrent connections

### DIFF
--- a/k8s/daemonsets/experiments/wehe.jsonnet
+++ b/k8s/daemonsets/experiments/wehe.jsonnet
@@ -58,7 +58,7 @@ exp.Experiment(expName, 5, 'pusher-' + std.extVar('PROJECT_ID'), 'netblock', ['r
                 },
               },
             ],
-            image: 'measurementlab/access:v0.0.8',
+            image: 'measurementlab/access:v0.0.9',
             name: 'access',
             securityContext: {
               capabilities: {

--- a/k8s/daemonsets/experiments/wehe.jsonnet
+++ b/k8s/daemonsets/experiments/wehe.jsonnet
@@ -41,6 +41,7 @@ exp.Experiment(expName, 5, 'pusher-' + std.extVar('PROJECT_ID'), 'netblock', ['r
               '-envelope.cert=/certs/tls.crt',
               '-envelope.listen-address=:4443',
               '-envelope.device=net1',
+              '-envelope.max-clients=5',
               '-envelope.subject=wehe',
               '-envelope.machine=$(MLAB_NODE_NAME)',
               '-envelope.verify-key=/verify/jwk_sig_EdDSA_locate_20200409.pub',


### PR DESCRIPTION
Applied manually in production on 2021-01-15. This change brings config in sync.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/539)
<!-- Reviewable:end -->
