### PR TITLE
Update responsiveness server proof of concept

### DIFF
--- a/k8s/daemonsets/experiments/responsiveness.jsonnet
+++ b/k8s/daemonsets/experiments/responsiveness.jsonnet
@@ -36,7 +36,9 @@ exp.ExperimentNoIndex(expName, 'pusher-' + std.extVar('PROJECT_ID'), "none", [],
             ],
             image: 'soltesz/responsiveness-server:v0.1',
             name: 'responsiveness-server',
-            command: '/server/networkqualityd',
+            command: [
+              '/server/networkqualityd',
+            ],
             volumeMounts: [
               {
                 mountPath: '/certs',

--- a/k8s/daemonsets/experiments/responsiveness.jsonnet
+++ b/k8s/daemonsets/experiments/responsiveness.jsonnet
@@ -36,7 +36,7 @@ exp.ExperimentNoIndex(expName, 'pusher-' + std.extVar('PROJECT_ID'), "none", [],
             ],
             image: 'soltesz/responsiveness-server:v0.1',
             name: 'responsiveness-server',
-            entrypoint: '/server/networkqualityd',
+            command: '/server/networkqualityd',
             volumeMounts: [
               {
                 mountPath: '/certs',

--- a/k8s/daemonsets/experiments/responsiveness.jsonnet
+++ b/k8s/daemonsets/experiments/responsiveness.jsonnet
@@ -16,9 +16,10 @@ exp.ExperimentNoIndex(expName, 'pusher-' + std.extVar('PROJECT_ID'), "none", [],
         containers: [
           {
             args: [
-              '-base-port=443',
+              '-config-port=443',
+              '-config-name=$(MLAB_NODE_NAME)',
+              '-public-port=443',
               '-public-name=$(MLAB_NODE_NAME)',
-              '-domain=$(MLAB_NODE_NAME)',
               '-cert-file=/certs/tls.crt',
               '-key-file=/certs/tls.key',
               '-listen-addr=0.0.0.0',
@@ -33,8 +34,9 @@ exp.ExperimentNoIndex(expName, 'pusher-' + std.extVar('PROJECT_ID'), "none", [],
                 },
               },
             ],
-            image: 'soltesz/responsiveness-server:v0.0',
+            image: 'soltesz/responsiveness-server:v0.1',
             name: 'responsiveness-server',
+            entrypoint: '/server/networkqualityd',
             volumeMounts: [
               {
                 mountPath: '/certs',


### PR DESCRIPTION
The network-quality/server recently added an upstream Dockerfile - https://github.com/network-quality/server/pull/14

This change updates the built image to use the result of building that Dockerfile.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/685)
<!-- Reviewable:end -->
