### PR TITLE
Loads BBR module + configures fq qdisc

### DIFF
--- a/manage-cluster/add_k8s_virtual_node.sh
+++ b/manage-cluster/add_k8s_virtual_node.sh
@@ -122,7 +122,7 @@ if [[ -z "${MACHINE_TYPE}" ]]; then
   MACHINE_TYPE="n1-highcpu-4"
 fi
 
-if echo $IPV6_REGIONS | grep ${!GCE_REGION}; then
+if echo $IPV6_REGIONS | grep "${GCE_ZONE%-*}"; then
   IPV6_FLAG="--stack-type=IPV4_IPV6"
 else
   IPV6_FLAG=""

--- a/manage-cluster/cloud-config_node.yml
+++ b/manage-cluster/cloud-config_node.yml
@@ -54,7 +54,15 @@ write_files:
     After=multi-user.target
     [Service]
     Type=oneshot
-    ExecStart=tc qdisc replace dev ens4 root fq maxrate 10gbit
+    # The - in front of the file name indicates that if the file doesn't exist,
+    # don't attempt to read it and don't emit and error.
+    EnvironmentFile=-/run/net-iface
+    # This is a fairly ugly way to get the device name of the default route
+    # (which should be representative of the primary NIC device). The double
+    # backslash in front of $5 is a requirement of systemd, since unit files can
+    # contain escape sequences.
+    ExecStartPre=/bin/bash -c 'echo IFACE=$(ip -o -4 route show default | awk "{print \\$5}") > /run/net-iface'
+    ExecStart=tc qdisc replace dev $IFACE root fq maxrate 10gbit
     [Install]
     WantedBy=multi-user.target
 

--- a/manage-cluster/cloud-config_node.yml
+++ b/manage-cluster/cloud-config_node.yml
@@ -41,8 +41,15 @@ write_files:
     net.bridge.bridge-nf-call-iptables  = 1
     net.bridge.bridge-nf-call-ip6tables = 1
 
+# Load the TCP BBR kernel module.
+- path: /etc/modules-load.d/tcp_bbr.conf
+  permissions: 0644
+  owner: root:root
+  content: tcp_bbr
+
 runcmd:
 - sysctl --system
 - systemctl restart systemd-modules-load.service
 - systemctl enable containerd
 - systemctl start containerd
+- tc qdisc replace dev ens4 root fq maxrate 10gbit

--- a/manage-cluster/cloud-config_node.yml
+++ b/manage-cluster/cloud-config_node.yml
@@ -30,6 +30,7 @@ write_files:
   content: |
     overlay
     br_netfilter
+    tcp_bbr
 
 # The odd number of 999 because GCE nodes already have a file named
 # 99-gce.conf, which, among other things, disables ip forwarding.
@@ -41,15 +42,25 @@ write_files:
     net.bridge.bridge-nf-call-iptables  = 1
     net.bridge.bridge-nf-call-ip6tables = 1
 
-# Load the TCP BBR kernel module.
-- path: /etc/modules-load.d/tcp_bbr.conf
+# Configures the fq qdisc on boot. Note that all GCE VMs we create will be
+# capable of 10g, even though we may choose to flag the site as 1g in siteinfo
+# for other reasons.
+- path: /etc/systemd/system/configure-tc-fq.service
   permissions: 0644
   owner: root:root
-  content: tcp_bbr
+  content: |
+    [Unit]
+    Description=Configures TCP pacing
+    After=multi-user.target
+    [Service]
+    Type=oneshot
+    ExecStart=tc qdisc replace dev ens4 root fq maxrate 10gbit
+    [Install]
+    WantedBy=multi-user.target
 
 runcmd:
 - sysctl --system
 - systemctl restart systemd-modules-load.service
 - systemctl enable containerd
 - systemctl start containerd
-- tc qdisc replace dev ens4 root fq maxrate 10gbit
+- systemctl start configure-tc-fq.service


### PR DESCRIPTION
Additionally, fixes a small bug in the IPv6 logic. We are currently grepping for the region of the sandbox control-place, not the region of the node.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/653)
<!-- Reviewable:end -->
