### PR TITLE
Removes socat proxy containers

### DIFF
--- a/config/prometheus/prometheus.yml
+++ b/config/prometheus/prometheus.yml
@@ -101,14 +101,6 @@ scrape_configs:
         regex: https
         action: drop
 
-      # socat proxy enables easy access to pprof targets but accidentally
-      # duplicates metric collection. The annotation mechanism applies at the pod
-      # level not at individual containers. So, this rule drops metrics with
-      # socat containers.
-      - source_labels: [__meta_kubernetes_pod_container_name]
-        regex: socat-.*
-        action: drop
-
       # For inventory, record whether a pod is ready. This helps distinguish
       # between: missing from inventory, not ready and failing, ready but
       # failing, ready and working.

--- a/k8s/daemonsets/README.md
+++ b/k8s/daemonsets/README.md
@@ -4,9 +4,10 @@ We have two kinds of daemonset we want to run on our nodes: Those that make the 
 
 ## Access Metrics and PProf Instrumentation
 
-Our core services (tcpinfo, traceroute, pcap, pusher) are built with native
-prometheus metrics and pprof instrumentation. Access to the `/metrics` and
-`/debug/pprof` targets are only accessible to the private k8s network.
+Our core services (tcp-info, traceroute-caller, packet-headers, uuid-annotator,
+pusher) are built with native prometheus metrics and pprof instrumentation.
+Access to the `/metrics` and `/debug/pprof` targets are only accessible to the
+private k8s network.
 
 Operators can access these targets by following these steps.
 

--- a/k8s/daemonsets/README.md
+++ b/k8s/daemonsets/README.md
@@ -5,30 +5,53 @@ We have two kinds of daemonset we want to run on our nodes: Those that make the 
 ## Access Metrics and PProf Instrumentation
 
 Our core services (tcpinfo, traceroute, pcap, pusher) are built with native
-prometheus metrics and pprof instrumentation. Ordinarily, access to the
-`/metrics` and `/debug/pprof` targets are only accessible to the private k8s
-network.
+prometheus metrics and pprof instrumentation. Access to the `/metrics` and
+`/debug/pprof` targets are only accessible to the private k8s network.
 
 Operators can access these targets by following these steps.
 
-1. Identify a pod of interest. For example:
+Identify a pod of interest. For example:
 
 ```sh
-$ kubectl get pods -o wide | grep mlab1.lga0t | grep ndt
-ndt-w6tr6   9/9       Running   0          29m     192.168.3.24    mlab1.lga0t
+$ kubectl get pods -l workload=ndt -o wide | grep mlab1-lga0t
+ndt-w6tr6   13/13       Running   0          29m     192.168.3.24 mlab1-lga0t[...]
 ```
 
-2. Forward a local port to the remote pod port for the container of interest.
-   Check the latest port-to-container mapping in k8s/daemonsets/templates.jsonnet
+In one terminal, use kubectl to start a proxy to the control plane (API
+cluster). By default `kubectl proxy` will create a local listener on port
+8001. You can use the default or change the port to whatever you prefer.
 
 ```sh
-$ kubectl port-forward pod/ndt-w6tr6 9993:9993
+$ kubectl proxy
 ```
 
-3. Access localhost:9993 using a browser, `go tool pprof <url>`, or other tool.
+Using the local listener created by `kubectl proxy`, make an API call to the
+"proxy" operation for the pod we discovered earlier. The general URL pattern is
+like:
 
 ```sh
-$ google-chrome http://localhost:9993/metrics
-$ go tool pprof -top http://localhost:9993/debug/pprof/heap
-$ lynx http://localhost:9993/debug/pprof/
+/api/v1/namespaces/<namespace>/pods/<podname>:<port>/proxy/
 ```
+
+For example:
+
+```sh
+$ curl http://localhost:8001/api/v1/namespaces/default/pods/ndt-w6tr6:9990/proxy/debug/pprof/
+$ curl http://localhost:8001/api/v1/namespaces/default/pods/ndt-w6tr6:9995/proxy/metrics
+$ go tool pprof -top http://localhost:8001/api/v1/namespaces/default/pods/ndt-w6tr6:9991/proxy/debug/pprof/heap
+$ google-chrome http://localhost:8001/api/v1/namespaces/default/pods/ndt-w6tr6:9992/proxy/debug/pprof/
+```
+
+Each sidecar service (and ndt-server) listens on a particular port. At the time
+of this writing the ports are as follows:
+
+* 9990: ndt-server
+* 9991: tcp-info
+* 9992: traceroute-caller
+* 9993: packet-headers
+* 9994: uuid-annotator
+* 9995: pusher
+
+To access metrics or pprof data for a given service, simply modify the the URL
+to specify `<podname>:<port>`. 
+

--- a/k8s/daemonsets/experiments/ndt-canary.jsonnet
+++ b/k8s/daemonsets/experiments/ndt-canary.jsonnet
@@ -98,8 +98,6 @@ exp.Experiment(expName, 2, 'pusher-' + std.extVar('PROJECT_ID'), "none", datatyp
             ],
 
           },
-        ] + [
-          exp.SOCATProxy('ndt-server', 9990)
         ],
         volumes+: [
           {

--- a/k8s/daemonsets/experiments/ndt-osupgrade.jsonnet
+++ b/k8s/daemonsets/experiments/ndt-osupgrade.jsonnet
@@ -98,8 +98,6 @@ exp.Experiment(expName, 2, 'pusher-' + std.extVar('PROJECT_ID'), "none", datatyp
             ],
 
           },
-        ] + [
-          exp.SOCATProxy('ndt-server', 9990)
         ],
         volumes+: [
           {

--- a/k8s/daemonsets/experiments/ndt.jsonnet
+++ b/k8s/daemonsets/experiments/ndt.jsonnet
@@ -87,8 +87,6 @@ exp.Experiment(expName, 2, 'pusher-' + std.extVar('PROJECT_ID'), "none", datatyp
             ],
 
           },
-        ] + [
-          exp.SOCATProxy('ndt-server', 9990)
         ],
         volumes+: [
           {


### PR DESCRIPTION
socat proxy is currently used to access natively instrumented metrics and pprof data for M-Lab core service containers. However, we discovered that socat proxy was not actually needed. Instead we can leverage `kubectl proxy` to make calls directly to the private cluster IPs/ports used by these services. This removes a considerable amount of clutter in our pods, since we will no longer need a separate socat proxy container for every core service container. The documentation for accessing this data without socat proxy was also updated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/647)
<!-- Reviewable:end -->
