### PR TITLE
Updates revtr image version to v0.1.9

### DIFF
--- a/k8s/daemonsets/experiments/revtr.jsonnet
+++ b/k8s/daemonsets/experiments/revtr.jsonnet
@@ -7,7 +7,7 @@ exp.Experiment('revtr', 3, 'pusher-' + std.extVar('PROJECT_ID'), 'none', []) + {
         containers+: [
           {
             name: 'revtrvp',
-            image: 'measurementlab/revtrvp:v0.1.7',
+            image: 'measurementlab/revtrvp:v0.1.9',
             args: [
               '/root.crt',
               '/plvp.config',


### PR DESCRIPTION
The principal change is causing the revtr process to inifinitely retry
a connection to the controller. Previously, if a connection couldn't be
made in 10000s, the process would give up, requiring a restart of the
pod.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/599)
<!-- Reviewable:end -->
