### PR TITLE
Fix redirection URL after OAuth login to Prometheus

### DIFF
--- a/k8s/services/prometheus-tls-ingress.jsonnet
+++ b/k8s/services/prometheus-tls-ingress.jsonnet
@@ -8,7 +8,8 @@
       'kubernetes.io/tls-acme': 'true',
       'kubernetes.io/ingress.class': 'nginx',
       'nginx.ingress.kubernetes.io/auth-url': 'https://prometheus.' + std.extVar('PROJECT_ID') + '.measurementlab.net/oauth2/auth',
-      'nginx.ingress.kubernetes.io/auth-signin': 'https://prometheus.' + std.extVar('PROJECT_ID') + '.measurementlab.net/oauth2/start?rd=$escaped_request_uri',
+      'nginx.ingress.kubernetes.io/auth-signin': 'https://prometheus.' + std.extVar('PROJECT_ID') +
+        '.measurementlab.net/oauth2/start?rd=https://prometheus-platform-cluster.'  + std.extVar('PROJECT_ID') + '.measurementlab.net',
       'nginx.ingress.kubernetes.io/configuration-snippet': |||
         auth_request_set $user   $upstream_http_x_auth_request_user;
         auth_request_set $email  $upstream_http_x_auth_request_email;

--- a/k8s/services/prometheus-tls-ingress.jsonnet
+++ b/k8s/services/prometheus-tls-ingress.jsonnet
@@ -8,8 +8,7 @@
       'kubernetes.io/tls-acme': 'true',
       'kubernetes.io/ingress.class': 'nginx',
       'nginx.ingress.kubernetes.io/auth-url': 'https://prometheus.' + std.extVar('PROJECT_ID') + '.measurementlab.net/oauth2/auth',
-      'nginx.ingress.kubernetes.io/auth-signin': 'https://prometheus.' + std.extVar('PROJECT_ID') +
-        '.measurementlab.net/oauth2/start?rd=https://prometheus-platform-cluster.'  + std.extVar('PROJECT_ID') + '.measurementlab.net',
+      'nginx.ingress.kubernetes.io/auth-signin': 'https://prometheus.' + std.extVar('PROJECT_ID') + '.measurementlab.net/oauth2/start?rd=$escaped_request_uri',
       'nginx.ingress.kubernetes.io/configuration-snippet': |||
         auth_request_set $user   $upstream_http_x_auth_request_user;
         auth_request_set $email  $upstream_http_x_auth_request_email;

--- a/k8s/services/prometheus-tls-ingress.jsonnet
+++ b/k8s/services/prometheus-tls-ingress.jsonnet
@@ -9,7 +9,7 @@
       'kubernetes.io/ingress.class': 'nginx',
       'nginx.ingress.kubernetes.io/auth-url': 'https://prometheus.' + std.extVar('PROJECT_ID') + '.measurementlab.net/oauth2/auth',
       'nginx.ingress.kubernetes.io/auth-signin': 'https://prometheus.' + std.extVar('PROJECT_ID') +
-        '.measurementlab.net/oauth2/start?rd=https://prometheus-platform-cluster.' + std.extVar('PROJECT_ID') + ".measurementlab.net$escaped_request_uri',
+        '.measurementlab.net/oauth2/start?rd=https://prometheus-platform-cluster.' + std.extVar('PROJECT_ID') + '.measurementlab.net$escaped_request_uri',
       'nginx.ingress.kubernetes.io/configuration-snippet': |||
         auth_request_set $user   $upstream_http_x_auth_request_user;
         auth_request_set $email  $upstream_http_x_auth_request_email;

--- a/k8s/services/prometheus-tls-ingress.jsonnet
+++ b/k8s/services/prometheus-tls-ingress.jsonnet
@@ -7,9 +7,14 @@
     annotations: {
       'kubernetes.io/tls-acme': 'true',
       'kubernetes.io/ingress.class': 'nginx',
-      'nginx.ingress.kubernetes.io/auth-type': 'basic',
-      'nginx.ingress.kubernetes.io/auth-secret': 'prometheus-htpasswd',
-      'nginx.ingress.kubernetes.io/auth-realm': 'Authentication Required',
+      'nginx.ingress.kubernetes.io/auth-url': 'https://prometheus.' + std.extVar('PROJECT_ID') + '.measurementlab.net/oauth2/auth',
+      'nginx.ingress.kubernetes.io/auth-signin': 'https://prometheus.' + std.extVar('PROJECT_ID') + '.measurementlab.net/oauth2/start?rd=$escaped_request_uri',
+      'nginx.ingress.kubernetes.io/configuration-snippet': |||
+        auth_request_set $user   $upstream_http_x_auth_request_user;
+        auth_request_set $email  $upstream_http_x_auth_request_email;
+        proxy_set_header X-User  $user;
+        proxy_set_header X-Email $email;
+      |||,
     },
   },
   spec: {

--- a/k8s/services/prometheus-tls-ingress.jsonnet
+++ b/k8s/services/prometheus-tls-ingress.jsonnet
@@ -8,7 +8,8 @@
       'kubernetes.io/tls-acme': 'true',
       'kubernetes.io/ingress.class': 'nginx',
       'nginx.ingress.kubernetes.io/auth-url': 'https://prometheus.' + std.extVar('PROJECT_ID') + '.measurementlab.net/oauth2/auth',
-      'nginx.ingress.kubernetes.io/auth-signin': 'https://prometheus.' + std.extVar('PROJECT_ID') + '.measurementlab.net/oauth2/start?rd=$escaped_request_uri',
+      'nginx.ingress.kubernetes.io/auth-signin': 'https://prometheus.' + std.extVar('PROJECT_ID') +
+        '.measurementlab.net/oauth2/start?rd=https://prometheus-platform-cluster.' + std.extVar('PROJECT_ID') + ".measurementlab.net$escaped_request_uri',
       'nginx.ingress.kubernetes.io/configuration-snippet': |||
         auth_request_set $user   $upstream_http_x_auth_request_user;
         auth_request_set $email  $upstream_http_x_auth_request_email;


### PR DESCRIPTION
Previously whenever the user signed in from the prometheus-platform-cluster URL they would still being redirected to the Prometheus instance on GKE. To fix that, two changes are needed (one in this repo, the other one in prometheus-support).

- Set the full URL to redirect to in the `rd` querystring parameter of the sign-in endpoint (this PR)
- Explicitly allow all the domains under `*.${PROJECT}.measurementlab.net` for redirection in the oauth2-proxy deployment config

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/559)
<!-- Reviewable:end -->
