### PR TITLE
Adds secondary nameserver to experiment DaemonSet configs

### DIFF
--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -457,7 +457,7 @@ local Experiment(name, index, bucket, anonMode, datatypes=[]) = ExperimentNoInde
         // kubernetes Services iptables rules.
         dnsPolicy: 'None',
         dnsConfig: {
-          nameservers: ['8.8.8.8'],
+          nameservers: ['8.8.8.8', '8.8.4.4'],
         },
         // Only enable extended grace period where production traffic is possible.
         [if std.extVar('PROJECT_ID') != 'mlab-sandbox' then 'terminationGracePeriodSeconds']: terminationGracePeriodSeconds,


### PR DESCRIPTION
For some reason our default experiment config only adds a single upstream DNS server for name resolution. This small PR adds Google's secondary public nameserver to the list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/664)
<!-- Reviewable:end -->
