### PR TITLE
Refinements to ndt-virtual DaemonSet

### DIFF
--- a/k8s/daemonsets/experiments/ndt-virtual.jsonnet
+++ b/k8s/daemonsets/experiments/ndt-virtual.jsonnet
@@ -51,6 +51,8 @@ exp.ExperimentNoIndex(expName, 'pusher-' + std.extVar('PROJECT_ID'), 'none', dat
               // port 3002 is arbitrary.
               '-ndt5_addr=127.0.0.1:3002',
               '-ndt5_ws_addr=:3001',
+              '-ndt5.token.required=true',
+              '-ndt7.token.required=true',
               '-uuid-prefix-file=' + exp.uuid.prefixfile,
               '-prometheusx.listen-address=127.0.0.1:9990',
               '-datadir=/var/spool/' + expName,
@@ -58,6 +60,7 @@ exp.ExperimentNoIndex(expName, 'pusher-' + std.extVar('PROJECT_ID'), 'none', dat
               '-cert=/certs/tls.crt',
               '-token.machine=$(NODE_NAME)',
               '-token.verify-key=/verify/jwk_sig_EdDSA_locate_20200409.pub',
+              '-txcontroller.device=ens4',
               '-txcontroller.max-rate=150000000',
               '-label=type=virtual',
               '-label=deployment=canary',

--- a/k8s/daemonsets/experiments/ndt-virtual.jsonnet
+++ b/k8s/daemonsets/experiments/ndt-virtual.jsonnet
@@ -18,7 +18,7 @@ local metadata = {
   },
 };
 
-exp.ExperimentNoIndex(expName, 'pusher-' + std.extVar('PROJECT_ID'), "none", datatypes, true) + {
+exp.ExperimentNoIndex(expName, 'pusher-' + std.extVar('PROJECT_ID'), 'none', datatypes, true) + {
   metadata+: {
     name: expName + '-virtual',
   },
@@ -31,7 +31,7 @@ exp.ExperimentNoIndex(expName, 'pusher-' + std.extVar('PROJECT_ID'), "none", dat
     template+: {
       metadata+: {
         annotations+: {
-          "secret.reloader.stakater.com/reload": "measurement-lab-org-tls",
+          'secret.reloader.stakater.com/reload': 'measurement-lab-org-tls',
         },
         labels+: {
           workload: expName + '-virtual',
@@ -48,18 +48,34 @@ exp.ExperimentNoIndex(expName, 'pusher-' + std.extVar('PROJECT_ID'), "none", dat
             name: 'ndt-server',
             image: 'measurementlab/ndt-server:' + exp.ndtVersion,
             args: [
+              // port 3002 is arbitrary.
+              '-ndt5_addr=127.0.0.1:3002',
+              '-ndt5_ws_addr=:3001',
               '-uuid-prefix-file=' + exp.uuid.prefixfile,
               '-prometheusx.listen-address=127.0.0.1:9990',
               '-datadir=/var/spool/' + expName,
               '-key=/certs/tls.key',
               '-cert=/certs/tls.crt',
+              '-token.machine=$(NODE_NAME)',
+              '-token.verify-key=/verify/jwk_sig_EdDSA_locate_20200409.pub',
               '-txcontroller.max-rate=150000000',
               '-label=type=virtual',
-              '-label=deployment=stable',
-              '-label=external-ip=@'+metadata.path+'/external-ip',
-              '-label=machine-type=@'+metadata.path+'/machine-type',
-              '-label=network-tier=@'+metadata.path+'/network-tier',
-              '-label=zone=@'+metadata.path+'/zone',
+              '-label=deployment=canary',
+              '-label=external-ip=@' + metadata.path + '/external-ip',
+              '-label=external-ipv6=@' + metadata.path + '/external-ipv6',
+              '-label=machine-type=@' + metadata.path + '/machine-type',
+              '-label=network-tier=@' + metadata.path + '/network-tier',
+              '-label=zone=@' + metadata.path + '/zone',
+            ],
+            env: [
+              {
+                name: 'NODE_NAME',
+                valueFrom: {
+                  fieldRef: {
+                    fieldPath: 'spec.nodeName',
+                  },
+                },
+              },
             ],
             volumeMounts: [
               {
@@ -67,10 +83,16 @@ exp.ExperimentNoIndex(expName, 'pusher-' + std.extVar('PROJECT_ID'), "none", dat
                 name: 'measurement-lab-org-tls',
                 readOnly: true,
               },
+              {
+                mountPath: '/verify',
+                name: 'locate-verify-keys',
+                readOnly: true,
+              },
               exp.uuid.volumemount,
               metadata.volumemount,
             ] + [
-              exp.VolumeMount(expName + '/' + d) for d in datatypes
+              exp.VolumeMount(expName + '/' + d)
+              for d in datatypes
             ],
             ports: [],
           },
@@ -82,6 +104,12 @@ exp.ExperimentNoIndex(expName, 'pusher-' + std.extVar('PROJECT_ID'), "none", dat
             name: 'measurement-lab-org-tls',
             secret: {
               secretName: 'measurement-lab-org-tls',
+            },
+          },
+          {
+            name: 'locate-verify-keys',
+            secret: {
+              secretName: 'locate-verify-keys',
             },
           },
           metadata.volume,

--- a/manage-cluster/add_ndt_virtual_site.sh
+++ b/manage-cluster/add_ndt_virtual_site.sh
@@ -12,6 +12,10 @@ PROJECT=${1:? Please specify a GCP project: ${USAGE}}
 CLOUD_SITE=${2:? Please specify a cloud site name: ${USAGE}}
 CLOUD_ZONE=${3:? Please specify the GCP zone for this VM: ${USAGE}}
 
+# List of GCP regions which support external IPv6 addresses for GCE VMs:
+# https://cloud.google.com/vpc/docs/vpc#ipv6-regions
+IPV6_REGIONS="asia-east1 asia-south1 europe-west2 us-west2"
+
 if [[ "${PROJECT}" == "mlab-sandbox" ]]; then
   SITE_REGEX="[a-z]{3}[0-9]t"
 else
@@ -60,6 +64,12 @@ else
       "${GCP_ARGS[@]}")
 fi
 
+if echo $IPV6_REGIONS | grep "${GCE_REGION}"; then
+  IPV6_FLAGS=("--stack-type=IPV4_IPV6" "--ipv6-access-type=EXTERNAL")
+else
+  export IPV6_FLAGS=""
+fi
+
 # If a subnet for the region of this VM doesn't already exist, then create it.
 EXISTING_SUBNET=$(gcloud compute networks subnets list \
     --filter "name=${GCE_K8S_SUBNET} AND region:( ${GCE_REGION} )" \
@@ -72,6 +82,7 @@ if [[ -z "${EXISTING_SUBNET}" ]]; then
       --network "${GCE_NETWORK}" \
       --range "10.${N}.0.0/16" \
       --region "${GCE_REGION}" \
+      ${IPV6_FLAGS[@]} \
       "${GCP_ARGS[@]}"
 fi
 

--- a/manage-cluster/add_ndt_virtual_site.sh
+++ b/manage-cluster/add_ndt_virtual_site.sh
@@ -9,13 +9,13 @@ set -euxo pipefail
 
 USAGE="USAGE: $0 <cloud-project> <cloud-site> <gce-zone>"
 PROJECT=${1:? Please specify a GCP project: ${USAGE}}
-CLOUD_SITE=${2:? Please specify a cloud site (ending in 'c'): ${USAGE}}
+CLOUD_SITE=${2:? Please specify a cloud site name: ${USAGE}}
 CLOUD_ZONE=${3:? Please specify the GCP zone for this VM: ${USAGE}}
 
 if [[ "${PROJECT}" == "mlab-sandbox" ]]; then
   SITE_REGEX="[a-z]{3}[0-9]t"
 else
-  SITE_REGEX="[a-z]{3}[0-9]c"
+  SITE_REGEX="[a-z]{3}[0-9]{2}"
 fi
 
 # Source configuration variables and bootstrap functions.


### PR DESCRIPTION
* Loads the access token verifier key into ndt-server
* Requires access tokens for both ndt5 and ndt7 protocols
* Effectively disables ndt5_raw by configuring the server to listen on the loopback
* Sets the proper interface name for the txcontroller. This is possibly not ideal in that now all virtual nodes will need to have the primary network interface named "ens4". However, this is a stopgap measure until we can figure out how to plumb through a varible. For now, all GCE platform nodes have this as the interface name.
* vscode apparently made a few automatic changes, like replacing double quotes with single quotes.
* Removes the requirement for virtual site names to end in "c".
* Allows creation of dual stack VPC subnets

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/658)
<!-- Reviewable:end -->
