### PR TITLE
Improves script for uprading k8s on virtual nodes

### DIFF
--- a/manage-cluster/upgrade_k8s_virtual_nodes.sh
+++ b/manage-cluster/upgrade_k8s_virtual_nodes.sh
@@ -37,16 +37,15 @@ NODES=$(
       --template '{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}'
 )
 
+UPGRADE_NODES=""
 for node in $NODES; do
-  UPGRADE_NODES=""
   CURRENT_VERSION=$(
     kubectl get node $node -o jsonpath='{.status.nodeInfo.kubeletVersion}{"\n"}'
   )
-  lowest_version=$(
-    echo -e "${CURRENT_VERSION}\n${K8S_VERSION}" | sort --version-sort | head --lines 1
-  )
-
-  if [[ $lowest_version == $CURRENT_VERSION ]]; then
+  # If the node is already at the right version, then continue.
+  if [[ $CURRENT_VERSION == $K8S_VERSION ]]; then
+    continue
+  else
     UPGRADE_NODES="${UPGRADE_NODES} ${node}"
   fi
 done


### PR DESCRIPTION
The script previously assumed that all VMs needed to be upgraded. This
commits adds logic that will skip nodes that are already at the right
version.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/659)
<!-- Reviewable:end -->
