### PR TITLE
Add mlab/ndt-version label to setup_k8s.sh

### DIFF
--- a/node/setup_k8s.sh.template
+++ b/node/setup_k8s.sh.template
@@ -40,7 +40,7 @@ MASTER_NODE="api-platform-cluster.${GCP_PROJECT}.measurementlab.net"
 # Capture K8S version for later usage.
 RELEASE=$(kubelet --version | awk '{print $2}')
 
-NODE_LABELS="mlab/machine=${MACHINE},mlab/site=${SITE},mlab/metro=${METRO},mlab/type=physical,mlab/project=${GCP_PROJECT}"
+NODE_LABELS="mlab/machine=${MACHINE},mlab/site=${SITE},mlab/metro=${METRO},mlab/type=physical,mlab/project=${GCP_PROJECT},mlab/ndt-version=production"
 DYNAMIC_CONFIG_DIR="/var/lib/kubelet/dynamic-configs"
 sed -ie "s|KUBELET_KUBECONFIG_ARGS=|KUBELET_KUBECONFIG_ARGS=--node-labels=$NODE_LABELS --dynamic-config-dir=$DYNAMIC_CONFIG_DIR |g" \
   /etc/systemd/system/kubelet.service.d/10-kubeadm.conf


### PR DESCRIPTION
Add the `mlab/ndt-version:production` default label to setup_k8s.sh.template. This label is going to be used by the ndt-server daemonset to identify the version to deploy on a specific node. If `mlab/ndt-version` is `canary`, a canary version is deployed. By default all the nodes serve production versions of ndt-server.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/580)
<!-- Reviewable:end -->
