### PR TITLE
Bumps Pusher version from v1.18 to v1.20

### DIFF
--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -274,7 +274,7 @@ local Pcap(expName, tcpPort, hostNetwork) = [
 
 local Pusher(expName, tcpPort, datatypes, hostNetwork, bucket) = [
   {
-    local version='v1.18',
+    local version='v1.20',
     name: 'pusher',
     image: 'measurementlab/pusher:'+version,
     args: [


### PR DESCRIPTION
Also, fixes permission mode for directories: https://github.com/m-lab/pusher/releases/tag/v1.19

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/623)
<!-- Reviewable:end -->
