### PR TITLE
Fixes a bug in system.jsonnet

### DIFF
--- a/k8s/deployments/kube-state-metrics.jsonnet
+++ b/k8s/deployments/kube-state-metrics.jsonnet
@@ -29,7 +29,7 @@
           {
             args: [
               '--resources=daemonsets,deployments,nodes,pods,resourcequotas,services',
-              '--metric-labels-allowlist=nodes=[mlab/type]',
+              '--metric-labels-allowlist=nodes=[mlab/type],pods=[site-type]',
             ],
             image: 'k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.4',
             name: 'kube-state-metrics',

--- a/k8s/deployments/kube-state-metrics.jsonnet
+++ b/k8s/deployments/kube-state-metrics.jsonnet
@@ -29,7 +29,7 @@
           {
             args: [
               '--resources=daemonsets,deployments,nodes,pods,resourcequotas,services',
-              '--metric-labels-allowlist=nodes=[mlab/type],pods=[site-type]',
+              '--metric-labels-allowlist=nodes=[mlab/type]',
             ],
             image: 'k8s.gcr.io/kube-state-metrics/kube-state-metrics:v2.2.4',
             name: 'kube-state-metrics',

--- a/system.jsonnet
+++ b/system.jsonnet
@@ -23,9 +23,11 @@
     import 'k8s/daemonsets/experiments/ndt-canary.jsonnet',
     import 'k8s/daemonsets/experiments/neubot.jsonnet',
     import 'k8s/daemonsets/experiments/revtr.jsonnet',
-  ] + if std.extVar('PROJECT_ID') == 'mlab-sandbox' then [
-    import 'k8s/daemonsets/experiments/responsiveness.jsonnet',
-  ] else [] + [
+  ] + (
+    if std.extVar('PROJECT_ID') == 'mlab-sandbox' then [
+      import 'k8s/daemonsets/experiments/responsiveness.jsonnet',
+    ] else []
+  ) + [
     import 'k8s/daemonsets/experiments/wehe.jsonnet',
     // Deployments
     import 'k8s/deployments/kube-state-metrics.jsonnet',


### PR DESCRIPTION
PR #679 introduced a change in system.jsonnet which didn't produce any noticeable error, but which caused jsonnet to stop evaluating the file after the conditional which pinned the responsiveness server experiment to mlab-sandbox. I don't know enough about the jsonnet language spec to know why putting the conditional in parentheses resolves the issue, but it seems to.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/686)
<!-- Reviewable:end -->
