### PR TITLE
Configures flannel NADs with same network name

### DIFF
--- a/k8s/networks/networks.jsonnet
+++ b/k8s/networks/networks.jsonnet
@@ -10,6 +10,7 @@
     spec: {
       local cniConfig = {
         cniVersion: '0.3.0',
+        name: 'flannel',
         type: 'flannel',
         delegate: {
           hairpinMode: true,
@@ -31,6 +32,7 @@
     spec: {
       local cniConfig = {
         cniVersion: '0.3.0',
+        name: 'flannel',
         type: 'flannel',
         delegate: {
           hairpinMode: true,


### PR DESCRIPTION
This commit _should_ resolve issue https://github.com/m-lab/k8s-support/issues/342. By adding the field `name` into each flannel Network Attachment Definition, we can cause both NADs to use the same network name. Apparently, in absence of `name` field in the CNI config, Multus will use the name of the NAD as the name of the CNI config (the "network").

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/615)
<!-- Reviewable:end -->
