### PR TITLE
Installs conntrack, needby by k8s now

### DIFF
--- a/manage-cluster/cloud-config_master.yml
+++ b/manage-cluster/cloud-config_master.yml
@@ -283,6 +283,7 @@ write_files:
     }
 
 packages:
+- conntrack
 - docker.io
 - socat
 - vim


### PR DESCRIPTION
This, too, [was already done in epoxy-images](https://github.com/m-lab/epoxy-images/pull/198/files), and now needs to be done for API nodes, too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/550)
<!-- Reviewable:end -->
