### PR TITLE
Fixes reboot-node.sh to not hang waiting for input

### DIFF
--- a/manage-cluster/cloud-config_master.yml
+++ b/manage-cluster/cloud-config_master.yml
@@ -265,7 +265,7 @@ write_files:
       exit 1
     fi
     # While we are at it, update all system packages.
-    apt full-upgrade --yes
+    DEBIAN_FRONTEND=noninteractive apt full-upgrade --yes
     echo "Reboot day ${REBOOT_DAY} equals today: ${TODAY}. Rebooting node."
     /sbin/reboot
 


### PR DESCRIPTION
https://github.com/m-lab/k8s-support/issues/681

This will fix future deployments of API nodes, but for existing nodes I'll have to fix them by hand.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/682)
<!-- Reviewable:end -->
