### PR TITLE
Sets resolvConf field in KubeletConfiguration

### DIFF
--- a/manage-cluster/kubeadm-config.yml.template
+++ b/manage-cluster/kubeadm-config.yml.template
@@ -5,7 +5,6 @@ nodeRegistration:
   kubeletExtraArgs:
     container-runtime: "remote"
     container-runtime-endpoint: "unix:///run/containerd/containerd.sock"
-    resolv-conf: "/run/systemd/resolve/resolv.conf"
 localAPIEndpoint:
   advertiseAddress: "{{INTERNAL_IP}}"
   bindPort: 6443
@@ -28,7 +27,6 @@ nodeRegistration:
   kubeletExtraArgs:
     container-runtime: "remote"
     container-runtime-endpoint: "unix:///run/containerd/containerd.sock"
-    resolv-conf: "/run/systemd/resolve/resolv.conf"
 ---
 apiVersion: kubeadm.k8s.io/v1beta2
 kind: ClusterConfiguration

--- a/manage-cluster/kubeadm-config.yml.template
+++ b/manage-cluster/kubeadm-config.yml.template
@@ -59,3 +59,5 @@ containerLogMaxSize: 100Mi
 # https://github.com/kubernetes-sigs/kubespray/blob/master/docs/kubernetes-reliability.md#medium-update-and-average-reaction
 nodeStatusUpdateFrequency: 20s
 podPidsLimit: 10000
+resolvConf: /run/systemd/resolve/resolv.conf
+


### PR DESCRIPTION
A couple times now we have seen a CoreDNS pod crash looping with an error about a forwarding loop for the root domain. [The documentation for the 'loop' plugin](https://coredns.io/plugins/loop/#troubleshooting-loops-in-kubernetes-clusters), which detects this, suggests changing the value of resolvConf in the Kubelet configuration from /etc/resolv.conf to
/run/systems/resolv/resolv.conf on systems that are using systemd-resolved, which we do.

This is intended to hopefully resolve issues like these:

https://github.com/m-lab/ops-tracker/issues/1480
https://github.com/m-lab/ops-tracker/issues/1519

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/629)
<!-- Reviewable:end -->
