### PR TITLE
Updates cAdvisor container image to v0.39.3

### DIFF
--- a/k8s/daemonsets/core/cadvisor.jsonnet
+++ b/k8s/daemonsets/core/cadvisor.jsonnet
@@ -31,7 +31,7 @@
               // Only show stats for docker containers.
               '--docker_only',
             ],
-            image: 'k8s.gcr.io/cadvisor:v0.34.0',
+            image: 'gcr.io/cadvisor/cadvisor:v0.39.3'
             name: 'cadvisor',
             ports: [
               {

--- a/k8s/daemonsets/core/cadvisor.jsonnet
+++ b/k8s/daemonsets/core/cadvisor.jsonnet
@@ -31,7 +31,7 @@
               // Only show stats for docker containers.
               '--docker_only',
             ],
-            image: 'gcr.io/cadvisor/cadvisor:v0.39.3'
+            image: 'gcr.io/cadvisor/cadvisor:v0.39.3',
             name: 'cadvisor',
             ports: [
               {


### PR DESCRIPTION
This is just part of the general push to keep our container images more up-to-date. It seems to be running okay in sandbox, so far, and changelogs from our old version to this don't indicate any breaking changes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/675)
<!-- Reviewable:end -->
