### PR TITLE
Exclude dash from pusher SLI metric

### DIFF
--- a/config/prometheus/rules.yml
+++ b/config/prometheus/rules.yml
@@ -153,8 +153,11 @@ groups:
 
   #
   # This rule optimizes the alert query used for PusherDailyDataVolumeTooLow.
+  # Do not collect data for "dash". The Dash data isn't parsed, only has a
+  # single client (that we know of), and is subject to too much variability in
+  # traffic/data.
   - record: datatype:pusher_bytes_per_tarfile:increase24h
-    expr: sum by(datatype) (increase(pusher_bytes_per_tarfile_sum[1d]))
+    expr: sum by(datatype) (increase(pusher_bytes_per_tarfile_sum{datatype!="dash"}[1d]))
 
 ## Ops: Tactical & SRE Overview Dashboard.
 

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -241,11 +241,9 @@ local Pcap(expName, tcpPort, hostNetwork) = [
       '-datadir=' + VolumeMount(expName).mountPath + '/pcap',
       '-tcpinfo.eventsocket=' + tcpinfoServiceVolume.socketFilename,
       '-stream=false',
-    ] + if hostNetwork then
-      if expName != 'ndtcloud' then
-        ['-interface=eth0',]
-      else []
-    else [],
+    ] + if hostNetwork && expName != 'ndtcloud' then [
+      '-interface=eth0',
+    ] else [],
     env: if hostNetwork then [] else [
       {
         name: 'PRIVATE_IP',

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -241,9 +241,11 @@ local Pcap(expName, tcpPort, hostNetwork) = [
       '-datadir=' + VolumeMount(expName).mountPath + '/pcap',
       '-tcpinfo.eventsocket=' + tcpinfoServiceVolume.socketFilename,
       '-stream=false',
-    ] + if hostNetwork then [
-      '-interface=eth0',
-    ] else [],
+    ] + if hostNetwork then
+      if expName != 'ndtcloud' then
+        ['-interface=eth0',]
+      else []
+    else [],
     env: if hostNetwork then [] else [
       {
         name: 'PRIVATE_IP',


### PR DESCRIPTION
* Excludes "dash" datatype from metric `datatype:pusher_bytes_per_tarfile:increase24h`. This metric is primarily (only?) used in an alert which fires when too little data has been pushed to GCS by pusher, compared to the day before. The alert has fired a couple times over the past few months for this data type. The data type is not parsed, only has a single client (OONI, that we know of), and seems to be variable in its use, causing swings in the data volume. This PR just removes it from consideration in the metric and alert.
*  This PR also causes the packet-headers sidecar container to listen on all interfaces for NDT virtual ("cloud") deployments. Currently, packet-headers will try to listen on "eth0" for all experiments with `hostNetwork=true`, but this cannot work for virtual nodes, since the underlying VM may not have an eth0 interface. In either case, for all "normal" experiments, packet-headers listens on all interfaces, so this change is consistent with the way we are doing things for NDT and other experiments.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/634)
<!-- Reviewable:end -->
