### PR TITLE
Revert traceroute3 datatype change

### DIFF
--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -192,7 +192,7 @@ local Traceroute(expName, tcpPort, hostNetwork) = [
         '-prometheusx.listen-address=127.0.0.1:' + tcpPort
       else
         '-prometheusx.listen-address=$(PRIVATE_IP):' + tcpPort,
-      '-outputPath=' + VolumeMount(expName).mountPath + '/traceroute3',
+      '-outputPath=' + VolumeMount(expName).mountPath + '/traceroute',
       '-uuid-prefix-file=' + uuid.prefixfile,
       '-poll=false',
       '-tcpinfo.eventsocket=' + tcpinfoServiceVolume.socketFilename,
@@ -399,7 +399,7 @@ local ExperimentNoIndex(name, bucket, anonMode, datatypes, hostNetwork) = {
   // TODO(m-lab/k8s-support/issues/358): make this unconditional once traceroute
   // supports anonymization.
   local allDatatypes =  ['tcpinfo', 'pcap', 'annotation'] + datatypes +
-      if anonMode == "none" then ['traceroute3'] else [],
+      if anonMode == "none" then ['traceroute'] else [],
   apiVersion: 'apps/v1',
   kind: 'DaemonSet',
   metadata: {


### PR DESCRIPTION
This change reverts the datatype directory name change from "traceroute3" back to "traceroute". While the traceroute binary version is conditional on project, these datatype names are not yet. And, we are no yet ready to name traceroute data "traceroute3". As well, with the redesign of the traceroute-caller & hop annotation, the output format may properly remain the same as the current output format (though there may be an additional output datatype).

FYI: @SaiedKazemi

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/567)
<!-- Reviewable:end -->
