### PR TITLE
Update ndt-server to v0.20.6

### DIFF
--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -1,4 +1,4 @@
-local ndtVersion = 'v0.20.5';
+local ndtVersion = 'v0.20.6';
 local PROJECT_ID = std.extVar('PROJECT_ID');
 
 // The default grace period after k8s sends SIGTERM is 30s. We


### PR DESCRIPTION
Updates the ndt DS to use ndt-server v0.20.6.

[Changelog](https://github.com/m-lab/ndt-server/releases/tag/v0.20.6)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/571)
<!-- Reviewable:end -->
