### PR TITLE
Installs flannel CNI plugin on NDT virtual instances

### DIFF
--- a/manage-cluster/add_k8s_virtual_node.sh
+++ b/manage-cluster/add_k8s_virtual_node.sh
@@ -167,27 +167,32 @@ gcloud compute ssh "${GCE_NAME}" "${GCE_ARGS[@]}" <<EOF
 
   # Install CNI plugins.
   mkdir -p /opt/cni/bin
-  curl -L "https://github.com/containernetworking/plugins/releases/download/${K8S_CNI_VERSION}/cni-plugins-linux-amd64-${K8S_CNI_VERSION}.tgz" | tar -C /opt/cni/bin -xz
+  curl --location "https://github.com/containernetworking/plugins/releases/download/${K8S_CNI_VERSION}/cni-plugins-linux-amd64-${K8S_CNI_VERSION}.tgz" | tar -C /opt/cni/bin -xz
+
+  # Install the Flannel CNI plugin
+  # v0.9.1 of the official CNI plugins release stopped including flannel, so we
+  # must now install it manually from its official source.
+  curl --location "https://github.com/flannel-io/cni-plugin/releases/download/${K8S_FLANNELCNI_VERSION}/flannel-amd64" > /opt/cni/bin/flannel
 
   # Install crictl.
   mkdir -p /opt/bin
-  curl -L "https://github.com/kubernetes-incubator/cri-tools/releases/download/${K8S_CRICTL_VERSION}/crictl-${K8S_CRICTL_VERSION}-linux-amd64.tar.gz" | tar -C /opt/bin -xz
+  curl --location "https://github.com/kubernetes-incubator/cri-tools/releases/download/${K8S_CRICTL_VERSION}/crictl-${K8S_CRICTL_VERSION}-linux-amd64.tar.gz" | tar -C /opt/bin -xz
 
   # Install conntrack.
   apt install -y conntrack
 
   # Install kubeadm, kubelet and kubectl.
   cd /opt/bin
-  curl -L --remote-name-all https://storage.googleapis.com/kubernetes-release/release/${K8S_VERSION}/bin/linux/amd64/{kubeadm,kubelet,kubectl}
+  curl --location --remote-name-all https://storage.googleapis.com/kubernetes-release/release/${K8S_VERSION}/bin/linux/amd64/{kubeadm,kubelet,kubectl}
   chmod +x {kubeadm,kubelet,kubectl}
 
   # Install kubelet systemd service and enable it.
-  curl -sSL \
+  curl --silent --show-error --location \
     "https://raw.githubusercontent.com/kubernetes/release/${K8S_TOOLING_VERSION}/cmd/kubepkg/templates/latest/deb/kubelet/lib/systemd/system/kubelet.service" \
 	| sed "s:/usr/bin:/opt/bin:g" | sudo tee /etc/systemd/system/kubelet.service
 
   mkdir -p /etc/systemd/system/kubelet.service.d
-  curl -sSL \
+  curl --silent --show-error --location \
     "https://raw.githubusercontent.com/kubernetes/release/${K8S_TOOLING_VERSION}/cmd/kubepkg/templates/latest/deb/kubeadm/10-kubeadm.conf" \
 	| sed "s:/usr/bin:/opt/bin:g" | sudo tee /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
 

--- a/manage-cluster/add_k8s_virtual_node.sh
+++ b/manage-cluster/add_k8s_virtual_node.sh
@@ -169,10 +169,11 @@ gcloud compute ssh "${GCE_NAME}" "${GCE_ARGS[@]}" <<EOF
   mkdir -p /opt/cni/bin
   curl --location "https://github.com/containernetworking/plugins/releases/download/${K8S_CNI_VERSION}/cni-plugins-linux-amd64-${K8S_CNI_VERSION}.tgz" | tar -C /opt/cni/bin -xz
 
-  # Install the Flannel CNI plugin
+  # Install the Flannel CNI plugin.
   # v0.9.1 of the official CNI plugins release stopped including flannel, so we
   # must now install it manually from its official source.
   curl --location "https://github.com/flannel-io/cni-plugin/releases/download/${K8S_FLANNELCNI_VERSION}/flannel-amd64" > /opt/cni/bin/flannel
+  chmod +x /opt/cni/bin/flannel
 
   # Install crictl.
   mkdir -p /opt/bin

--- a/manage-cluster/add_ndt_virtual_node.sh
+++ b/manage-cluster/add_ndt_virtual_node.sh
@@ -77,4 +77,4 @@ fi
 
 ./add_k8s_virtual_node.sh -p "${PROJECT}" -z "${CLOUD_ZONE}" \
     -n "${GCE_NAME}" -H "${K8S_NAME}" -a "${GCE_NAME}" -t "ndt-cloud" \
-    -l "mlab/type=virtual mlab/run=ndtcloud mlab/machine=${MLAB_MACHINE} mlab/metro=${CLOUD_SITE::-2} mlab/site=${CLOUD_SITE} mlab/project=${PROJECT}"
+    -l "mlab/type=virtual mlab/run=ndt mlab/machine=${MLAB_MACHINE} mlab/metro=${CLOUD_SITE::-2} mlab/site=${CLOUD_SITE} mlab/project=${PROJECT}"

--- a/manage-cluster/k8s_deploy.conf
+++ b/manage-cluster/k8s_deploy.conf
@@ -31,7 +31,10 @@ GCE_API_SCOPES="cloud-platform"
 K8S_VERSION="v1.20.13"
 K8S_CNI_VERSION="v1.0.1"
 K8S_CRICTL_VERSION="v1.20.0"
+# FLANNEL is for the flannel DaemonSet, whereas FLANNELCNI is for the CNI
+# plugin located at /opt/cni/bin (used by the kubelet).
 K8S_FLANNEL_VERSION="v0.15.1"
+K8S_FLANNELCNI_VERSION=v1.0.0
 K8S_TOOLING_VERSION="v0.12.0"
 ETCDCTL_VERSION="v3.4.14"
 K8S_HELM_VERSION="v3.7.1"


### PR DESCRIPTION
This was [already done for physical machines](https://github.com/m-lab/epoxy-images/pull/215), but not for virtual nodes. This PR corrects that.

Changes the `mlab/run` label for virtual nodes from "ndtcloud" to just "ndt". We want NDT virtual instances to be more like regular bare-metal NDT pods.

Use long flags for `curl` for better readability.