### PR TITLE
Fixes incorrect label and adds collection of broadcast metrics

### DIFF
--- a/config/disco/metrics.yaml
+++ b/config/disco/metrics.yaml
@@ -2,7 +2,7 @@
   description: Ingress octets.
   oidStub: .1.3.6.1.2.1.31.1.1.1.6
   mlabUplinkName: switch.octets.uplink.rx
-  mlabMachineName: switch.octets.local.tx
+  mlabMachineName: switch.octets.local.rx
 - name: ifHCOutOctets
   description: Egress octets.
   oidStub: .1.3.6.1.2.1.31.1.1.1.10

--- a/config/disco/metrics.yaml
+++ b/config/disco/metrics.yaml
@@ -38,3 +38,13 @@
   oidStub: .1.3.6.1.2.1.2.2.1.19
   mlabUplinkName: switch.discards.uplink.tx
   mlabMachineName: switch.discards.local.tx
+- name: ifHCInBroadcastPkts
+  description: Ingress broadcast packets.
+  oidStub: .1.3.6.1.2.1.31.1.1.1.9
+  mlabUplinkName: switch.broadcast.uplink.rx
+  mlabMachineName: switch.broadcast.local.rx
+- name: ifHCOutBroadcastPkts
+  description: Egress broadcast packets.
+  oidStub: .1.3.6.1.2.1.31.1.1.1.13
+  mlabUplinkName: switch.broadcast.uplink.tx
+  mlabMachineName: switch.broadcast.local.tx


### PR DESCRIPTION
I had previously been trying to make changes to the DISCO config by committing to the disco repository. However, the config file in the disco repository is nothing more than a sample/reference config file. I have made changes to the disco repo to make that more clear so that doesn't happen in the future.

Meanwhile, this PR is the real fix for these previous bad PRs to the disco repo:

https://github.com/m-lab/disco/pull/21
https://github.com/m-lab/disco/pull/22

I have verified in a running container that the correct config is making it to the cluster, and that disco is now collecting broadcast metrics, and that the mislabeled `ifHCInOctets` seems to be fixed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/633)
<!-- Reviewable:end -->
