### PR TITLE
update conditional trc prod deployment

### DIFF
--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -191,7 +191,7 @@ local Traceroute(expName, tcpPort, hostNetwork) = [
     // traceroute-caller in production and non-production projects.
     image: (if std.extVar('PROJECT_ID') != 'mlab-oti'
          then 'measurementlab/traceroute-caller:v0.8.2'
-         else 'measurementlab/traceroute-caller:v0.8.0'),
+         else 'measurementlab/traceroute-caller:v0.8.2'),
     args: [
       if hostNetwork then
         '-prometheusx.listen-address=127.0.0.1:' + tcpPort
@@ -201,16 +201,12 @@ local Traceroute(expName, tcpPort, hostNetwork) = [
       '-uuid-prefix-file=' + uuid.prefixfile,
       '-poll=false',
       '-tcpinfo.eventsocket=' + tcpinfoServiceVolume.socketFilename,
-    ] + if std.extVar('PROJECT_ID') != 'mlab-oti' then [
-        '-tracetool=scamper',
-        '-IPCacheTimeout=5m',
-        '-IPCacheUpdatePeriod=1m',
-        '-scamper.timeout=60m',
-        '-scamper.tracelb-W=15',
-      ]
-      else [
-        '-tracetool=scamper-daemon',
-      ],
+      '-tracetool=scamper',
+      '-IPCacheTimeout=10m',
+      '-IPCacheUpdatePeriod=1m',
+      '-scamper.timeout=30m',
+      '-scamper.tracelb-W=15',
+    ],
     env: if hostNetwork then [] else [
       {
         name: 'PRIVATE_IP',


### PR DESCRIPTION
This updates the prod deployment of trc to more or less match the staging deployment.

1. Use v0.8.2
2.  use scamper instead of scamper-daemon
3. Update other parameters to better match reality.     
      '-IPCacheTimeout=10m',  // Average trace latency is 4 minutes, 99th is 11 minutes, so this seems reasonable.
      '-IPCacheUpdatePeriod=1m', 
      '-scamper.timeout=30m',  // 99th percentile in staging is now 11 minutes, so 30 should give lots of headroom
      '-scamper.tracelb-W=15',

Will observe behavior in staging for a couple more hours, in addition to roughly last 24 hours (deployment took most of the day on Tuesday - all pods running 0.8.2 for about 16 hours so far.

Later today, we intend to tag for production deployment, after checking with soltesz or nkinkade.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/592)
<!-- Reviewable:end -->
