### PR TITLE
Sets some limits for the Stackdriver output plugin

### DIFF
--- a/config/fluentbit/values.yaml.template
+++ b/config/fluentbit/values.yaml.template
@@ -116,6 +116,14 @@ initContainers:
         namespace ${NODE_NAME}
         node_id ${NODE_NAME}
         export_to_project_id {{PROJECT}}
+        # Don't try to push a chunk forever.
+        Retry_Limit 10
+        # Default timeout is 10s. Increase this a bit to workaround a slow or
+        # flaky network connection.
+        net.connect_timeout 60
+        # Don't continue to fill up the filesystem with buffered chunks when
+        # pushing logs to Stackdriver isn't working for some reason.
+        storage.total_limit_size 1G
     EOF
   env:
   - name: NODE_NAME


### PR DESCRIPTION
We are having some issues with fluent-bit where a flaky or down
Internet connection causes it to stop sending log data, and it never
recovers. This commit introduces a few new configuration settings which
are aimed to workaround this probable bug in fluent-bit, which are also
probably sensible in any case. We don't want fluent-bit to fill up the
filesystem, and in the case of extended outages we don't need to worry
about trying to send data forever. It is okay for us to lose some log
data.

The motivation for this PR is to maybe workaround [an issue we are seeing with fluent-bit](https://github.com/m-lab/ops-tracker/issues/1594) when it encounters and Internet outage or a flaky connection.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/700)
<!-- Reviewable:end -->
