### PR TITLE
Revert ndtVersion to v0.20.5

### DIFF
--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -1,4 +1,4 @@
-local ndtVersion = 'v0.20.6';
+local ndtVersion = 'v0.20.5';
 local PROJECT_ID = std.extVar('PROJECT_ID');
 
 // The default grace period after k8s sends SIGTERM is 30s. We


### PR DESCRIPTION
This reverts the version of ndt-server to `v0.20.5`. It had originally been set to v0.20.6 on Jun 1, before we decided to run this version through the canary process. `v0.20.6` has never been deployed since k8s-support hasn't been tagged since May 3.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/582)
<!-- Reviewable:end -->
