### PR TITLE
Update systemd flag and use latest static version

### DIFF
--- a/k8s/daemonsets/core/node-exporter.jsonnet
+++ b/k8s/daemonsets/core/node-exporter.jsonnet
@@ -54,9 +54,6 @@
             ],
             image: 'quay.io/prometheus/node-exporter:v1.1.0',
             name: 'node-exporter',
-            nodeSelector: {
-              'mlab/type': 'physical',
-            },
             resources: {
               limits: {
                 cpu: '250m',
@@ -133,6 +130,9 @@
         ],
         hostNetwork: true,
         hostPID: true,
+        nodeSelector: {
+          'mlab/type': 'physical',
+        },
         serviceAccountName: 'kube-rbac-proxy',
         tolerations: [
           {

--- a/k8s/daemonsets/core/node-exporter.jsonnet
+++ b/k8s/daemonsets/core/node-exporter.jsonnet
@@ -33,7 +33,7 @@
               '--collector.filesystem.ignored-fs-types=^(autofs|binfmt_misc|cgroup|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|mqueue|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|sysfs|tracefs)$',
               '--collector.netstat.fields=^(.*_(InErrors|InErrs)|Ip_Forwarding|Ip(6|Ext)_(InOctets|OutOctets)|Icmp6?_(InMsgs|OutMsgs)|TcpExt_(TCPDSACK.*|Listen.*|Syncookies.*|TCPSynRetrans)|Tcp_(ActiveOpens|InSegs|OutSegs|PassiveOpens|RetransSegs|CurrEstab)|Udp6?_(InDatagrams|OutDatagrams|NoPorts))$',
               '--collector.systemd',
-              '--collector.systemd.unit-whitelist=^(setup-after-boot.service|system-cloudinit.+|docker.service|kubelet.service)',
+              '--collector.systemd.unit-include=^(setup-after-boot.service|system-cloudinit.+|docker.service|kubelet.service)',
               '--collector.processes',
               '--no-collector.arp',
               '--no-collector.bcache',
@@ -52,7 +52,7 @@
               '--no-collector.vmstat',
               '--no-collector.zfs',
             ],
-            image: 'quay.io/prometheus/node-exporter',
+            image: 'quay.io/prometheus/node-exporter:v1.1.0',
             name: 'node-exporter',
             resources: {
               limits: {

--- a/k8s/daemonsets/core/node-exporter.jsonnet
+++ b/k8s/daemonsets/core/node-exporter.jsonnet
@@ -33,7 +33,7 @@
               '--collector.filesystem.ignored-fs-types=^(autofs|binfmt_misc|cgroup|configfs|debugfs|devpts|devtmpfs|fusectl|hugetlbfs|mqueue|overlay|proc|procfs|pstore|rpc_pipefs|securityfs|sysfs|tracefs)$',
               '--collector.netstat.fields=^(.*_(InErrors|InErrs)|Ip_Forwarding|Ip(6|Ext)_(InOctets|OutOctets)|Icmp6?_(InMsgs|OutMsgs)|TcpExt_(TCPDSACK.*|Listen.*|Syncookies.*|TCPSynRetrans)|Tcp_(ActiveOpens|InSegs|OutSegs|PassiveOpens|RetransSegs|CurrEstab)|Udp6?_(InDatagrams|OutDatagrams|NoPorts))$',
               '--collector.systemd',
-              '--collector.systemd.unit-include=^(setup-after-boot.service|system-cloudinit.+|docker.service|kubelet.service)',
+              '--collector.systemd.unit-include=^(setup-after-boot.service|containerd.service|configure-tc-fq.service|kubelet.service)',
               '--collector.processes',
               '--no-collector.arp',
               '--no-collector.bcache',
@@ -54,6 +54,9 @@
             ],
             image: 'quay.io/prometheus/node-exporter:v1.1.0',
             name: 'node-exporter',
+            nodeSelector: {
+              'mlab/type': 'physical',
+            },
             resources: {
               limits: {
                 cpu: '250m',


### PR DESCRIPTION
The unpinned version led to an uncontrolled deployment of the latest node exporter version, which included changes to flags.

This change pins the version and updates the flag.

```
panic: Couldn't create metrics handler: couldn't create collector: --collector.systemd.unit-whitelist and --collector.systemd.unit-include are mutually exclusive
goroutine 1 [running]:
main.newHandler(0xc000218f01, 0x28, 0xd0cf40, 0xc0002bd200, 0x0)
	/app/node_exporter.go:64 +0x317
main.main()
	/app/node_exporter.go:184 +0x1052
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/551)
<!-- Reviewable:end -->
