### PR TITLE
Run traceroute-caller v0.8.0 in sandbox and staging

### DIFF
--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -185,7 +185,7 @@ local Traceroute(expName, tcpPort, hostNetwork) = [
   {
     name: 'traceroute-caller',
     image: (if std.extVar('PROJECT_ID') != 'mlab-oti'
-         then 'measurementlab/traceroute-caller:v0.7.2'
+         then 'measurementlab/traceroute-caller:v0.8.0'
          else  'measurementlab/traceroute-caller:v0.6.0'),
     args: [
       if hostNetwork then


### PR DESCRIPTION
traceroute-caller (TRC) v0.8.0 is functionally the same as TRC
v0.6.0 running on production generating traceroute2 datatype
but with cleaned up source code, paris-traceroute removed,
and latency metrics added.

What was previously running on sandbox and staging was TRC v0.7.x
generating traceroute3 datatype but it had issues because it
was not saving all of scamper output.

Once we've confirmed TRC v0.8.0 works as expected on sandbox
and staging, it will be deployed to production.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/578)
<!-- Reviewable:end -->
