### PR TITLE
Updates kube-rbac-proxy to v0.11.0

### DIFF
--- a/k8s/daemonsets/core/node-exporter.jsonnet
+++ b/k8s/daemonsets/core/node-exporter.jsonnet
@@ -108,7 +108,7 @@
                 },
               },
             ],
-            image: 'quay.io/coreos/kube-rbac-proxy:v0.4.1',
+            image: 'quay.io/brancz/kube-rbac-proxy:v0.11.0',
             name: 'kube-rbac-proxy',
             ports: [
               {

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -63,7 +63,7 @@ local VolumeMount(name) = {
 
 local RBACProxy(name, port) = {
   name: 'kube-rbac-proxy-' + name,
-  image: 'quay.io/coreos/kube-rbac-proxy:v0.4.1',
+  image: 'quay.io/brancz/kube-rbac-proxy:v0.11.0',
   args: [
     '--logtostderr',
     '--secure-listen-address=$(IP):' + port,


### PR DESCRIPTION
Also updates the registry path, as the "coreos" quay.io repo was no
longer receiving updates since v0.5.0.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/663)
<!-- Reviewable:end -->
