### PR TITLE
Adds speed label to max_by() Prom query

### DIFF
--- a/config/prometheus/rules.yml
+++ b/config/prometheus/rules.yml
@@ -188,7 +188,7 @@ groups:
   #
   # Units: bits per second.
   - record: switch:ifHCOutOctets:bps2m
-    expr: max by (site, speed) (8 * irate(ifHCOutOctets{ifAlias="uplink"}[4m]))
+    expr: max by (site, speed, ifAlias) (8 * irate(ifHCOutOctets{ifAlias="uplink"}[4m]))
 
   ## NDT Early Warning aggregation rules for Kubernetes platform.
 

--- a/config/prometheus/rules.yml
+++ b/config/prometheus/rules.yml
@@ -188,7 +188,7 @@ groups:
   #
   # Units: bits per second.
   - record: switch:ifHCOutOctets:bps2m
-    expr: max by (site) (8 * irate(ifHCOutOctets{ifAlias="uplink"}[4m]))
+    expr: max by (site, speed) (8 * irate(ifHCOutOctets{ifAlias="uplink"}[4m]))
 
   ## NDT Early Warning aggregation rules for Kubernetes platform.
 


### PR DESCRIPTION
We use this recording rule to check for switches that are overloaded,
and whether a switch is overloaded depends on how fast the uplink is.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/645)
<!-- Reviewable:end -->
