### PR TITLE
Adds a "workload=fluentbit" label to fluentbit pods

### DIFF
--- a/config/fluentbit/values.yaml.template
+++ b/config/fluentbit/values.yaml.template
@@ -129,5 +129,7 @@ podAnnotations:
   prometheus.io/scrape: "true"
   prometheus.io/scheme: http
   prometheus.io/metrics_path: /api/v1/metrics/prometheus
+podLabels:
+  workload: fluentbit
 
 

--- a/config/fluentbit/values.yaml.template
+++ b/config/fluentbit/values.yaml.template
@@ -125,6 +125,7 @@ initContainers:
   volumeMounts:
   - name: fluent-bit-etc
     mountPath: /fluent-bit/etc
+nameOverride: fluentbit
 podAnnotations:
   prometheus.io/scrape: "true"
   prometheus.io/scheme: http

--- a/config/fluentbit/values.yaml.template
+++ b/config/fluentbit/values.yaml.template
@@ -125,7 +125,7 @@ initContainers:
   volumeMounts:
   - name: fluent-bit-etc
     mountPath: /fluent-bit/etc
-nameOverride: fluentbit
+fullnameOverride: fluentbit
 podAnnotations:
   prometheus.io/scrape: "true"
   prometheus.io/scheme: http


### PR DESCRIPTION
This should partially resolve https://github.com/m-lab/ops-tracker/issues/1592

This PR also changes the name of the fluentbit DaemonSet from "fluent-bit" to "fluentbit", so that naming of the thing is consistent.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/694)
<!-- Reviewable:end -->
