### PR TITLE
Moves 'tuning' CNI Plugin to be second (and last) in list

### DIFF
--- a/k8s/networks/networks.jsonnet
+++ b/k8s/networks/networks.jsonnet
@@ -57,18 +57,18 @@
         name: 'ipvlan-index-' + index,
         plugins: [
           {
-            type: 'tuning',
-            sysctl: {
-              'net.ipv6.conf.net1.accept_ra': '0',
-              'net.ipv6.conf.net1.autoconf': '0',
-            },
-          },
-          {
             type: 'ipvlan',
             master: 'eth0',
             ipam: {
               type: 'index2ip',
               index: index,
+            },
+          },
+          {
+            type: 'tuning',
+            sysctl: {
+              'net.ipv6.conf.net1.accept_ra': '0',
+              'net.ipv6.conf.net1.autoconf': '0',
             },
           },
         ],

--- a/k8s/networks/networks.jsonnet
+++ b/k8s/networks/networks.jsonnet
@@ -64,6 +64,18 @@
               index: index,
             },
           },
+          // For now, the tuning plugin needs to be run after ipvlan. This is
+          // because the index2ip plugin is still using CNI spec v0.2.0, and
+          // does not properly handle the 'prevResult' field. Putting tuning
+          // first, which we would like to do, results in the error: 'Required
+          // "prevResult" missing'. If a plugin is passed a 'prevResult' field,
+          // then it _must_ output the field, which the index2ip plugin surely
+          // does not do. Ultimately, we want tuning first, so that sysctls get
+          // set before the ipvlan interface is even created. See this issue:
+          // https://github.com/m-lab/index2ip/issues/8
+          //
+          // TODO(kinkade): when the above issue is resolved, move tuning to be
+          // the first plugin in the list.
           {
             type: 'tuning',
             sysctl: {


### PR DESCRIPTION
We would like for the `tuning` plugin to be first in the list of CNI plugins called to be sure that various sysctls get set before the ipvlan interface is even created, eliminating the possibility that IPv6 SLAAC and RAs could interfere with IPv6 configs in an experiment container. However, the `index2ip` ipam plugin is very old, and is still operating using CNI spec v0.2.0, and does not handle the field called "prevResult". Newer versions of the spec require this field in a plugins output if it was present in the input. It would appear that the `tuning` plugin inputs this field to chained plugins, yet `index2ip` will not output it, which is an error. By putting `tuning` last in the list, it will not receive the "prevResult" field from the output of the `index2ip`, and thus will not result in an error. Once this issue is resolved, we should move `tuning` back to first in the list:

https://github.com/m-lab/index2ip/issues/8