### PR TITLE
Remove -tracetool=scamper from traceroute-caller flags

### DIFF
--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -194,7 +194,6 @@ local Traceroute(expName, tcpPort, hostNetwork) = [
       '-traceroute-output=' + VolumeMount(expName).mountPath + '/scamper1',
       '-uuid-prefix-file=' + uuid.prefixfile,
       '-tcpinfo.eventsocket=' + tcpinfoServiceVolume.socketFilename,
-      '-tracetool=scamper',
       '-IPCacheTimeout=10m',
       '-IPCacheUpdatePeriod=1m',
       '-scamper.timeout=30m',


### PR DESCRIPTION
Since the "scamper-daemon" mode resulted in traceroute timeouts,
"traceroute-caller" does not use or support this mode anymore and
the "-tracetool" flag has been removed from "traceroute-caller".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/621)
<!-- Reviewable:end -->
