### PR TITLE
Bumps prometheus VM machine-type to e2-highmem-16

### DIFF
--- a/manage-cluster/bootstrap_prometheus.sh
+++ b/manage-cluster/bootstrap_prometheus.sh
@@ -41,7 +41,7 @@ case $PROJECT in
     DISK_SIZE="200GB"
     ;;
   mlab-staging)
-    MACHINE_TYPE="e2-highmem-8"
+    MACHINE_TYPE="e2-highmem-16"
     DISK_SIZE="1500GB"
     ;;
   mlab-oti)


### PR DESCRIPTION
The machine was running out of memory with the old e2-highmem-8
machine-type (64GB memory). Memory usage is right around 64GB, so giving
it an additional 64 (128GB) should give it plenty of room to grow for
the foreseeable future.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/677)
<!-- Reviewable:end -->
