### PR TITLE
Change v1beta1 to v1 to unblock GKE upgrades

### DIFF
--- a/manage-cluster/kubeadm-config.yml.template
+++ b/manage-cluster/kubeadm-config.yml.template
@@ -50,7 +50,7 @@ kind: KubeProxyConfiguration
 clusterCIDR: {{K8S_CLUSTER_CIDR}}
 hostnameOverride: "{{MASTER_NAME}}"
 ---
-apiVersion: kubelet.config.k8s.io/v1beta1
+apiVersion: kubelet.config.k8s.io/v1
 kind: KubeletConfiguration
 cgroupDriver: systemd
 containerLogMaxSize: 100Mi


### PR DESCRIPTION
GKE v1beta1 is deprecated and clusters with these resources are
blocked from upgrading automatically.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/698)
<!-- Reviewable:end -->
