### PR TITLE
Adds privileged initContainer for setting sysctls

### DIFF
--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -54,7 +54,9 @@ local sysctls = {
     command: [
       'sysctl', '-w',
       // Do not use IPv6 autoconfiguration (SLAAC), and reject RAs (Router
-      // Advertisements), which can muck with IPv6 config in a pod.
+      // Advertisements). When accept_ra=1, RAs can cause the IPv6 network
+      // stack to reconfigure itself, for example changing or removing the
+      // default route.
       'net.ipv6.conf.net1.accept_ra=0',
       'net.ipv6.conf.net1.autoconf=0',
     ],


### PR DESCRIPTION
Kubernetes supports a mechanism for setting an exceedingly small set of
sysctls in a Pod spec:
https://kubernetes.io/docs/tasks/administer-cluster/sysctl-cluster/
... but the sysctls we need to set are not in that list, and the
workaround (using a cluster PodSecurityPolicy) is deprecated and will be
removed from a later version of Kubernetes (v1.25.x):
https://kubernetes.io/blog/2021/04/06/podsecuritypolicy-deprecation-past-present-and-future/

This PR should resolve https://github.com/m-lab/epoxy-images/issues/209

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/601)
<!-- Reviewable:end -->
