### PR TITLE
Writes out metadata to filesystem upon VM creation

### DIFF
--- a/manage-cluster/add_k8s_virtual_node.sh
+++ b/manage-cluster/add_k8s_virtual_node.sh
@@ -179,8 +179,8 @@ gcloud compute ssh "${GCE_NAME}" "${GCE_ARGS[@]}" <<EOF
   mkdir -p /opt/bin
   curl --location "https://github.com/kubernetes-incubator/cri-tools/releases/download/${K8S_CRICTL_VERSION}/crictl-${K8S_CRICTL_VERSION}-linux-amd64.tar.gz" | tar -C /opt/bin -xz
 
-  # Install conntrack.
-  apt install -y conntrack
+  # Install a few network-related packages.
+  apt install -y conntrack ebtables iptables socat
 
   # Install kubeadm, kubelet and kubectl.
   cd /opt/bin
@@ -252,6 +252,27 @@ EXTERNAL_IP=$(gcloud compute instances list \
     --format 'value(networkInterfaces[].accessConfigs[0].natIP)'\
     --project="${PROJECT}" \
     --filter="name~'${GCE_NAME}'")
+
+# Ssh to the new VM and write out various pieces of metadata to the filesystem.
+# These bits of metadata can be used by various services running on the VM to
+# know more about their environment. For example, an experiment might use the
+# metadata to label data that it produces so that someone querying the data in
+# BigQuery could discover more about the operating environment of the experiment.
+gcloud compute ssh "${GCE_NAME}" "${GCE_ARGS[@]}" <<EOF
+  set -euxo pipefail
+  sudo --login
+
+  # Bash options are not inherited by subshells. Reset them to exit on any error.
+  set -euxo pipefail
+
+  metadata_dir=/var/local/metadata
+
+  mkdir -p \$metadata_dir
+
+  echo $GCE_ZONE > "\${metadata_dir}/zone"
+  echo $EXTERNAL_IP > "\${metadata_dir}/external-ip"
+  echo $MACHINE_TYPE > "\${metadata_dir}/machine-type"
+EOF
 
 # Ssh to the master and fix the network annotation for the node.
 gcloud compute ssh "${K8S_MASTER}" --zone "${MASTER_ZONE}" "${GCP_ARGS[@]}" <<EOF


### PR DESCRIPTION
ndt-server is going to start labeling data it produces with anything that might be useful to know about when analyzing the data. For  virtual nodes, it will be important/useful to know a few things, such at the external/public IP, the GCP zone and the machine type (e.g., e1-standard-2).  @stephen-soltesz is making [some changes to the `go/flagx` package](https://github.com/m-lab/go/pull/142
) which will allow a flag whose value is located in a file. This new facility will allow ndt-server to create labels based on the contents of the files that get written here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/649)
<!-- Reviewable:end -->
