### PR TITLE
Use explicit dns config

### DIFF
--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -480,10 +480,12 @@ local Experiment(name, index, bucket, anonMode, datatypes=[]) = ExperimentNoInde
         },
       },
       spec+: {
-        //dnsPolicy: 'None',
-        //dnsConfig: {
-        //  nameservers: ['8.8.8.8'],
-        //},
+        // default kube-dns configuration because M-Lab pod networks bypass
+        // kubernetes Services iptables rules.
+        dnsPolicy: 'None',
+        dnsConfig: {
+          nameservers: ['8.8.8.8'],
+        },
         // Only enable extended grace period where production traffic is possible.
         [if std.extVar('PROJECT_ID') != 'mlab-sandbox' then 'terminationGracePeriodSeconds']: terminationGracePeriodSeconds,
       },

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -480,6 +480,7 @@ local Experiment(name, index, bucket, anonMode, datatypes=[]) = ExperimentNoInde
         },
       },
       spec+: {
+        // NOTE(github.com/m-lab/k8s-support/issues/542): this overrides the
         // default kube-dns configuration because M-Lab pod networks bypass
         // kubernetes Services iptables rules.
         dnsPolicy: 'None',

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -480,19 +480,10 @@ local Experiment(name, index, bucket, anonMode, datatypes=[]) = ExperimentNoInde
         },
       },
       spec+: {
-        initContainers+: [
-          // TODO: this is a hack. Remove the hack by fixing
-          // contents of resolv.
-          {
-            name: 'fix-resolv-conf',
-            image: 'busybox',
-            command: [
-              'sh',
-              '-c',
-              'echo "nameserver 8.8.8.8" > /etc/resolv.conf',
-            ],
-          },
-        ],
+        dnsPolicy: 'None',
+        dnsConfig: {
+          nameservers: ['8.8.8.8'],
+        },
         // Only enable extended grace period where production traffic is possible.
         [if std.extVar('PROJECT_ID') != 'mlab-sandbox' then 'terminationGracePeriodSeconds']: terminationGracePeriodSeconds,
       },

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -480,10 +480,10 @@ local Experiment(name, index, bucket, anonMode, datatypes=[]) = ExperimentNoInde
         },
       },
       spec+: {
-        dnsPolicy: 'None',
-        dnsConfig: {
-          nameservers: ['8.8.8.8'],
-        },
+        //dnsPolicy: 'None',
+        //dnsConfig: {
+        //  nameservers: ['8.8.8.8'],
+        //},
         // Only enable extended grace period where production traffic is possible.
         [if std.extVar('PROJECT_ID') != 'mlab-sandbox' then 'terminationGracePeriodSeconds']: terminationGracePeriodSeconds,
       },


### PR DESCRIPTION
This change removes the initContainer that manually overwrites the content of /etc/resolv.conf in favor of using the native k8s support for specifying the `dnsPolicy` and `dnsConfig` -- see also: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/541)
<!-- Reviewable:end -->
