### PR TITLE
Run traceroute-caller v0.9.0 in production

### DIFF
--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -189,18 +189,13 @@ local Traceroute(expName, tcpPort, hostNetwork) = [
     // of traceroute-caller in all projects, let's leave the check for
     // mlab-oti here so we can easily configure different versions of
     // traceroute-caller in production and non-production projects.
-    image: (if std.extVar('PROJECT_ID') != 'mlab-oti'
-         then 'measurementlab/traceroute-caller:v0.9.0'
-         else 'measurementlab/traceroute-caller:v0.8.4'),
+    image: 'measurementlab/traceroute-caller:v0.9.0',
     args: [
       if hostNetwork then
         '-prometheusx.listen-address=127.0.0.1:' + tcpPort
       else
         '-prometheusx.listen-address=$(PRIVATE_IP):' + tcpPort,
-      if std.extVar('PROJECT_ID') != 'mlab-oti' then
-        '-traceroute-output=' + VolumeMount(expName).mountPath + '/scamper1'
-      else
-        '-outputPath=' + VolumeMount(expName).mountPath + '/traceroute',
+      '-traceroute-output=' + VolumeMount(expName).mountPath + '/scamper1',
       '-uuid-prefix-file=' + uuid.prefixfile,
       '-tcpinfo.eventsocket=' + tcpinfoServiceVolume.socketFilename,
       '-tracetool=scamper',
@@ -208,12 +203,9 @@ local Traceroute(expName, tcpPort, hostNetwork) = [
       '-IPCacheUpdatePeriod=1m',
       '-scamper.timeout=30m',
       '-scamper.tracelb-W=15',
-    ] + if std.extVar('PROJECT_ID') != 'mlab-oti'
-          then [
-            '-hopannotation-output=' + VolumeMount(expName).mountPath + '/hopannotation1',
-            '-ipservice.sock=' + uuidannotatorServiceVolume.socketFilename
-          ]
-          else [ ],
+      '-hopannotation-output=' + VolumeMount(expName).mountPath + '/hopannotation1',
+      '-ipservice.sock=' + uuidannotatorServiceVolume.socketFilename,
+    ],
     env: if hostNetwork then [] else [
       {
         name: 'PRIVATE_IP',

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -185,10 +185,6 @@ local Tcpinfo(expName, tcpPort, hostNetwork, anonMode) = [
 local Traceroute(expName, tcpPort, hostNetwork) = [
   {
     name: 'traceroute-caller',
-    // Although from time to time we may be running the same version
-    // of traceroute-caller in all projects, let's leave the check for
-    // mlab-oti here so we can easily configure different versions of
-    // traceroute-caller in production and non-production projects.
     image: 'measurementlab/traceroute-caller:v0.9.0',
     args: [
       if hostNetwork then


### PR DESCRIPTION
Now that traceroute-caller v0.9.0 (with hop annotations) has
been successfully running in staging and sandbox for a week,
we can upgrade production from v0.8.4 to v0.9.0.

Tested the changes:
    $ jsonnet-lint k8s/daemonsets/templates.jsonnet

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/610)
<!-- Reviewable:end -->
