### PR TITLE
Updates Prometheus to version v2.24.1

### DIFF
--- a/k8s/deployments/prometheus.jsonnet
+++ b/k8s/deployments/prometheus.jsonnet
@@ -39,7 +39,7 @@ local prometheusConfig = import '../../config/prometheus.jsonnet';
               '--web.enable-lifecycle',
               '--storage.tsdb.retention.time=2880h',
             ],
-            image: 'prom/prometheus:v2.16.0',
+            image: 'prom/prometheus:v2.24.1',
             name: 'prometheus',
             ports: [
               {


### PR DESCRIPTION
This small PR updates Prometheus to version 2.24.1, the latest available at the time of this writing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/547)
<!-- Reviewable:end -->
