### PR TITLE
Run traceroute-caller v0.8.3 in all platform clusters

### DIFF
--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -190,8 +190,8 @@ local Traceroute(expName, tcpPort, hostNetwork) = [
     // mlab-oti here so we can easily configure different versions of
     // traceroute-caller in production and non-production projects.
     image: (if std.extVar('PROJECT_ID') != 'mlab-oti'
-         then 'measurementlab/traceroute-caller:v0.8.2'
-         else 'measurementlab/traceroute-caller:v0.8.2'),
+         then 'measurementlab/traceroute-caller:v0.8.4'
+         else 'measurementlab/traceroute-caller:v0.8.4'),
     args: [
       if hostNetwork then
         '-prometheusx.listen-address=127.0.0.1:' + tcpPort


### PR DESCRIPTION
Version 0.8.3 uses tini to reap the orphaned child processes
of scamper.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/596)
<!-- Reviewable:end -->
