### PR TITLE
Run two instances of traceroute-caller

### DIFF
--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -478,8 +478,8 @@ local ExperimentNoIndex(name, bucket, anonMode, datatypes, hostNetwork) = {
         containers:
           std.flattenArrays([
             Tcpinfo(name, 9991, hostNetwork, anonMode),
-            if anonMode == "none" then [TracerouteScamper1(name, 9992, hostNetwork), TracerouteScamper2(name, 9996, hostNetwork)]
-            else [],
+            if anonMode == "none" then TracerouteScamper1(name, 9992, hostNetwork) else [],
+            if anonMode == "none" then TracerouteScamper2(name, 9996, hostNetwork) else [],
             Pcap(name, 9993, hostNetwork),
             UUIDAnnotator(name, 9994, hostNetwork),
             Pusher(name, 9995, allDatatypes, hostNetwork, bucket),

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -226,9 +226,9 @@ local TracerouteScamper1(expName, tcpPort, hostNetwork) = [
     ],
   }] +
   if hostNetwork then
-    [RBACProxy('traceroute', tcpPort)]
+    [RBACProxy('traceroute-scamper1', tcpPort)]
   else
-    [SOCATProxy('traceroute', tcpPort)]
+    [SOCATProxy('traceroute-scamper1', tcpPort)]
 ;
 
 local TracerouteScamper2(expName, tcpPort, hostNetwork) = [
@@ -273,9 +273,9 @@ local TracerouteScamper2(expName, tcpPort, hostNetwork) = [
     ],
   }] +
   if hostNetwork then
-    [RBACProxy('traceroute', tcpPort)]
+    [RBACProxy('traceroute-scamper2', tcpPort)]
   else
-    [SOCATProxy('traceroute', tcpPort)]
+    [SOCATProxy('traceroute-scamper2', tcpPort)]
 ;
 
 local Pcap(expName, tcpPort, hostNetwork) = [
@@ -478,8 +478,8 @@ local ExperimentNoIndex(name, bucket, anonMode, datatypes, hostNetwork) = {
         containers:
           std.flattenArrays([
             Tcpinfo(name, 9991, hostNetwork, anonMode),
-            if anonMode == "none" then
-              Traceroute(name, 9992, hostNetwork) else [],
+            if anonMode == "none" then [TracerouteScamper1(name, 9992, hostNetwork), TracerouteScamper2(name, 9996, hostNetwork)]
+            else [],
             Pcap(name, 9993, hostNetwork),
             UUIDAnnotator(name, 9994, hostNetwork),
             Pusher(name, 9995, allDatatypes, hostNetwork, bucket),

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -184,8 +184,8 @@ local Tcpinfo(expName, tcpPort, hostNetwork, anonMode) = [
 
 local TracerouteScamper1(expName, tcpPort, hostNetwork) = [
   {
-    name: 'trc-scamper1',
-    image: 'measurementlab/traceroute-caller:v0.10.0',
+    name: 'traceroute-caller-scamper1',
+    image: 'measurementlab/traceroute-caller:latest',
     args: [
       if hostNetwork then
         '-prometheusx.listen-address=127.0.0.1:' + tcpPort
@@ -226,15 +226,15 @@ local TracerouteScamper1(expName, tcpPort, hostNetwork) = [
     ],
   }] +
   if hostNetwork then
-    [RBACProxy('traceroute-scamper1', tcpPort)]
+    [RBACProxy('traceroute-caller-scamper1', tcpPort)]
   else
-    [SOCATProxy('traceroute-scamper1', tcpPort)]
+    [SOCATProxy('traceroute-caller-scamper1', tcpPort)]
 ;
 
 local TracerouteScamper2(expName, tcpPort, hostNetwork) = [
   {
-    name: 'trc-scamper2',
-    image: 'measurementlab/traceroute-caller:v0.10.0',
+    name: 'traceroute-caller-scamper2',
+    image: 'measurementlab/traceroute-caller:latest',
     args: [
       if hostNetwork then
         '-prometheusx.listen-address=127.0.0.1:' + tcpPort
@@ -273,9 +273,9 @@ local TracerouteScamper2(expName, tcpPort, hostNetwork) = [
     ],
   }] +
   if hostNetwork then
-    [RBACProxy('traceroute-scamper2', tcpPort)]
+    [RBACProxy('traceroute-caller-scamper2', tcpPort)]
   else
-    [SOCATProxy('traceroute-scamper2', tcpPort)]
+    [SOCATProxy('traceroute-caller-scamper2', tcpPort)]
 ;
 
 local Pcap(expName, tcpPort, hostNetwork) = [
@@ -557,7 +557,7 @@ local Experiment(name, index, bucket, anonMode, datatypes=[]) = ExperimentNoInde
   // ourselves.
   RBACProxy(name, port):: RBACProxy(name, port),
 
-  // RBACProxy creates a localhost proxy for containers that listen on the
+  // SOCATProxy creates a localhost proxy for containers that listen on the
   // pod private IP. This allows operators to use kubectl port-forward to access
   // metrics and debug/pprof profiling safely through kubectl.
   SOCATProxy(name, port):: SOCATProxy(name, port),


### PR DESCRIPTION
This commit configures Kubernetes to run two instances of
the traceroute-caller container, one running MDA traceroutes
(scamper1 datatype) and another running regular traceroutes
(scamper2 datatype).

Running the above configuration on a gLinux desktop was tested
using docker-compose.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/632)
<!-- Reviewable:end -->
