### PR TITLE
Updates Prometheus container image to v2.31.1

### DIFF
--- a/k8s/deployments/prometheus.jsonnet
+++ b/k8s/deployments/prometheus.jsonnet
@@ -38,9 +38,9 @@ local prometheusConfig = import '../../config/prometheus.jsonnet';
               '--storage.tsdb.path=/prometheus',
               '--web.enable-lifecycle',
               '--web.external-url=https://prometheus-platform-cluster.' + std.extVar('PROJECT_ID') + '.measurementlab.net',
-              '--storage.tsdb.retention.time=2880h',
+              '--storage.tsdb.retention.time=120d',
             ],
-            image: 'prom/prometheus:v2.24.1',
+            image: 'prom/prometheus:v2.31.1',
             name: 'prometheus',
             ports: [
               {


### PR DESCRIPTION
Also changes TSDB retention time from 2880h, which is somewhat opaque,
to a more readily understandable value of 120d.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/626)
<!-- Reviewable:end -->
