### PR TITLE
Add metadata volume for adding external-ip label

### DIFF
--- a/k8s/daemonsets/experiments/ndt-virtual.jsonnet
+++ b/k8s/daemonsets/experiments/ndt-virtual.jsonnet
@@ -12,7 +12,7 @@ local metadata = {
   volume: {
     hostPath: {
       path: '/var/local/metadata',
-      type: 'DirectoryOrCreate',
+      type: 'Directory',
     },
     name: 'metadata',
   },

--- a/k8s/daemonsets/experiments/ndt-virtual.jsonnet
+++ b/k8s/daemonsets/experiments/ndt-virtual.jsonnet
@@ -39,7 +39,7 @@ exp.ExperimentNoIndex(expName, 'pusher-' + std.extVar('PROJECT_ID'), "none", dat
             volumeMounts: [
               {
                 mountPath: '/var/local/metadata',
-                name: 'metadta',
+                name: 'metadata',
                 readOnly: false,
               },
             ],
@@ -73,7 +73,7 @@ exp.ExperimentNoIndex(expName, 'pusher-' + std.extVar('PROJECT_ID'), "none", dat
               exp.uuid.volumemount,
               {
                 mountPath: '/var/local/metadata',
-                name: 'metadta',
+                name: 'metadata',
                 readOnly: true,
               },
             ] + [

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -1,7 +1,7 @@
-local ndtVersion = 'v0.20.7';
+local ndtVersion = 'v0.20.9';
 // The canary version is expected to be greater than or equal to
 // the current stable version.
-local ndtCanaryVersion = 'v0.20.7';
+local ndtCanaryVersion = 'v0.20.9';
 local PROJECT_ID = std.extVar('PROJECT_ID');
 
 // The default grace period after k8s sends SIGTERM is 30s. We


### PR DESCRIPTION
This change adds support for a local metadata volume to load additional labels for the ndt-server. This change includes labels for `external-ip`, `zone`, `machine-type`, `network-tier`.

FYI: @cristinaleonr

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/648)
<!-- Reviewable:end -->
