### PR TITLE
Run traceroute-caller v0.9.0 in sandbox and staging

### DIFF
--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -191,7 +191,7 @@ local Traceroute(expName, tcpPort, hostNetwork) = [
     // traceroute-caller in production and non-production projects.
     image: (if std.extVar('PROJECT_ID') != 'mlab-oti'
          then 'measurementlab/traceroute-caller:v0.8.4'
-         else 'measurementlab/traceroute-caller:v0.8.4'),
+         else 'measurementlab/traceroute-caller:v0.9.0'),
     args: [
       if hostNetwork then
         '-prometheusx.listen-address=127.0.0.1:' + tcpPort

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -190,8 +190,8 @@ local Traceroute(expName, tcpPort, hostNetwork) = [
     // mlab-oti here so we can easily configure different versions of
     // traceroute-caller in production and non-production projects.
     image: (if std.extVar('PROJECT_ID') != 'mlab-oti'
-         then 'measurementlab/traceroute-caller:v0.8.4'
-         else 'measurementlab/traceroute-caller:v0.9.0'),
+         then 'measurementlab/traceroute-caller:v0.9.0'
+         else 'measurementlab/traceroute-caller:v0.8.4'),
     args: [
       if hostNetwork then
         '-prometheusx.listen-address=127.0.0.1:' + tcpPort


### PR DESCRIPTION
This is the first version of the traceroute-caller with hop annotation support.

It has been successfully running in my local gLinux environment, so we're ready to officially deploy it to sandbox and staging.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/605)
<!-- Reviewable:end -->
