### PR TITLE
Pushes setup_k8s.sh to static version path of 'latest' in GCS

### DIFF
--- a/manage-cluster/apply_k8s_configs.sh
+++ b/manage-cluster/apply_k8s_configs.sh
@@ -41,9 +41,11 @@ fi
 gcloud --quiet components update kubectl
 
 # Upload the evaluated setup_k8s.sh template to GCS.
+# TODO(kinkade): Move setup_k8s.sh to the epoxy-images repo to be baked into
+# stage3 images, obviating the need for the static "version" path in GCS of
+# "latest": https://github.com/m-lab/k8s-support/issues/569
 cache_control="Cache-Control:private, max-age=0, no-transform"
-gsutil -h "$cache_control" cp ./setup_k8s.sh gs://epoxy-${PROJECT}/stage3_coreos/setup_k8s.sh
-gsutil -h "$cache_control" cp ./setup_k8s.sh gs://epoxy-${PROJECT}/stage3_ubuntu/setup_k8s.sh
+gsutil -h "$cache_control" cp ./setup_k8s.sh gs://epoxy-${PROJECT}/latest/stage3_ubuntu/setup_k8s.sh
 
 # Download helm and use it to install cert-manager and ingress-nginx
 curl -O https://get.helm.sh/helm-${K8S_HELM_VERSION}-linux-amd64.tar.gz


### PR DESCRIPTION
This is a temporary workaround until this issue can be resolved:

https://github.com/m-lab/k8s-support/issues/569

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/570)
<!-- Reviewable:end -->
