### PR TITLE
Run traceroute-caller v0.8.2 and use scamper in production

### DIFF
--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -191,7 +191,7 @@ local Traceroute(expName, tcpPort, hostNetwork) = [
     // traceroute-caller in production and non-production projects.
     image: (if std.extVar('PROJECT_ID') != 'mlab-oti'
          then 'measurementlab/traceroute-caller:v0.8.2'
-         else 'measurementlab/traceroute-caller:v0.8.0'),
+         else 'measurementlab/traceroute-caller:v0.8.2'),
     args: [
       if hostNetwork then
         '-prometheusx.listen-address=127.0.0.1:' + tcpPort
@@ -201,16 +201,12 @@ local Traceroute(expName, tcpPort, hostNetwork) = [
       '-uuid-prefix-file=' + uuid.prefixfile,
       '-poll=false',
       '-tcpinfo.eventsocket=' + tcpinfoServiceVolume.socketFilename,
-    ] + if std.extVar('PROJECT_ID') != 'mlab-oti' then [
-        '-tracetool=scamper',
-        '-IPCacheTimeout=5m',
-        '-IPCacheUpdatePeriod=1m',
-        '-scamper.timeout=60m',
-        '-scamper.tracelb-W=15',
-      ]
-      else [
-        '-tracetool=scamper-daemon',
-      ],
+      '-tracetool=scamper',
+      '-IPCacheTimeout=10m',
+      '-IPCacheUpdatePeriod=1m',
+      '-scamper.timeout=30m',
+      '-scamper.tracelb-W=15',
+    ],
     env: if hostNetwork then [] else [
       {
         name: 'PRIVATE_IP',


### PR DESCRIPTION
This commit updates production to run match what has been
successfully running in staging which seems to have resolved
the issue of traceroute timeout by running a separate instance
of scamper for each traceroute instead of running one instance
of scamper in daemon mode for all traceroutes.

This commit also updates parameters as follows:
  o IPCacheTimeout=10m
    Average trace latency is 4 minutes, 99th is 11 minutes, so
    this seems reasonable.
  o IPCacheUpdatePeriod=1m
  o scamper.timeout=30m
    99th percentile in staging is now 11 minutes, so 30 should
    give lots of headroom.
  o scamper.tracelb-W=15

The above changes were tested in staging.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/595)
<!-- Reviewable:end -->
