### PR TITLE
Add aimscore proof of concept

### DIFF
--- a/k8s/daemonsets/core/host.jsonnet
+++ b/k8s/daemonsets/core/host.jsonnet
@@ -9,8 +9,42 @@ local nodeinfo_datatypes = [d.Datatype for d in nodeinfoconfig];
 exp.ExperimentNoIndex(expName, 'pusher-' + std.extVar('PROJECT_ID'), "none", nodeinfo_datatypes, true) + {
   spec+: {
     template+: {
+      metadata+: {
+        annotations+: {
+          'secret.reloader.stakater.com/reload': 'measurement-lab-org-tls',
+        },
+      },
       spec+: {
         containers+: [
+          {
+            args: [
+              '-base-port=443',
+              '-public-name=$(MLAB_NODE_NAME)',
+              '-domain=$(MLAB_NODE_NAME)',
+              '-cert-file=/certs/tls.crt',
+              '-key-file=/certs/tls.key',
+              '-listen-addr=0.0.0.0',
+            ],
+            env: [
+              {
+                name: 'MLAB_NODE_NAME',
+                valueFrom: {
+                  fieldRef: {
+                    fieldPath: 'spec.nodeName',
+                  },
+                },
+              },
+            ],
+            image: 'soltesz/aimscore-server:v0.0',
+            name: 'aimscore-server',
+            volumeMounts: [
+              {
+                mountPath: '/certs',
+                name: 'measurement-lab-org-tls',
+                readOnly: true,
+              },
+            ],
+          },
           {
             name: 'nodeinfo',
             image: 'measurementlab/nodeinfo:v1.2.1',
@@ -40,6 +74,12 @@ exp.ExperimentNoIndex(expName, 'pusher-' + std.extVar('PROJECT_ID'), "none", nod
         hostPID: true,
         [if std.extVar('PROJECT_ID') != 'mlab-sandbox' then 'terminationGracePeriodSeconds']: 180,
         volumes+: [
+          {
+            name: 'measurement-lab-org-tls',
+            secret: {
+              secretName: 'measurement-lab-org-tls',
+            },
+          },
           {
             configMap: {
               name: nodeinfoConfig.metadata.name,

--- a/k8s/daemonsets/core/host.jsonnet
+++ b/k8s/daemonsets/core/host.jsonnet
@@ -9,42 +9,8 @@ local nodeinfo_datatypes = [d.Datatype for d in nodeinfoconfig];
 exp.ExperimentNoIndex(expName, 'pusher-' + std.extVar('PROJECT_ID'), "none", nodeinfo_datatypes, true) + {
   spec+: {
     template+: {
-      metadata+: {
-        annotations+: {
-          'secret.reloader.stakater.com/reload': 'measurement-lab-org-tls',
-        },
-      },
       spec+: {
         containers+: [
-          {
-            args: [
-              '-base-port=443',
-              '-public-name=$(MLAB_NODE_NAME)',
-              '-domain=$(MLAB_NODE_NAME)',
-              '-cert-file=/certs/tls.crt',
-              '-key-file=/certs/tls.key',
-              '-listen-addr=0.0.0.0',
-            ],
-            env: [
-              {
-                name: 'MLAB_NODE_NAME',
-                valueFrom: {
-                  fieldRef: {
-                    fieldPath: 'spec.nodeName',
-                  },
-                },
-              },
-            ],
-            image: 'soltesz/aimscore-server:v0.0',
-            name: 'aimscore-server',
-            volumeMounts: [
-              {
-                mountPath: '/certs',
-                name: 'measurement-lab-org-tls',
-                readOnly: true,
-              },
-            ],
-          },
           {
             name: 'nodeinfo',
             image: 'measurementlab/nodeinfo:v1.2.1',
@@ -74,12 +40,6 @@ exp.ExperimentNoIndex(expName, 'pusher-' + std.extVar('PROJECT_ID'), "none", nod
         hostPID: true,
         [if std.extVar('PROJECT_ID') != 'mlab-sandbox' then 'terminationGracePeriodSeconds']: 180,
         volumes+: [
-          {
-            name: 'measurement-lab-org-tls',
-            secret: {
-              secretName: 'measurement-lab-org-tls',
-            },
-          },
           {
             configMap: {
               name: nodeinfoConfig.metadata.name,

--- a/k8s/daemonsets/experiments/responsiveness.jsonnet
+++ b/k8s/daemonsets/experiments/responsiveness.jsonnet
@@ -10,7 +10,10 @@ exp.ExperimentNoIndex(expName, 'pusher-' + std.extVar('PROJECT_ID'), "none", [],
         },
       },
       spec+: {
-        containers+: [
+        // NOTE: we override the containers to include only those named below.
+        // Once this service has a dedicated experiment index assigned, we should
+        // update the config to use all sidecar services.
+        containers: [
           {
             args: [
               '-base-port=443',

--- a/k8s/daemonsets/experiments/responsiveness.jsonnet
+++ b/k8s/daemonsets/experiments/responsiveness.jsonnet
@@ -44,8 +44,9 @@ exp.ExperimentNoIndex(expName, 'pusher-' + std.extVar('PROJECT_ID'), "none", [],
             ],
           },
         ],
+        // Use host network to listen on the machine IP address without
+        // registering an experiment index yet.
         hostNetwork: true,
-        hostPID: true,
         volumes+: [
           {
             name: 'measurement-lab-org-tls',

--- a/k8s/daemonsets/experiments/responsiveness.jsonnet
+++ b/k8s/daemonsets/experiments/responsiveness.jsonnet
@@ -1,0 +1,57 @@
+local exp = import '../templates.jsonnet';
+local expName = 'responsiveness';
+
+exp.ExperimentNoIndex(expName, 'pusher-' + std.extVar('PROJECT_ID'), "none", [], true) + {
+  spec+: {
+    template+: {
+      metadata+: {
+        annotations+: {
+          'secret.reloader.stakater.com/reload': 'measurement-lab-org-tls',
+        },
+      },
+      spec+: {
+        containers+: [
+          {
+            args: [
+              '-base-port=443',
+              '-public-name=$(MLAB_NODE_NAME)',
+              '-domain=$(MLAB_NODE_NAME)',
+              '-cert-file=/certs/tls.crt',
+              '-key-file=/certs/tls.key',
+              '-listen-addr=0.0.0.0',
+            ],
+            env: [
+              {
+                name: 'MLAB_NODE_NAME',
+                valueFrom: {
+                  fieldRef: {
+                    fieldPath: 'spec.nodeName',
+                  },
+                },
+              },
+            ],
+            image: 'soltesz/responsiveness-server:v0.0',
+            name: 'responsiveness-server',
+            volumeMounts: [
+              {
+                mountPath: '/certs',
+                name: 'measurement-lab-org-tls',
+                readOnly: true,
+              },
+            ],
+          },
+        ],
+        hostNetwork: true,
+        hostPID: true,
+        volumes+: [
+          {
+            name: 'measurement-lab-org-tls',
+            secret: {
+              secretName: 'measurement-lab-org-tls',
+            },
+          },
+        ],
+      },
+    },
+  },
+}

--- a/system.jsonnet
+++ b/system.jsonnet
@@ -24,6 +24,9 @@
     import 'k8s/daemonsets/experiments/ndt-osupgrade.jsonnet',
     import 'k8s/daemonsets/experiments/neubot.jsonnet',
     import 'k8s/daemonsets/experiments/revtr.jsonnet',
+  ] + if std.extVar('PROJECT_ID') == 'mlab-sandbox' then [
+    import 'k8s/daemonsets/experiments/responsiveness.jsonnet',
+  ] else [] + [
     import 'k8s/daemonsets/experiments/wehe.jsonnet',
     // Deployments
     import 'k8s/deployments/kube-state-metrics.jsonnet',


### PR DESCRIPTION
This change includes a proof of concept responsiveness AimScore server. The server is built from the reference server https://github.com/network-quality/server/tree/main/go in a [custom Dockerfile](https://github.com/stephen-soltesz/server/blob/main/Dockerfile) & image. The server uses our standard measurement lab TLS certificates. The server runs in the host context without sidecar services until it supports archiving information and we allocate an experiment index for this service in siteinfo.

The client https://github.com/network-quality/goresponsiveness may target the sandbox servers with this service using:

```
$ go run ./networkQuality.go -config mlab4-lga1t.mlab-sandbox.measurement-lab.org -port 443
```



<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/679)
<!-- Reviewable:end -->
