### PR TITLE
Removes alert for Vector DaemonSet, and replaces it with a Fluentbit one

### DIFF
--- a/config/fluentbit/values.yaml.template
+++ b/config/fluentbit/values.yaml.template
@@ -127,4 +127,6 @@ initContainers:
 podAnnotations:
   prometheus.io/scrape: true
   prometheus.io/scheme: http
+  prometheus.io/metrics_path: /api/v1/metrics/prometheus
+
 

--- a/config/fluentbit/values.yaml.template
+++ b/config/fluentbit/values.yaml.template
@@ -125,7 +125,7 @@ initContainers:
   - name: fluent-bit-etc
     mountPath: /fluent-bit/etc
 podAnnotations:
-  prometheus.io/scrape: true
+  prometheus.io/scrape: "true"
   prometheus.io/scheme: http
   prometheus.io/metrics_path: /api/v1/metrics/prometheus
 

--- a/config/fluentbit/values.yaml.template
+++ b/config/fluentbit/values.yaml.template
@@ -124,4 +124,7 @@ initContainers:
   volumeMounts:
   - name: fluent-bit-etc
     mountPath: /fluent-bit/etc
+podAnnotations:
+  prometheus.io/scrape: true
+  prometheus.io/scheme: http
 

--- a/config/prometheus/alerts.yml
+++ b/config/prometheus/alerts.yml
@@ -51,22 +51,17 @@ groups:
         the DaemonSet is healthy (`kubectl describe ds cadvisor`).
       dashboard: https://grafana.mlab-staging.measurementlab.net/d/tZHLFQRZk/k8s-workload-overview
 
-  # NOTE: this alert is currently structured a bit differently than the other
-  # "DaemonSet Missing" alerts because Vector does not currently expose any
-  # metrics and cannot be auto-discovered by Prometheus as part of the
-  # kubernetes-pods job. Therefore, in this one case we use one known metric
-  # that is valid for Vector to determine if metrics are missing or not.
-  - alert: PlatformCluster_VectorMissing
-    expr: absent(kube_daemonset_status_desired_number_scheduled{daemonset="vector"})
+  - alert: PlatformCluster_FluentbitMissing
+    expr: absent(up{deployment="fluent-bit"})
     for: 15m
     labels:
       repo: ops-tracker
       severity: ticket
       cluster: platform
     annotations:
-      summary: The Vector DaemonSet is missing or has no metrics.
-      description: The Vector DaemonSet is missing or has no metrics. Verify that
-        the DaemonSet is healthy (`kubectl describe ds vector`).
+      summary: The Fluentbit DaemonSet is missing or has no metrics.
+      description: The Fluentbit DaemonSet is missing or has no metrics. Verify
+        that the DaemonSet is healthy (`kubectl describe ds fluent-bit`).
       dashboard: https://grafana.mlab-oti.measurementlab.net/d/tZHLFQRZk/k8s-workload-overview
 
   - alert: PlatformCluster_NdtMissing

--- a/config/prometheus/prometheus.yml
+++ b/config/prometheus/prometheus.yml
@@ -114,6 +114,13 @@ scrape_configs:
         action: keep
         regex: true
 
+      # If a custom metrics path was specified in an annotation, use it instead
+      # of the default /metrics.
+      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_metric_path]
+        action: replace
+        target_label: __metrics_path__
+        regex: (.+)
+
       # Only keep containers that have a declared container port.
       - source_labels: [__meta_kubernetes_pod_container_port_number]
         action: keep

--- a/config/prometheus/prometheus.yml
+++ b/config/prometheus/prometheus.yml
@@ -119,6 +119,7 @@ scrape_configs:
       - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_metrics_path]
         regex: (.+)
         target_label: __metrics_path__
+        action: replace
         replacement: ${1}
 
       # Only keep containers that have a declared container port.

--- a/config/prometheus/prometheus.yml
+++ b/config/prometheus/prometheus.yml
@@ -116,10 +116,10 @@ scrape_configs:
 
       # If a custom metrics path was specified in an annotation, use it instead
       # of the default /metrics.
-      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_metric_path]
-        action: replace
-        target_label: __metrics_path__
+      - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_metrics_path]
         regex: (.+)
+        target_label: __metrics_path__
+        replacement: ${1}
 
       # Only keep containers that have a declared container port.
       - source_labels: [__meta_kubernetes_pod_container_port_number]


### PR DESCRIPTION
We lately moved from vector to fluent-bit. This PR replaces the old Vector alert with one appropriate for fluent-bit. A nice thing is that fluent-bit exports a reasonable number of useful metrics (whereas Vector exported a massive, overwhelming amount of metrics, such that we even turned off metrics). Our new fluent-bit alerts looks just like all other DaemonSet alerts.

Additionally, the PR includes the changes to allow Prometheus to auto discover the fluent-bit pods and scrape them.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/667)
<!-- Reviewable:end -->
