### PR TITLE
Deploy traceroute-caller v0.8.0 to production

### DIFF
--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -184,9 +184,13 @@ local Tcpinfo(expName, tcpPort, hostNetwork, anonMode) = [
 local Traceroute(expName, tcpPort, hostNetwork) = [
   {
     name: 'traceroute-caller',
+    // Although from time to time we may be running the same version
+    // of traceroute-caller in all projects, let's leave the check for
+    // mlab-oti here so we can easily configure different versions of
+    // traceroute-caller in production and non-production projects.
     image: (if std.extVar('PROJECT_ID') != 'mlab-oti'
          then 'measurementlab/traceroute-caller:v0.8.0'
-         else  'measurementlab/traceroute-caller:v0.6.0'),
+         else  'measurementlab/traceroute-caller:v0.8.0'),
     args: [
       if hostNetwork then
         '-prometheusx.listen-address=127.0.0.1:' + tcpPort


### PR DESCRIPTION
	traceroute-caller (TRC) v0.8.0 has been successfully running
	in the sandbox and staging environments for a couple of days.
	This commit deploys it to production.

	TRC v0.8.0 is functionally the same as v0.6.0.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/581)
<!-- Reviewable:end -->
