### PR TITLE
Add scamper1 and hopannotation1 to pusher

### DIFF
--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -415,7 +415,7 @@ local ExperimentNoIndex(name, bucket, anonMode, datatypes, hostNetwork) = {
   // TODO(m-lab/k8s-support/issues/358): make this unconditional once traceroute
   // supports anonymization.
   local allDatatypes =  ['tcpinfo', 'pcap', 'annotation'] + datatypes +
-      if anonMode == "none" then ['traceroute'] else [],
+      if anonMode == "none" then ['traceroute', 'scamper1', 'hopannotation1'] else [],
   apiVersion: 'apps/v1',
   kind: 'DaemonSet',
   metadata: {


### PR DESCRIPTION
Starting with traceroute-caller v0.9.0 we are renaming the
"traceroute" datatype to "scamper1" and are also adding a new
datatype called "hopannotation1".

Tested the syntax of the change:
$ jsonnet-lint k8s/daemonsets/templates.jsonnet

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/608)
<!-- Reviewable:end -->
