### PR TITLE
Pins socat proxy and busybox versions

### DIFF
--- a/k8s/daemonsets/experiments/wehe.jsonnet
+++ b/k8s/daemonsets/experiments/wehe.jsonnet
@@ -15,7 +15,7 @@ exp.Experiment(expName, 5, 'pusher-' + std.extVar('PROJECT_ID'), 'netblock', ['r
             args: [
               'cp', '/wehe-ca/ca.key', '/wehe-ca/ca.crt', '/wehe/ssl/',
             ],
-            image: 'busybox',
+            image: 'busybox:1.34',
             // Wehe expects the ca.key and ca.crt to be in a
             // directory to which it can write the resulting keys
             // produced. Secrets can't be mounted read/write, so

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -65,7 +65,7 @@ local VolumeMount(name) = {
 // information.
 local SOCATProxy(name, port) = {
   name: 'socat-proxy-' + name,
-  image: 'alpine/socat',
+  image: 'alpine/socat:1.0.5',
   args: [
     // socat does not support long options.
     '-dd', // debug.


### PR DESCRIPTION
Currently, both are using the latest version (implicitly). We generally discourage this, so this PR pins their versions at the current stable releases.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/643)
<!-- Reviewable:end -->
