### PR TITLE
Sets the default flush value to 15s for fluent-bit

### DIFF
--- a/config/fluentbit/values.yaml.template
+++ b/config/fluentbit/values.yaml.template
@@ -90,6 +90,7 @@ extraVolumeMounts:
   readOnly: true
 - name: fluent-bit-etc
   mountPath: /fluent-bit/etc
+flush: 15
 image:
   repository: fluent/fluent-bit
   tag: {{K8S_FLUENTBIT_VERSION}}


### PR DESCRIPTION
See: https://github.com/m-lab/ops-tracker/issues/1561

The default flush value is 1s. We are beginning to run up against GCP
quotas and limits with regards to requests per minute to the logging
API. Hopefully this change will cause fluent-bit to flush local data to
the Stackdriver output less frequently, causing us to not hit quotas and
limits.