### PR TITLE
Update heartbeat image tag to Locate tagged build

### DIFF
--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -380,7 +380,7 @@ local UUIDAnnotator(expName, tcpPort, hostNetwork) = [
 local Heartbeat(expName, tcpPort, hostNetwork, services) = [
   {
     name: 'heartbeat',
-    image: 'measurementlab/heartbeat:v0.0',
+    image: 'measurementlab/heartbeat:v0.10.0',
     args: [
       if PROJECT_ID == 'mlab-oti' then
         '-heartbeat-url=wss://locate.measurementlab.net/v2/platform/heartbeat?key=$(API_KEY)'


### PR DESCRIPTION
Current image points to a `v0.0` version. 
This PR updates it to the latest tagged build for the Locate (the code is the same in both versions).

```
$ kubectl --context mlab-sandbox logs ndt-m6s7s heartbeat
2022/06/22 19:21:17 WARNING: Not overriding flag -hostname="ndt-mlab2-lga1t.mlab-sandbox.measurement-lab.org" with evironment variable HOSTNAME="ndt-m6s7s"
2022/06/22 19:21:17 successfully established a connection with wss://locate.mlab-sandbox.measurementlab.net/v2/platform/heartbeat?key=AIzaSyAn9_jO6DkyWiqB7Xu8t2wVp_1WzkF72aQ
```

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/693)
<!-- Reviewable:end -->
