### PR TITLE
Set -txcontroller.max-rate=150000000 for virtual nodes

### DIFF
--- a/k8s/daemonsets/experiments/ndt-virtual.jsonnet
+++ b/k8s/daemonsets/experiments/ndt-virtual.jsonnet
@@ -39,6 +39,7 @@ exp.ExperimentNoIndex(expName, 'pusher-' + std.extVar('PROJECT_ID'), "none", dat
               '-cert=/certs/tls.crt',
               '-label=type=virtual',
               '-label=deployment=stable',
+              '-txcontroller.max-rate=150000000',
             ],
             volumeMounts: [
               {


### PR DESCRIPTION
This is normally set at runtime on physical machines based the value in
the ConfigMap nodes-max-rate. However, that ConfigMap is created by
looking at the switch configuration for a site, but virtual sites do not
have switches and thus no entry for switches.json in siteinfo. This
commit manually configures the value to the same value we use for other
1g sites.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/646)
<!-- Reviewable:end -->
