### PR TITLE
Add heartbeat api key as a secret

### DIFF
--- a/manage-cluster/create_k8s_configs.sh
+++ b/manage-cluster/create_k8s_configs.sh
@@ -77,6 +77,7 @@ gsutil cp gs://${!GCS_BUCKET_K8S}/prometheus-htpasswd secrets/auth
 # specification, so copy it directly to the secret-configs/ directory.
 gsutil cp gs://${!GCS_BUCKET_K8S}/alertmanager-basicauth.yaml secret-configs/.
 gsutil cp -R gs://${!GCS_BUCKET_K8S}/locate secrets/.
+gsutil cp -R gs://${!GCS_BUCKET_K8S}/locate-heartbeat secrets/.
 
 # Convert secret data into configs.
 kubectl create secret generic uuid-annotator-credentials --from-file secrets/uuid-annotator.json \
@@ -99,6 +100,8 @@ kubectl create secret generic prometheus-htpasswd --from-file secrets/auth \
     --dry-run -o json > secret-configs/prometheus-htpasswd.json
 kubectl create secret generic locate-verify-keys --from-file secrets/locate/ \
     --dry-run -o json > secret-configs/locate-verify-keys.json
+kubectl create secret generic locate-heartbeat-key --from-file secrets/locate-heartbeat/ \
+    --dry-run -o json > secret-configs/locate-heartbeat-key.json
 
 # Download the platform cluster CA cert.
 gsutil cp gs://k8s-support-${PROJECT}/pki/ca.crt .


### PR DESCRIPTION
This change adds a new secret that contains the api keys for the /heartbeat path.

```
$ kubectl --context mlab-sandbox get secrets | grep locate-heartbeat
locate-heartbeat-key                Opaque                                1      6m41s
```

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/689)
<!-- Reviewable:end -->
