### PR TITLE
Adds --web.external-url flag to Prometheus 

### DIFF
--- a/k8s/deployments/prometheus.jsonnet
+++ b/k8s/deployments/prometheus.jsonnet
@@ -37,6 +37,7 @@ local prometheusConfig = import '../../config/prometheus.jsonnet';
               '--config.file=/etc/prometheus/prometheus.yml',
               '--storage.tsdb.path=/prometheus',
               '--web.enable-lifecycle',
+              '--web.external-url=https://prometheus-platform-cluster.{{PROJECT}}.measurementlab.net',
               '--storage.tsdb.retention.time=2880h',
             ],
             image: 'prom/prometheus:v2.24.1',

--- a/k8s/deployments/prometheus.jsonnet
+++ b/k8s/deployments/prometheus.jsonnet
@@ -37,7 +37,7 @@ local prometheusConfig = import '../../config/prometheus.jsonnet';
               '--config.file=/etc/prometheus/prometheus.yml',
               '--storage.tsdb.path=/prometheus',
               '--web.enable-lifecycle',
-              '--web.external-url=https://prometheus-platform-cluster.{{PROJECT}}.measurementlab.net',
+              '--web.external-url=https://prometheus-platform-cluster.' + std.extVar('PROJECT_ID') + '.measurementlab.net',
               '--storage.tsdb.retention.time=2880h',
             ],
             image: 'prom/prometheus:v2.24.1',


### PR DESCRIPTION
Without this flag, links to Prometheus, generated by Prometheus, will be incorrect. Specifically, we noticed that the "Source" URL for a Prometheus instance was incorrect, causing us to not be able to view the source of the alert easily. This PR introduces the `--web.external-url` flag, which fixes this issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/600)
<!-- Reviewable:end -->
