### PR TITLE
Configures Vector to export internal metrics

### DIFF
--- a/config/vector/values.yaml.template
+++ b/config/vector/values.yaml.template
@@ -59,7 +59,7 @@ extraVolumeMounts:
 image:
   tag: {{IMAGE}}
 podAnnotations:
-  prometheus.io/scrape: true
+  prometheus.io/scrape: "true"
 podLabels:
   workload: vector
 role: Agent

--- a/config/vector/values.yaml.template
+++ b/config/vector/values.yaml.template
@@ -15,11 +15,18 @@ customConfig:
         location: {{PROJECT}}
         namespace: "${VECTOR_SELF_NODE_NAME}"
         node_id: "${VECTOR_SELF_NODE_NAME}"
+    prometheus_exporter:
+      type: prometheus_exporter
+      inputs:
+      - internal_metrics
+      address: 0.0.0.0:9598
   sources:
     journald:
       type: journald
     kubernetes_logs:
       type: kubernetes_logs
+    internal_metrics:
+      type: internal_metrics
   transforms:
     kernel_log:
       type: filter

--- a/config/vector/values.yaml.template
+++ b/config/vector/values.yaml.template
@@ -19,7 +19,7 @@ customConfig:
       type: prometheus_exporter
       inputs:
       - internal_metrics
-      address: 0.0.0.0:9598
+      address: 0.0.0.0:9090
   sources:
     journald:
       type: journald
@@ -58,6 +58,8 @@ extraVolumeMounts:
   readOnly: true
 image:
   tag: {{IMAGE}}
+podAnnotations:
+  prometheus.io/scrape: true
 podLabels:
   workload: vector
 role: Agent


### PR DESCRIPTION
The changes in this PR cause Vector to export internal metrics about its own operation. We can probably use some of these metrics to determine if Vector is working as intended, and to alert when something seems off.

This is an interesting configuration, as Vector treats its own internal operating metrics in the same way as it does all other data sources and sinks. That is, internal metrics are just another source of data, which can be transformed and shuttled off to some other location. In this case, they aren't shuttled anywhere, but are just served up at `:9090/metrics` inside the pod, which gets picked up automatically by Prometheus kubernetes service discovery.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/644)
<!-- Reviewable:end -->
