### PR TITLE
Use CNI `tuning` plugin to set various sysctls 

### DIFF
--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -46,30 +46,6 @@ local uuid = {
   },
 };
 
-// An initContainer that can be used to set various sysctls in pods.
-// NOTE: do not set unnamespaced sysctls here!
-// https://kubernetes.io/docs/tasks/administer-cluster/sysctl-cluster/#setting-sysctls-for-a-pod
-local sysctls = {
-  initContainer: {
-    command: [
-      // Do not use IPv6 autoconfiguration (SLAAC), and reject RAs (Router
-      // Advertisements). When accept_ra=1, RAs can cause the IPv6 network
-      // stack to reconfigure itself, for example changing or removing the
-      // default route.
-      'sh', '-c', |||
-        for i in /proc/sys/net/ipv6/conf/*/accept_ra; do echo 0 > $i; done;
-        for i in /proc/sys/net/ipv6/conf/*/autoconf; do echo 0 > $i; done;
-      |||,
-    ],
-    image: 'busybox',
-    name: 'set-pod-sysctls',
-    securityContext: {
-      privileged: true,
-      runAsUser: 0,
-    },
-  },
-};
-
 local volume(name) = {
   hostPath: {
     path: '/cache/data/' + name,
@@ -468,7 +444,6 @@ local ExperimentNoIndex(name, bucket, anonMode, datatypes, hostNetwork) = {
         [if hostNetwork then 'serviceAccountName']: 'kube-rbac-proxy',
         initContainers: [
           uuid.initContainer,
-          sysctls.initContainer,
         ],
         nodeSelector: {
           'mlab/type': 'physical',

--- a/k8s/networks/networks.jsonnet
+++ b/k8s/networks/networks.jsonnet
@@ -57,18 +57,18 @@
         name: 'ipvlan-index-' + index,
         plugins: [
           {
+            type: 'tuning',
+            sysctl: {
+              'net.ipv6.conf.net1.accept_ra': '0',
+              'net.ipv6.conf.net1.autoconf': '0',
+            },
+          },
+          {
             type: 'ipvlan',
             master: 'eth0',
             ipam: {
               type: 'index2ip',
               index: index,
-            },
-          },
-          {
-            type: 'tuning',
-            sysctl: {
-              'net.ipv6.conf.net1.accept_ra': '0',
-              'net.ipv6.conf.net1.autoconf': '0',
             },
           },
         ],

--- a/k8s/networks/networks.jsonnet
+++ b/k8s/networks/networks.jsonnet
@@ -54,13 +54,24 @@
     spec: {
       local cniConfig = {
         cniVersion: '0.2.0',
-        name: "ipvlan-index-" + index,
-        type: "ipvlan",
-        master: "eth0",
-        ipam: {
-          type: "index2ip",
-          index: index
-        },
+        name: 'ipvlan-index-' + index,
+        plugins: [
+          {
+            type: 'ipvlan',
+            master: 'eth0',
+            ipam: {
+              type: 'index2ip',
+              index: index,
+            },
+          },
+          {
+            type: 'tuning',
+            sysctl: {
+              net.ipv6.conf.net1.accept_ra: '0',
+              net.ipv6.conf.net1.autoconf: '0',
+            },
+          },
+        ],
       },
       config: std.toString(cniConfig),
     },

--- a/k8s/networks/networks.jsonnet
+++ b/k8s/networks/networks.jsonnet
@@ -67,8 +67,8 @@
           {
             type: 'tuning',
             sysctl: {
-              net.ipv6.conf.net1.accept_ra: '0',
-              net.ipv6.conf.net1.autoconf: '0',
+              'net.ipv6.conf.net1.accept_ra': '0',
+              'net.ipv6.conf.net1.autoconf': '0',
             },
           },
         ],


### PR DESCRIPTION
There is an [open issue](https://github.com/m-lab/epoxy-images/issues/209) to address the case where IPv6 SLAAC and RAs modify default IPv6 routes inside of experiment containers. We _thought_ we had resolved that issue with PR #601, but even after that change was deployed to production, we still discovered random IPv6 breakage. Indeed, you could login to an affected container and show that `net.ipv6.conf.net1.{accept_ra,autoconf}` were both set to 0, yet the default IPv6 route was still gone.

I came across [an old issue](https://github.com/lxc/lxd/issues/3582) that determined that there was a race between SLAAC and network configurations being done from within containers. I believe this is the most plausible explanation of what we are currently seeing. Probably the network namespace is created, and sometime later a process is created using that net-ns (in which our previous initContainer ran), but somewhere between creation of the net-ns and the container SLAAC did its thing and configured a default IPv6 with an expiration.

Investigating this I stumbled across a CNI plugin I had not previously known about  named `tuning`, which allows you to set various network-related kernel parameters. This PR leverages that plugin to set the sysctls required to disabled SLAAC and acceptance of RAs, obviating the need for the initContainer. The hope is that this will set the desired sysctls at an earlier stage, before SLAAC can actually do anything to corrupt our desired configuration.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/603)
<!-- Reviewable:end -->
