### PR TITLE
Replace dots with dashes in hostnames

### DIFF
--- a/manage-cluster/upgrade_k8s_virtual_nodes.sh
+++ b/manage-cluster/upgrade_k8s_virtual_nodes.sh
@@ -59,6 +59,8 @@ fi
 set -x
 
 for node in $NODES; do
+  # Replace the dots in the hostname with dashes.
+  node="${node//./-}"
   # Determine the zone of the node.
   ZONE=$(gcloud compute instances list --filter "name=${node}" \
       --project ${PROJECT} \


### PR DESCRIPTION
This PR updates `upgrade_k8s_virtual_nodes.sh` to replace dots with dashes in node names. 

When a virtual k8s node is created on GCP the VM's name cannot contain dots, thus hostnames and VM names end up being different. This script was failing on hostnames such as `mlab1-fra0t.mlab-sandbox.measurement-lab.org` since the corresponding VM is `mlab1-fra0t-mlab-sandbox-measurement-lab-org`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/594)
<!-- Reviewable:end -->
