### PR TITLE
Run traceroute-caller v0.7.3 in sandbox and staging

### DIFF
--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -185,7 +185,7 @@ local Traceroute(expName, tcpPort, hostNetwork) = [
   {
     name: 'traceroute-caller',
     image: (if std.extVar('PROJECT_ID') != 'mlab-oti'
-         then 'measurementlab/traceroute-caller:v0.7.2'
+         then 'measurementlab/traceroute-caller:v0.7.3'
          else  'measurementlab/traceroute-caller:v0.6.0'),
     args: [
       if hostNetwork then


### PR DESCRIPTION
traceroute-caller v0.7.3 restores raw scamper output and M-Lab
headers (aka traceroute2) in ".jsonl" format.

Once we've confirmed it works as expected in sandbox and staging,
it will also be deployed in production.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/574)
<!-- Reviewable:end -->
