### PR TITLE
Adds support for adding IPv6-enabled virtual nodes

### DIFF
--- a/manage-cluster/add_k8s_virtual_node.sh
+++ b/manage-cluster/add_k8s_virtual_node.sh
@@ -267,6 +267,8 @@ if [[ -n $IPV6_FLAG ]]; then
   EXTERNAL_IPV6=$(gcloud compute instances describe "${GCE_NAME}" \
       --format 'value(networkInterfaces[0].ipv6AccessConfigs[0].externalIpv6)' \
       "${GCE_ARGS[@]}")
+else
+  EXTERNAL_IPV6=""
 fi
 
 # Determine the network tier for this VM. It does not appear that this value is
@@ -295,9 +297,7 @@ gcloud compute ssh "${GCE_NAME}" "${GCE_ARGS[@]}" <<EOF
 
   echo -n $GCE_ZONE > "\${metadata_dir}/zone"
   echo -n $EXTERNAL_IP > "\${metadata_dir}/external-ip"
-  if [[ -n $EXTERNAL_IPV6 ]]; then
-    echo -n $EXTERNAL_IPV6 > "\${metadata_dir}/external-ipv6"
-  fi
+  echo -n $EXTERNAL_IPV6 > "\${metadata_dir}/external-ipv6"
   echo -n $MACHINE_TYPE > "\${metadata_dir}/machine-type"
   echo -n $NETWORK_TIER > "\${metadata_dir}/network-tier"
 EOF


### PR DESCRIPTION
Note: dual stack GCE VMs are only available in a few regions. As of this
commit, the only region in the US is us-west2 (LAX). With these changes,
if a VM is being added in one of the few regions where IPv6 is
supported, then this script will automatically enable IPv6.

This PR also updates the default VM machine-type to n1-highcpu-4, which gives these VMs a bit more horsepower.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/651)
<!-- Reviewable:end -->
