### PR TITLE
Update -heartbeat-url

### DIFF
--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -382,7 +382,10 @@ local Heartbeat(expName, tcpPort, hostNetwork, services) = [
     name: 'heartbeat',
     image: 'measurementlab/heartbeat:v0.0',
     args: [
-      '-heartbeat-url=wss://locate.measurementlab.net/v2/platform/heartbeat?key=$(API_KEY)',
+      if PROJECT_ID == 'mlab-oti' then
+        '-heartbeat-url=wss://locate.measurementlab.net/v2/platform/heartbeat?key=$(API_KEY)'
+      else
+        '-heartbeat-url=wss://locate-dot-' + PROJECT_ID + '.appspot.com/v2/platform/heartbeat?key=$(API_KEY)',
       '-registration-url=https://siteinfo.' + PROJECT_ID + '.measurementlab.net/v2/sites/registration.json',
       '-experiment=' + expName,
       '-hostname=' + expName + '-$(MLAB_NODE_NAME)',

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -385,7 +385,7 @@ local Heartbeat(expName, tcpPort, hostNetwork, services) = [
       if PROJECT_ID == 'mlab-oti' then
         '-heartbeat-url=wss://locate.measurementlab.net/v2/platform/heartbeat?key=$(API_KEY)'
       else
-        '-heartbeat-url=wss://locate-dot-' + PROJECT_ID + '.appspot.com/v2/platform/heartbeat?key=$(API_KEY)',
+        '-heartbeat-url=wss://locate.' + PROJECT_ID + '.measurementlab.net/v2/platform/heartbeat?key=$(API_KEY)',
       '-registration-url=https://siteinfo.' + PROJECT_ID + '.measurementlab.net/v2/sites/registration.json',
       '-experiment=' + expName,
       '-hostname=' + expName + '-$(MLAB_NODE_NAME)',


### PR DESCRIPTION
Request to the `locate.measurementlab.net` domain are routed to `locate-dot-mlab-ns.appspot.com`. 

This PR updates the URL to a project-specific domain.
Note: the mlab-staging domain needs to be created. 

Other (IMO less desirable) options are to use the `locate-dot-' + PROJECT_ID + '.appspot.com` URL or to have all projects make requests to  `locate.measurementlab.net`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/692)
<!-- Reviewable:end -->
