### PR TITLE
Changes measurementlab.net/type label to site-type

### DIFF
--- a/k8s/daemonsets/experiments/ndt-virtual.jsonnet
+++ b/k8s/daemonsets/experiments/ndt-virtual.jsonnet
@@ -35,7 +35,7 @@ exp.ExperimentNoIndex(expName, 'pusher-' + std.extVar('PROJECT_ID'), 'none', dat
         },
         labels+: {
           workload: expName + '-virtual',
-          site-type: 'virtual',
+          'site-type': 'virtual',
         },
       },
       spec+: {

--- a/k8s/daemonsets/experiments/ndt-virtual.jsonnet
+++ b/k8s/daemonsets/experiments/ndt-virtual.jsonnet
@@ -35,7 +35,7 @@ exp.ExperimentNoIndex(expName, 'pusher-' + std.extVar('PROJECT_ID'), 'none', dat
         },
         labels+: {
           workload: expName + '-virtual',
-          'measurementlab.net/type': 'virtual',
+          site-type': 'virtual',
         },
       },
       spec+: {

--- a/k8s/daemonsets/experiments/ndt-virtual.jsonnet
+++ b/k8s/daemonsets/experiments/ndt-virtual.jsonnet
@@ -35,7 +35,7 @@ exp.ExperimentNoIndex(expName, 'pusher-' + std.extVar('PROJECT_ID'), 'none', dat
         },
         labels+: {
           workload: expName + '-virtual',
-          site-type': 'virtual',
+          site-type: 'virtual',
         },
       },
       spec+: {

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -392,7 +392,7 @@ local ExperimentNoIndex(name, bucket, anonMode, datatypes, hostNetwork) = {
         },
         labels: {
           workload: name,
-          'measurementlab.net/type': 'physical',
+          site-type: 'physical',
         },
       },
       spec: {

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -392,7 +392,7 @@ local ExperimentNoIndex(name, bucket, anonMode, datatypes, hostNetwork) = {
         },
         labels: {
           workload: name,
-          site-type: 'physical',
+          'site-type': 'physical',
         },
       },
       spec: {


### PR DESCRIPTION
We decided that the label prefix wasn't necessary, and that "type" was too generic. `site-type` is a nice high-level label describing whether a site is physical or virtual, and does not collide with any lower level machine or pod attributes with similar names.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/676)
<!-- Reviewable:end -->
