### PR TITLE
Updates URLs for kubelet.service and 10-kubeadm.conf

### DIFF
--- a/manage-cluster/bootstraplib.sh
+++ b/manage-cluster/bootstraplib.sh
@@ -192,10 +192,10 @@ function create_master {
     chmod +x {kubeadm,kubelet,kubectl}
 
     # Install kubelet systemd service and enable it.
-    curl -sSL "https://raw.githubusercontent.com/kubernetes/kubernetes/${K8S_VERSION}/build/debs/kubelet.service" \
+    curl -sSL "https://raw.githubusercontent.com/kubernetes/release/v0.7.0/cmd/kubepkg/templates/latest/deb/kubelet/lib/systemd/system/kubelet.service" \
         | sed "s:/usr/bin:/opt/bin:g" > /etc/systemd/system/kubelet.service
     mkdir -p /etc/systemd/system/kubelet.service.d
-    curl -sSL "https://raw.githubusercontent.com/kubernetes/kubernetes/${K8S_VERSION}/build/debs/10-kubeadm.conf" \
+    curl -sSL ""https://raw.githubusercontent.com/kubernetes/release/v0.7.0/cmd/kubepkg/templates/latest/deb/kubeadm/10-kubeadm.conf" \
         | sed "s:/usr/bin:/opt/bin:g" > /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
 
     # Install etcdctl


### PR DESCRIPTION
This change has [already been made in epoxy-images](https://github.com/m-lab/epoxy-images/pull/198/files), and we now need to make it in this repo too. These files must have been _very_ recently removed from the `kubernetes/kubernetes` repo, since deployments worked fine for mlab-sandbox and mlab-staging a week or so ago, but are now failing in production without these changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/548)
<!-- Reviewable:end -->
