### PR TITLE
Enable OAuth authentication on the platform-cluster-prometheus URL

### DIFF
--- a/k8s/services/prometheus-tls-ingress.jsonnet
+++ b/k8s/services/prometheus-tls-ingress.jsonnet
@@ -7,9 +7,14 @@
     annotations: {
       'kubernetes.io/tls-acme': 'true',
       'kubernetes.io/ingress.class': 'nginx',
-      'nginx.ingress.kubernetes.io/auth-type': 'basic',
-      'nginx.ingress.kubernetes.io/auth-secret': 'prometheus-htpasswd',
-      'nginx.ingress.kubernetes.io/auth-realm': 'Authentication Required',
+      'nginx.ingress.kubernetes.io/auth-url': 'https://prometheus.' + std.extVar('PROJECT_ID') + '.measurementlab.net/oauth2/auth',
+      'nginx.ingress.kubernetes.io/auth-signin': 'https://prometheus.' + std.extVar('PROJECT_ID') + '.measurementlab.net/oauth2/start?rd=$escaped_request_uri',
+      'nginx.ingress.kubernetes.io/configuration-snippet': |||
+        auth_request_set $user   $upstream_http_x_auth_request_user;
+        auth_request_set $email  $upstream_http_x_auth_request_email;
+        proxy_set_header X-User  $user;
+        proxy_set_header X-Email $email;
+      |||,
     },
   },
   spec: {


### PR DESCRIPTION
Step 3/3: This PR enables OAuth on https://platform-cluster-prometheus.${PROJECT}.measurementlab.net .

Instead of running a separate oauth2-proxy instance, this leverages the existing one running on GKE. Since the session cookie is valid for every subdomain of `${PROJECT}.measurementlab.net` this works without any additional change, and the user does not need to re-login when moving from the main Prometheus instance to the platform-cluster one.

You can test it at https://prometheus-platform-cluster.mlab-sandbox.measurementlab.net

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/558)
<!-- Reviewable:end -->
