### PR TITLE
Adds flag --enable-feature=memory-snapshot-on-shutdown

### DIFF
--- a/k8s/deployments/prometheus.jsonnet
+++ b/k8s/deployments/prometheus.jsonnet
@@ -39,6 +39,7 @@ local prometheusConfig = import '../../config/prometheus.jsonnet';
               '--web.enable-lifecycle',
               '--web.external-url=https://prometheus-platform-cluster.' + std.extVar('PROJECT_ID') + '.measurementlab.net',
               '--storage.tsdb.retention.time=120d',
+              '--enable-feature=memory-snapshot-on-shutdown',
             ],
             image: 'prom/prometheus:v2.31.1',
             name: 'prometheus',


### PR DESCRIPTION
In production Prometheus takes a very long time to start up... up to
10m. This flag enables an experimental feature which might help reduce
startup times:

> Snapshot in-memory chunks on shutdown for faster restarts.

Adding this flag in sandbox reduced startup time from about 12s to 3.5s.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/630)
<!-- Reviewable:end -->
