### PR TITLE
test trc v0.8.2 in scamper mode

### DIFF
--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -190,7 +190,7 @@ local Traceroute(expName, tcpPort, hostNetwork) = [
     // mlab-oti here so we can easily configure different versions of
     // traceroute-caller in production and non-production projects.
     image: (if std.extVar('PROJECT_ID') != 'mlab-oti'
-         then 'measurementlab/traceroute-caller:v0.8.1-beta'
+         then 'measurementlab/traceroute-caller:v0.8.2'
          else 'measurementlab/traceroute-caller:v0.8.0'),
     args: [
       if hostNetwork then
@@ -201,14 +201,16 @@ local Traceroute(expName, tcpPort, hostNetwork) = [
       '-uuid-prefix-file=' + uuid.prefixfile,
       '-poll=false',
       '-tcpinfo.eventsocket=' + tcpinfoServiceVolume.socketFilename,
-      '-tracetool=scamper-daemon',
     ] + if std.extVar('PROJECT_ID') != 'mlab-oti' then [
+        '-tracetool=scamper',
         '-IPCacheTimeout=5m',
         '-IPCacheUpdatePeriod=1m',
-        '-scamper.timeout=90m',
+        '-scamper.timeout=60m',
         '-scamper.tracelb-W=15',
       ]
-      else [],
+      else [
+        '-tracetool=scamper-daemon',
+      ],
     env: if hostNetwork then [] else [
       {
         name: 'PRIVATE_IP',


### PR DESCRIPTION
This updates config for traceroute-caller to use scamper mode and change timeouts and tracelb parameters.
This is a candidate for prod, but should soak in staging for a day or two first.

Testing/Validation:
  * Successful cloud build and deployment 6/28 18:31 Eastern when this branch was pushed to github.  Deployment was overwritten shortly thereafter around 20:20 Eastern by sandbox-soltesz-uuid-annotator-update, but it ran with 4 minute average trace latency, and no errors, during that 110 minute period, based on [dashboard metrics](https://grafana.mlab-sandbox.measurementlab.net/d/7l1KQtR7k/exp-scamper-detail?orgId=1&from=1624917629923&to=1624928282111&var-datasource=Platform%20Cluster%20(mlab-sandbox)&var-site=All&var-interval=10m&var-deployment=All).
  * Redeployed manually to ndt, neubot, revtr, host pods at 2:10pm Eastern June 29th.



<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/588)
<!-- Reviewable:end -->
