### PR TITLE
Adds explicit pod label for site type

### DIFF
--- a/k8s/daemonsets/experiments/ndt-virtual.jsonnet
+++ b/k8s/daemonsets/experiments/ndt-virtual.jsonnet
@@ -35,6 +35,7 @@ exp.ExperimentNoIndex(expName, 'pusher-' + std.extVar('PROJECT_ID'), 'none', dat
         },
         labels+: {
           workload: expName + '-virtual',
+          measurementlab.net/type: 'virtual',
         },
       },
       spec+: {

--- a/k8s/daemonsets/experiments/ndt-virtual.jsonnet
+++ b/k8s/daemonsets/experiments/ndt-virtual.jsonnet
@@ -35,7 +35,7 @@ exp.ExperimentNoIndex(expName, 'pusher-' + std.extVar('PROJECT_ID'), 'none', dat
         },
         labels+: {
           workload: expName + '-virtual',
-          measurementlab.net/type: 'virtual',
+          'measurementlab.net/type': 'virtual',
         },
       },
       spec+: {

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -392,6 +392,7 @@ local ExperimentNoIndex(name, bucket, anonMode, datatypes, hostNetwork) = {
         },
         labels: {
           workload: name,
+          measurementlab.net/type: 'physical',
         },
       },
       spec: {

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -392,7 +392,7 @@ local ExperimentNoIndex(name, bucket, anonMode, datatypes, hostNetwork) = {
         },
         labels: {
           workload: name,
-          measurementlab.net/type: 'physical',
+          'measurementlab.net/type': 'physical',
         },
       },
       spec: {


### PR DESCRIPTION
We have a need to be able to segregate metrics between experiment pods running in physical and virtual environments. This PR adds an explicit `measurementlab.net/type` label to all experiment pods. By default the value is "physical", but the ndt-virtual DaemonSet sets this label to "virtual". This [label value should propagate](https://github.com/m-lab/k8s-support/blob/master/config/prometheus/prometheus.yml#L130) to all experiment pod metrics. We can then use this metric label to separate metrics running on physical hardware from ones running in virtual environments.

On nodes, the equivalent label is currently `mlab/type`. In this case, I chose `measurementlab.net/type` because [the official k8s documentation on labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set) states:

> The prefix is optional. If specified, the prefix must be a DNS subdomain: a series of DNS labels separated by dots

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/673)
<!-- Reviewable:end -->
