### PR TITLE
Suppresses echo NLs when writing metadata files

### DIFF
--- a/manage-cluster/add_k8s_virtual_node.sh
+++ b/manage-cluster/add_k8s_virtual_node.sh
@@ -276,10 +276,10 @@ gcloud compute ssh "${GCE_NAME}" "${GCE_ARGS[@]}" <<EOF
 
   mkdir -p \$metadata_dir
 
-  echo $GCE_ZONE > "\${metadata_dir}/zone"
-  echo $EXTERNAL_IP > "\${metadata_dir}/external-ip"
-  echo $MACHINE_TYPE > "\${metadata_dir}/machine-type"
-  echo $NETWORK_TIER > "\${metadata_dir}/network-tier"
+  echo -n $GCE_ZONE > "\${metadata_dir}/zone"
+  echo -n $EXTERNAL_IP > "\${metadata_dir}/external-ip"
+  echo -n $MACHINE_TYPE > "\${metadata_dir}/machine-type"
+  echo -n $NETWORK_TIER > "\${metadata_dir}/network-tier"
 EOF
 
 # Ssh to the master and fix the network annotation for the node.


### PR DESCRIPTION
Whatever ingests the values from these metadata files should probably be able to gracefully handle unwanted space before and after the value, but neither should we be writing unwanted white space. This PR suppresses `echo`'s default newline.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/650)
<!-- Reviewable:end -->
