### PR TITLE
Updates kube-state-metrics + increase Prometheus VM size

### DIFF
--- a/k8s/deployments/kube-state-metrics.jsonnet
+++ b/k8s/deployments/kube-state-metrics.jsonnet
@@ -30,7 +30,7 @@
             args: [
               '--collectors=daemonsets,deployments,nodes,pods,resourcequotas,services',
             ],
-            image: 'quay.io/coreos/kube-state-metrics:v1.8.0',
+            image: 'k8s.gcr.io/kube-state-metrics/kube-state-metrics:v1.9.7',
             name: 'kube-state-metrics',
             ports: [
               {
@@ -50,46 +50,10 @@
               initialDelaySeconds: 5,
               timeoutSeconds: 5,
             },
-          },
-          {
-            command: [
-              '/pod_nanny',
-              '--container=kube-state-metrics',
-              '--cpu=100m',
-              '--extra-cpu=1m',
-              '--memory=100Mi',
-              '--extra-memory=2Mi',
-              '--threshold=5',
-              '--deployment=kube-state-metrics',
-            ],
-            env: [
-              {
-                name: 'MY_POD_NAME',
-                valueFrom: {
-                  fieldRef: {
-                    fieldPath: 'metadata.name',
-                  },
-                },
-              },
-              {
-                name: 'MY_POD_NAMESPACE',
-                valueFrom: {
-                  fieldRef: {
-                    fieldPath: 'metadata.namespace',
-                  },
-                },
-              },
-            ],
-            image: 'k8s.gcr.io/addon-resizer:1.8.3',
-            name: 'addon-resizer',
             resources: {
               limits: {
-                cpu: '150m',
-                memory: '50Mi',
-              },
-              requests: {
-                cpu: '150m',
-                memory: '50Mi',
+                cpu: '1',
+                memory: '1500Mi',
               },
             },
           },

--- a/k8s/deployments/kube-state-metrics.jsonnet
+++ b/k8s/deployments/kube-state-metrics.jsonnet
@@ -30,7 +30,7 @@
             args: [
               '--collectors=daemonsets,deployments,nodes,pods,resourcequotas,services',
             ],
-            image: 'k8s.gcr.io/kube-state-metrics/kube-state-metrics:v1.9.7',
+            image: 'quay.io/coreos/kube-state-metrics:v1.9.7',
             name: 'kube-state-metrics',
             ports: [
               {

--- a/k8s/deployments/kube-state-metrics.jsonnet
+++ b/k8s/deployments/kube-state-metrics.jsonnet
@@ -50,6 +50,8 @@
               initialDelaySeconds: 5,
               timeoutSeconds: 5,
             },
+            // Resources based on:
+            // https://github.com/kubernetes/kube-state-metrics#resource-recommendation
             resources: {
               limits: {
                 cpu: '1',

--- a/manage-cluster/bootstrap_prometheus.sh
+++ b/manage-cluster/bootstrap_prometheus.sh
@@ -45,7 +45,7 @@ case $PROJECT in
     DISK_SIZE="1500GB"
     ;;
   mlab-oti)
-    MACHINE_TYPE="n1-highmem-16"
+    MACHINE_TYPE="n2-highmem-16"
     DISK_SIZE="2500GB"
     ;;
   *)


### PR DESCRIPTION
This PR updates kube-state-metrics and also removes the `addon-resizer` container from the pod. Current documentation for kube-state-metrics makes no mention of this sidecar container and today it was getting oom-killed. Now, the kube-state-metrics container defines its own static resource limits based on [some (possibly outdated) recommendations](https://github.com/kubernetes/kube-state-metrics#resource-recommendation). The current settings consider a node count of roughly 500, and then adds in plenty of breathing room.

We are also generally seeing an increase in the memory usage of Prometheus, and the VM seems to now however at around 80% of it's memory capacity, with spikes near the limit. This PR changes the VM type for Prometheus from n1-highmem-16 to [n2-highmem-16](https://cloud.google.com/compute/docs/machine-types#n2_machine_types), which not only brings in ~25GB more memory but also sports faster CPUs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/556)
<!-- Reviewable:end -->
