### PR TITLE
change to scamper (not daemon) and long trace timeout and cache timeout

### DIFF
--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -196,7 +196,10 @@ local Traceroute(expName, tcpPort, hostNetwork) = [
       '-uuid-prefix-file=' + uuid.prefixfile,
       '-poll=false',
       '-tcpinfo.eventsocket=' + tcpinfoServiceVolume.socketFilename,
-      '-tracetool=scamper-daemon',
+      '-tracetool=scamper',
+      '-scamper.timeout=30m',
+      '-IPCacheTimeout=30m',
+      '-IPCacheUpdatePeriod=1m'
     ],
     env: if hostNetwork then [] else [
       {


### PR DESCRIPTION
It looks like the update to v0.8.0 with 15 minute timeout still has more than 50% timeout running in staging.

This changes the config to use 30 minute timeout, and use scamper instead of scamper-daemon.

This will likely result in lots of zombie processes, but have some idea how to fix that.  Should also follow up with scamper authors to find out their recommended best practices for this kind of application.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/579)
<!-- Reviewable:end -->
