### PR TITLE
Update MAX_RATE_10G to 25%

### DIFF
--- a/manage-cluster/k8s_deploy.conf
+++ b/manage-cluster/k8s_deploy.conf
@@ -80,13 +80,13 @@ GCS_BUCKET_SITEINFO_mlab_oti="siteinfo-mlab-oti"
 REBOOT_DAYS=(Tue Wed Thu)
 
 # Configurations for setting the --max-rate flag in ndt-server.  For 1g sites
-# we are starting with a conservative value of 25% of the uplink, as this will
-# be applied per-node. For 10g sites we use a more liberal value of 80%. The
-# values are in bits.
+# we are starting with a conservative value of 15% of the uplink, because
+# single clients may be very fast and this is applied per-node. For 10g
+# sites we use a more liberal value of 25%. The values are in bits.
 MAX_RATES_DIR="nodes-max-rate"
 MAX_RATES_CONFIGMAP="nodes-max-rate"
 MAX_RATE_1G="150000000"
-MAX_RATE_10G="8000000000"
+MAX_RATE_10G="2500000000"
 
 # Whether the script should exit after deleting all existing GCP resources
 # associated with creating this k8s cluster. This could be useful, for example,


### PR DESCRIPTION
During a recent flash crowd, we saw uplink saturation for some 10G sites and during this load, at least 30% of ndt measurements were taken at the same time switch discards were observed.

This change updates the MAX_RATE_10G to 25% of uplink so that if all three nodes have very fast clients, fewer measurements will content for the uplink.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/545)
<!-- Reviewable:end -->
