### PR TITLE
Changes machine type for Prometheus VM in staging

### DIFF
--- a/manage-cluster/bootstrap_prometheus.sh
+++ b/manage-cluster/bootstrap_prometheus.sh
@@ -41,7 +41,7 @@ case $PROJECT in
     DISK_SIZE="200GB"
     ;;
   mlab-staging)
-    MACHINE_TYPE="n1-standard-8"
+    MACHINE_TYPE="e2-highmem-8"
     DISK_SIZE="1500GB"
     ;;
   mlab-oti)


### PR DESCRIPTION
The old n1-standard-8 VM was running out of memory. This changes the
type to e2-highmem-8, which gives Prometheus plenty of breathing room.

This resolves issues #612.