### PR TITLE
Adds new alert for when node is unschedulable

### DIFF
--- a/config/prometheus/alerts.yml
+++ b/config/prometheus/alerts.yml
@@ -305,6 +305,32 @@ groups:
         Perhaps an API server node was incorrectly upgraded _not_ using the
         ugprade script and not all components got updated?
 
+  # If any node is unschedulable for too long, fire an alert, unless the node
+  # is in lame-duck mode or GMX maintenance mode. We give the condition 1d
+  # before firing the alert because a node can get into an unschedulable state
+  # by being flagged for reboot, and the reboot not working as expected. Often
+  # this state will resolve itself, or Rebot will reboot the node resolving the
+  # state. On the other hand, it occasionally happens that a node fails to
+  # reboot properly in a timely fashion (4h) and Kured abandons the node and
+  # moves on to the next node, while leaving the node cordoned. When the node
+  # eventually comes back up, it is unschedulable until an operator uncordons
+  # it.
+  - alert: PlatformCluster_NodeUnschedulableForTooLong
+    expr: |
+      kube_node_spec_unschedulable == 1 unless on(node) (
+        kube_node_spec_taint{key="lame-duck"} or
+        gmx_machine_maintenance == 1
+      )
+    for: 1d
+    labels:
+      repo: ops-tracker
+      severity: ticket
+      cluster: platform
+    annotations:
+      summary: A node has been in an unschedulable state for too long.
+      description: https://github.com/m-lab/ops-tracker/wiki/Alerts-&-Troubleshooting#platformcluster_nodeunschedulablefortoolong
+      dashboard: https://grafana.mlab-staging.measurementlab.net/d/rJ7z2Suik/k8s-site-overview
+
   # If any pod is down or otherwise broken, fire an alert, unless the node is
   # in lame-duck mode, the node is NotReady, GMX maintenance mode, or the
   # scrape job for the entire node is down.


### PR DESCRIPTION
When a node is unschedulale for too long, fires an alert. This often happens when a node is flagged for reboot using Kured, and the node fails to come back up after 4h (the configured limit within Kured). When this happens, Kured moves on to the next node, leaving the other node in a cordoned state. Currently, we have no automated way of detecting this. I usually incidentally notice it and resolve the issue manually. This PR adds a new alert to warn us of this condition so that someone can manually intervene. I'm slightly concerned that this will be a noisy alert. We can wait and see and make adjustments as necessary.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/674)
<!-- Reviewable:end -->
