### PR TITLE
Revert "Revert "chore: use neubot/dash v0.4.3""

### DIFF
--- a/k8s/daemonsets/experiments/neubot.jsonnet
+++ b/k8s/daemonsets/experiments/neubot.jsonnet
@@ -14,7 +14,7 @@ exp.Experiment(expName, 10, 'pusher-' + std.extVar('PROJECT_ID'), "none", dataty
         containers+: [
             {
               name: 'dash',
-              image: 'measurementlab/dash:v0.4.1',
+              image: 'measurementlab/dash:v0.4.3',
             args: [
               '-datadir=/var/spool/' + expName,
               '-prometheusx.listen-address=$(PRIVATE_IP):9990',


### PR DESCRIPTION
Reverts m-lab/k8s-support#696 - docker pull measurementlab/dash:v0.4.3 now exists..

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/697)
<!-- Reviewable:end -->
