### PR TITLE
Removes Vector internal metrics

### DIFF
--- a/config/vector/values.yaml.template
+++ b/config/vector/values.yaml.template
@@ -15,18 +15,11 @@ customConfig:
         location: {{PROJECT}}
         namespace: "${VECTOR_SELF_NODE_NAME}"
         node_id: "${VECTOR_SELF_NODE_NAME}"
-    prometheus_exporter:
-      type: prometheus_exporter
-      inputs:
-      - internal_metrics
-      address: 0.0.0.0:9090
   sources:
     journald:
       type: journald
     kubernetes_logs:
       type: kubernetes_logs
-    internal_metrics:
-      type: internal_metrics
   transforms:
     kernel_log:
       type: filter


### PR DESCRIPTION
It was decided that we would monitor the functioning of Vector by
looking for logs in Google Logging (Stackdriver), and not by trying to
infer Vector's state by using its own internal metrics. Since nothing
was going to be using these metrics, we just remove them to reduce the
load on Prometheus.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/655)
<!-- Reviewable:end -->
