### PR TITLE
Add -basicauth subdomain for the platform-cluster Prometheus

### DIFF
--- a/k8s/clusterissuers/letsencrypt-staging.jsonnet
+++ b/k8s/clusterissuers/letsencrypt-staging.jsonnet
@@ -26,6 +26,7 @@
           selector: {
             dnsNames: [
               'prometheus-platform-cluster.' + std.extVar('PROJECT_ID') + '.measurementlab.net',
+              'prometheus-platform-cluster-basicauth.' + std.extVar('PROJECT_ID') + '.measurementlab.net',
             ],
           },
         },

--- a/k8s/clusterissuers/letsencrypt.jsonnet
+++ b/k8s/clusterissuers/letsencrypt.jsonnet
@@ -21,6 +21,7 @@
           selector: {
             dnsNames: [
               'prometheus-platform-cluster.' + std.extVar('PROJECT_ID') + '.measurementlab.net',
+              'prometheus-platform-cluster-basicauth.' + std.extVar('PROJECT_ID') + '.measurementlab.net',
             ],
           },
         },

--- a/k8s/services/prometheus-tls-basic-ingress.jsonnet
+++ b/k8s/services/prometheus-tls-basic-ingress.jsonnet
@@ -15,6 +15,11 @@
   spec: {
     tls: [
       {
+        // We generate a single certificate for the OAuth and the basic auth 
+        // domains. The reason for this is that LetsEncrypt's CN fields cannot
+        // be longer than 64 characters, and the -basicauth is just barely
+        // above that. By putting them together, only the first domain is used
+        // in the CN field.
         hosts: [
           'prometheus-platform-cluster.' + std.extVar('PROJECT_ID') + '.measurementlab.net',
           'prometheus-platform-cluster-basicauth.' + std.extVar('PROJECT_ID') + '.measurementlab.net',

--- a/k8s/services/prometheus-tls-basic-ingress.jsonnet
+++ b/k8s/services/prometheus-tls-basic-ingress.jsonnet
@@ -16,9 +16,10 @@
     tls: [
       {
         hosts: [
+          'prometheus-platform-cluster.' + std.extVar('PROJECT_ID') + '.measurementlab.net',
           'prometheus-platform-cluster-basicauth.' + std.extVar('PROJECT_ID') + '.measurementlab.net',
         ],
-        secretName: 'prometheus-tls-basicauth',
+        secretName: 'prometheus-tls',
       },
     ],
     rules: [

--- a/k8s/services/prometheus-tls-basic-ingress.jsonnet
+++ b/k8s/services/prometheus-tls-basic-ingress.jsonnet
@@ -1,0 +1,41 @@
+{
+  apiVersion: 'networking.k8s.io/v1beta1',
+  kind: 'Ingress',
+  metadata: {
+    name: 'prometheus-tls',
+    namespace: 'default',
+    annotations: {
+      'kubernetes.io/tls-acme': 'true',
+      'kubernetes.io/ingress.class': 'nginx',
+      'nginx.ingress.kubernetes.io/auth-type': 'basic',
+      'nginx.ingress.kubernetes.io/auth-secret': 'prometheus-htpasswd',
+      'nginx.ingress.kubernetes.io/auth-realm': 'Authentication Required',
+    },
+  },
+  spec: {
+    tls: [
+      {
+        hosts: [
+          'prometheus-platform-cluster-basicauth.' + std.extVar('PROJECT_ID') + '.measurementlab.net',
+        ],
+        secretName: 'prometheus-tls',
+      },
+    ],
+    rules: [
+      {
+        host: 'prometheus-platform-cluster-basicauth.' + std.extVar('PROJECT_ID') + '.measurementlab.net',
+        http: {
+          paths: [
+            {
+              path: '/',
+              backend: {
+                serviceName: 'prometheus-tls',
+                servicePort: 9090,
+              },
+            },
+          ],
+        },
+      },
+    ],
+  },
+}

--- a/k8s/services/prometheus-tls-basic-ingress.jsonnet
+++ b/k8s/services/prometheus-tls-basic-ingress.jsonnet
@@ -18,7 +18,7 @@
         hosts: [
           'prometheus-platform-cluster-basicauth.' + std.extVar('PROJECT_ID') + '.measurementlab.net',
         ],
-        secretName: 'prometheus-tls',
+        secretName: 'prometheus-tls-basicauth',
       },
     ],
     rules: [

--- a/k8s/services/prometheus-tls-basic-ingress.jsonnet
+++ b/k8s/services/prometheus-tls-basic-ingress.jsonnet
@@ -2,7 +2,7 @@
   apiVersion: 'networking.k8s.io/v1beta1',
   kind: 'Ingress',
   metadata: {
-    name: 'prometheus-tls',
+    name: 'prometheus-tls-basic',
     namespace: 'default',
     annotations: {
       'kubernetes.io/tls-acme': 'true',

--- a/k8s/services/prometheus-tls-ingress.jsonnet
+++ b/k8s/services/prometheus-tls-ingress.jsonnet
@@ -17,6 +17,7 @@
       {
         hosts: [
           'prometheus-platform-cluster.' + std.extVar('PROJECT_ID') + '.measurementlab.net',
+          'prometheus-platform-cluster-basicauth.' + std.extVar('PROJECT_ID') + '.measurementlab.net',
         ],
         secretName: 'prometheus-tls',
       },

--- a/system.jsonnet
+++ b/system.jsonnet
@@ -36,6 +36,7 @@
     // Services
     import 'k8s/services/prometheus-tls.jsonnet',
     import 'k8s/services/prometheus-tls-ingress.jsonnet',
+    import 'k8s/services/prometheus-tls-basic-ingress.jsonnet',
   ] + std.flattenArrays([
     // Networks (which are in array form already).
     import 'k8s/networks/networks.jsonnet',


### PR DESCRIPTION
This PR creates the `prometheus-platform-cluster-basicauth` subdomain, protected via HTTP basic authentication and pointing to the same Prometheus service as `prometheus-platform-cluster`.

To work around the 64-character limit LetsEncrypt enforces for the CN field, the two domains are under the same TLS certificate. Only the first one (< 64 characters) in the list is used as CN, while both are listed as "alternative names".  

This is the first step in migrating prometheus-platform-cluster to OAuth. Following PRs will change the prometheus-federation to scrape the -basicauth domain and only after that I'll enable OAuth on the original subdomain, to make sure the system in a working state at all times.

Note: differently from what happens with ingresses created on GKE, the DNS entries must already exist on Google Cloud DNS before deploying these changes as they won't be created for us.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/557)
<!-- Reviewable:end -->
