### PR TITLE
Updates uuid-annotator to v0.4.7

### DIFF
--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -308,7 +308,7 @@ local Pusher(expName, tcpPort, datatypes, hostNetwork, bucket) = [
 local UUIDAnnotator(expName, tcpPort, hostNetwork) = [
   {
     name: 'uuid-annotator',
-    image: 'measurementlab/uuid-annotator:v0.4.6',
+    image: 'measurementlab/uuid-annotator:v0.4.7',
     args: [
       if hostNetwork then
         '-prometheusx.listen-address=127.0.0.1:' + tcpPort
@@ -320,7 +320,7 @@ local UUIDAnnotator(expName, tcpPort, hostNetwork) = [
       '-maxmind.url=gs://downloader-' + PROJECT_ID + '/Maxmind/current/GeoLite2-City.tar.gz',
       '-routeview-v4.url=gs://downloader-' + PROJECT_ID + '/RouteViewIPv4/current/routeview.pfx2as.gz',
       '-routeview-v6.url=gs://downloader-' + PROJECT_ID + '/RouteViewIPv6/current/routeview.pfx2as.gz',
-      '-siteinfo.url=https://siteinfo.' + PROJECT_ID + '.measurementlab.net/v1/sites/annotations.json',
+      '-siteinfo.url=https://siteinfo.' + PROJECT_ID + '.measurementlab.net/v2/sites/annotations.json',
       '-hostname=$(MLAB_NODE_NAME)',
     ],
     env: [


### PR DESCRIPTION
This new version of uuid-annotator consumes v2 of the siteinfo
annotations format, so the commit also updates the -siteinfo.url flag
value to v2 of the format.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/690)
<!-- Reviewable:end -->
