### PR TITLE
Adds a POD_NAME env variable to uuid initContainer

### DIFF
--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -30,6 +30,11 @@ local uuid = {
     args: [
       '-filename=' + uuid.prefixfile,
     ],
+    env:
+    - name: POD_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.name
     volumeMounts: [
       uuid.volumemount {
         readOnly: false,

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -26,7 +26,7 @@ local uuid = {
     // more on this, see DESIGN.md
     // https://github.com/m-lab/uuid/
     name: 'set-up-uuid-prefix-file',
-    image: 'measurementlab/uuid:v0.1',
+    image: 'measurementlab/uuid:v1.0.0',
     args: [
       '-filename=' + uuid.prefixfile,
     ],

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -30,11 +30,16 @@ local uuid = {
     args: [
       '-filename=' + uuid.prefixfile,
     ],
-    env:
-    - name: POD_NAME
-      valueFrom:
-        fieldRef:
-          fieldPath: metadata.name
+    env: [
+      {
+        name: 'POD_NAME',
+        valueFrom: {
+          fieldRef: {
+            fieldPath: 'metadata.name',
+          },
+        },
+      },
+    ],
     volumeMounts: [
       uuid.volumemount {
         readOnly: false,


### PR DESCRIPTION
Issue #687 has details for the impetus behind this PR. This PR sets an environment variable named `POD_NAME`, set to the name of the pod, in the "set-up-uuid-prefix-file" initContainer of experiments. The uuid container will use the value of the new environment variable to set the prefix of the generated UUID.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/688)
<!-- Reviewable:end -->
