### PR TITLE
Sandbox kinkade

### DIFF
--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -52,7 +52,7 @@ local uuid = {
 local sysctls = {
   initContainer: {
     command: [
-      'sysctl', '--write', '--ignore',
+      'sysctl', '-e', '-w',
       // Do not use IPv6 autoconfiguration (SLAAC), and reject RAs (Router
       // Advertisements). When accept_ra=1, RAs can cause the IPv6 network
       // stack to reconfigure itself, for example changing or removing the

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -52,7 +52,7 @@ local uuid = {
 local sysctls = {
   initContainer: {
     command: [
-      'sysctl', '-w',
+      'sysctl', '--write', '--ignore',
       // Do not use IPv6 autoconfiguration (SLAAC), and reject RAs (Router
       // Advertisements). When accept_ra=1, RAs can cause the IPv6 network
       // stack to reconfigure itself, for example changing or removing the
@@ -61,7 +61,7 @@ local sysctls = {
       'net.ipv6.conf.net1.autoconf=0',
     ],
     image: 'busybox',
-    name: 'set-namespaced-sysctls',
+    name: 'set-pod-sysctls',
     securityContext: {
       privileged: true,
       runAsUser: 0,

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -52,13 +52,14 @@ local uuid = {
 local sysctls = {
   initContainer: {
     command: [
-      'sysctl', '-e', '-w',
       // Do not use IPv6 autoconfiguration (SLAAC), and reject RAs (Router
       // Advertisements). When accept_ra=1, RAs can cause the IPv6 network
       // stack to reconfigure itself, for example changing or removing the
       // default route.
-      'net.ipv6.conf.net1.accept_ra=0',
-      'net.ipv6.conf.net1.autoconf=0',
+      'sh', '-c', |||
+        for i in /proc/sys/net/ipv6/conf/*/accept_ra; do echo 0 > $i; done;
+        for i in /proc/sys/net/ipv6/conf/*/autoconf; do echo 0 > $i; done;
+      |||,
     ],
     image: 'busybox',
     name: 'set-pod-sysctls',


### PR DESCRIPTION
Not every DaemonSet pod is going to have a "net1" interface, since not all of them use ipvlan. In those cases, the current initContainer will exit with a non 0 status, and then crash loop. This PR instead uses `sh` to just splat a 0 value to all existing interfaces for `/proc/sys/net/ipv6/conf/*/{accept_ra,autoconf}`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/602)
<!-- Reviewable:end -->
