### PR TITLE
Updates all system packages during weekly reboot

### DIFF
--- a/manage-cluster/cloud-config_master.yml
+++ b/manage-cluster/cloud-config_master.yml
@@ -264,6 +264,8 @@ write_files:
       echo "There are less than 3 healthy etcd cluster members. Not rebooting."
       exit 1
     fi
+    # While we are at it, update all system packages.
+    apt full-upgrade --yes
     echo "Reboot day ${REBOOT_DAY} equals today: ${TODAY}. Rebooting node."
     /sbin/reboot
 


### PR DESCRIPTION
The original purpose of weekly reboots for API nodes was to pick up any
system updates downloaded by CoreOS. When we migrated away from CoreOS,
the weekly reboots continued, but haven't served any real purpose. This
small update takes advantage of the weekly reboot script to also update
all system packages, some of which could require a reboot e.g., some
update to the kernel. While most package updates won't require a
restart, this small change give some small meaning to the weekly reboots
once again. Because the auto reboot checks that the etcd cluster is
healthy before rebooting, there is some safeguard builtin that package
updates haven't disabled the node in some way. Additionally, because the
nodes are rebooted sequentially on different days, and only weekdays,
this allow an operator to take notice of some fundamental problem caused
by a package update.

One final safeguard is the [PlatformCluster_NodeNotReady](https://github.com/m-lab/prometheus-support/blob/master/config/federation/prometheus/alerts.yml#L1082) alert, which will fire if a node is in a `NotReady` state for more than 1h. Therefore if an upgrade causes a problem with the kubelet, or the functioning of the node in general as it relates to kubernetes and the cluster, we will get a production alert after 1 hour, nearly 24h before the next API node would possibly attempt a reboot.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/628)
<!-- Reviewable:end -->
