### PR TITLE
Updates nodeinfo to v1.2.1 and increases -wait to 6h

### DIFF
--- a/k8s/daemonsets/core/host.jsonnet
+++ b/k8s/daemonsets/core/host.jsonnet
@@ -16,7 +16,7 @@ exp.ExperimentNoIndex(expName, 'pusher-' + std.extVar('PROJECT_ID'), "none", nod
             image: 'measurementlab/nodeinfo:v1.2.1',
             args: [
               '-datadir=/var/spool/' + expName,
-              '-wait=6',
+              '-wait=6h',
               '-prometheusx.listen-address=127.0.0.1:9990',
               '-config=/etc/nodeinfo/config.json',
             ],


### PR DESCRIPTION
https://github.com/m-lab/dev-tracker/issues/689

* nodeinfo was running more frequently than we felt necessary. Instead of the `-wait=1h` this PR changes it to `-wait=6h`.
* nodeinfo image version is updated to v1.2.1: https://github.com/m-lab/nodeinfo/pull/14

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/622)
<!-- Reviewable:end -->
