### PR TITLE
Handle nodeinfo differently in PusherDailyVolume alert

### DIFF
--- a/config/prometheus/alerts.yml
+++ b/config/prometheus/alerts.yml
@@ -513,7 +513,7 @@ groups:
 
   - alert: PlatformCluster_PusherDailyDataVolumeTooLow
     expr: |
-      datatype:pusher_bytes_per_tarfile:increase24h
+      datatype:pusher_bytes_per_tarfile:increase24h{datatype!="nodeinfo"}
         < (0.7 * quantile by(datatype)(0.5,
           label_replace(datatype:pusher_bytes_per_tarfile:increase24h offset 1d, "delay", "1d", "", ".*") or
           label_replace(datatype:pusher_bytes_per_tarfile:increase24h offset 3d, "delay", "3d", "", ".*") or
@@ -541,6 +541,21 @@ groups:
       summary: Test data volume today is less than 70% of nominal daily volume.
       description: Are machines online? Is data being collected? Is pusher working?
         Is mlab-ns working? A new rollout?
+      dashboard: https://grafana.mlab-oti.measurementlab.net/d/WnaxPZJZz
+
+  - alert: PlatformCluster_PusherDailyDataVolumeTooLow_NodeinfoMissing
+    expr: |
+      datatype:pusher_bytes_per_tarfile:increase24h{datatype="nodeinfo"} == 0 OR
+        absent(datatype:pusher_bytes_per_tarfile:increase24h{datatype="nodeinfo"})
+    for: 2h
+    labels:
+      repo: dev-tracker
+      severity: ticket
+      cluster: platform
+    annotations:
+      summary: Test data volume for nodeinfo is either missing or dropped to zero.
+      description: Are machines online? Is data being collected? Is pusher working?
+        A new rollout?
       dashboard: https://grafana.mlab-oti.measurementlab.net/d/WnaxPZJZz
 
 # PusherSLO

--- a/config/prometheus/alerts.yml
+++ b/config/prometheus/alerts.yml
@@ -513,7 +513,7 @@ groups:
 
   - alert: PlatformCluster_PusherDailyDataVolumeTooLow
     expr: |
-      datatype:pusher_bytes_per_tarfile:increase24h{datatype!="nodeinfo"}
+      datatype:pusher_bytes_per_tarfile:increase24h{datatype!~"biosversion|chassisserial|ipaddress|iproute4|iproute6|lshw|lspci|lsusb|osrelease|uname"}
         < (0.7 * quantile by(datatype)(0.5,
           label_replace(datatype:pusher_bytes_per_tarfile:increase24h offset 1d, "delay", "1d", "", ".*") or
           label_replace(datatype:pusher_bytes_per_tarfile:increase24h offset 3d, "delay", "3d", "", ".*") or
@@ -545,8 +545,8 @@ groups:
 
   - alert: PlatformCluster_PusherDailyDataVolumeTooLow_NodeinfoMissing
     expr: |
-      datatype:pusher_bytes_per_tarfile:increase24h{datatype="nodeinfo"} == 0 OR
-        absent(datatype:pusher_bytes_per_tarfile:increase24h{datatype="nodeinfo"})
+      datatype:pusher_bytes_per_tarfile:increase24h{datatype=~"biosversion|chassisserial|ipaddress|iproute4|iproute6|lshw|lspci|lsusb|osrelease|uname"} == 0 OR
+        absent(datatype:pusher_bytes_per_tarfile:increase24h{datatype=~"biosversion|chassisserial|ipaddress|iproute4|iproute6|lshw|lspci|lsusb|osrelease|uname"})
     for: 2h
     labels:
       repo: dev-tracker


### PR DESCRIPTION
This change removes "nodeinfo" datatype from the standard `PlatformCluster_PusherDailyDataVolumeTooLow` alert due to its history of irregular data volume - See: https://github.com/m-lab/dev-tracker/issues/689

This change additionally adds a new alert to check that the nodeinfo data type is still present and greater than zero. This tries to balance making sure the system is minimally working without prescribing any particular volume threshold for this datatype.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/669)
<!-- Reviewable:end -->
