### PR TITLE
Configures Prometheus to send alerts to prometheus-federation AM

### DIFF
--- a/config/prometheus.jsonnet
+++ b/config/prometheus.jsonnet
@@ -1,8 +1,9 @@
 local cmutil = import 'configmap.jsonnet';
 
 local data = {
-    'rules.yml': importstr 'prometheus/rules.yml',
-    'prometheus.yml': std.strReplace(importstr 'prometheus/prometheus.yml', '{{PROJECT}}', std.extVar('PROJECT_ID')),
+  'alerts.yml': importstr 'prometheus/alerts.yml',
+  'rules.yml': importstr 'prometheus/rules.yml',
+  'prometheus.yml': std.strReplace(importstr 'prometheus/prometheus.yml', '{{PROJECT}}', std.extVar('PROJECT_ID')),
 };
 
 {

--- a/config/prometheus/alerts.yml
+++ b/config/prometheus/alerts.yml
@@ -1,13 +1,3 @@
 groups:
 - name: alerts.yml
   rules:
-  - alert: TestAlert
-    expr: kube_node_info{ready="true"}
-    for: 1m
-    labels:
-      repo: ops-tracker
-      severity: ticket
-    annotations:
-      summary: The test site is ready.
-      description: Test description.
-      dashboard: https://example.com/test

--- a/config/prometheus/alerts.yml
+++ b/config/prometheus/alerts.yml
@@ -1,0 +1,13 @@
+groups:
+- name: alerts.yml
+  rules:
+  - alert: TestAlert
+    expr: kube_node_info{ready="true"}
+    for: 1m
+    labels:
+      repo: ops-tracker
+      severity: ticket
+    annotations:
+      summary: The test site is ready.
+      description: Test description.
+      dashboard: https://example.com/test

--- a/config/prometheus/prometheus.yml
+++ b/config/prometheus/prometheus.yml
@@ -8,6 +8,16 @@ rule_files:
   - /etc/prometheus/rules.yml
 #  - /etc/prometheus/alerts.yml
 
+alerting:
+  alertmanagers:
+    - static_configs:
+      - targets:
+        - alertmanager.{{PROJECT}}.measurementlab.net:9093
+      api_version: v2
+      basic_auth:
+        username: mlab
+        password_file: /etc/alertmanager/password
+
 # Scrape configurations.
 scrape_configs:
 
@@ -317,4 +327,3 @@ scrape_configs:
     scheme: http
     static_configs:
       - targets: ['token-server.{{PROJECT}}.measurementlab.net:8800']
-

--- a/config/prometheus/prometheus.yml
+++ b/config/prometheus/prometheus.yml
@@ -328,3 +328,9 @@ scrape_configs:
     scheme: http
     static_configs:
       - targets: ['token-server.{{PROJECT}}.measurementlab.net:8800']
+
+  # Scrape the Github Maintenance Exporter.
+  - job_name: 'github-maintenance-exporter'
+    scheme: https
+    static_configs:
+      - targets: ['gmx.{{PROJECT}}.measurementlab.net']

--- a/config/prometheus/prometheus.yml
+++ b/config/prometheus/prometheus.yml
@@ -6,7 +6,7 @@ global:
 
 rule_files:
   - /etc/prometheus/rules.yml
-#  - /etc/prometheus/alerts.yml
+  - /etc/prometheus/alerts.yml
 
 alerting:
   alertmanagers:

--- a/config/prometheus/prometheus.yml
+++ b/config/prometheus/prometheus.yml
@@ -12,7 +12,7 @@ alerting:
   alertmanagers:
     - static_configs:
       - targets:
-        - alertmanager.{{PROJECT}}.measurementlab.net:9093
+        - alertmanager.{{PROJECT}}.measurementlab.net
       api_version: v2
       basic_auth:
         username: mlab

--- a/config/prometheus/prometheus.yml
+++ b/config/prometheus/prometheus.yml
@@ -17,6 +17,7 @@ alerting:
       basic_auth:
         username: mlab
         password_file: /etc/alertmanager/password
+      scheme: https
 
 # Scrape configurations.
 scrape_configs:

--- a/k8s/deployments/prometheus.jsonnet
+++ b/k8s/deployments/prometheus.jsonnet
@@ -55,6 +55,10 @@ local prometheusConfig = import '../../config/prometheus.jsonnet';
                 mountPath: '/prometheus',
                 name: 'prometheus-storage',
               },
+              {
+                mountPath: '/etc/alertmanager/',
+                name: 'alertmanager-basicauth',
+              },
             ],
           },
         ],
@@ -71,6 +75,12 @@ local prometheusConfig = import '../../config/prometheus.jsonnet';
               name: prometheusConfig.metadata.name,
             },
             name: 'prometheus-config',
+          },
+          {
+            name: 'alertmanager-basicauth',
+            secret: {
+              secretName: 'alertmanager-basicauth',
+            },
           },
           // TODO: use native k8s persistent volume claims, if possible.
           {

--- a/manage-cluster/apply_k8s_configs.sh
+++ b/manage-cluster/apply_k8s_configs.sh
@@ -92,7 +92,7 @@ sed -e "s/{{PROJECT}}/${PROJECT}/" ../config/vector/values.yaml.template \
 # Apply the configuration
 
 # The configurations of the secrets for the cluster happen in a separate
-# directory. We might publicly aechive system.json. We should never make any
+# directory. We might publicly archive system.json. We should never make any
 # part of secret-configs public.  They are our passwords and private keys!
 kubectl apply -f secret-configs/
 

--- a/manage-cluster/create_k8s_configs.sh
+++ b/manage-cluster/create_k8s_configs.sh
@@ -73,6 +73,9 @@ gsutil cp gs://${!GCS_BUCKET_K8S}/cert-manager-credentials.json secrets/cert-man
 gsutil cp gs://${!GCS_BUCKET_K8S}/vector-credentials.json secrets/vector.json
 gsutil cp gs://${!GCS_BUCKET_K8S}/snmp-community/snmp.community secrets/snmp.community
 gsutil cp gs://${!GCS_BUCKET_K8S}/prometheus-htpasswd secrets/auth
+# The alertmanager-basicauth.yaml file is already a valid k8s YAML Secret
+# specification, so copy it directly to the secret-configs/ directory.
+gsutil cp gs://${!GCS_BUCKET_K8S}/alertmanager-basicauth.yaml secret-configs/.
 gsutil cp -R gs://${!GCS_BUCKET_K8S}/locate secrets/.
 
 # Convert secret data into configs.


### PR DESCRIPTION
This has been [an issue](https://github.com/m-lab/k8s-support/issues/329) for a long time.

This PR does not configure any alerts but merely sets up Prometheus to send alerts to the AlertManager instance running in the prometheus-federation cluster. It leverages the fact that we have an nginx ingress configured in that cluster with a public IP and fixed domain name, which uses HTTP basic auth for authentication. A separate PR will address moving platform cluster alerts from prometheus-federation to the platform cluster.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/575)
<!-- Reviewable:end -->
