### PR TITLE
Better support for physical/virtual dashboards + updates to cAdvisor config 

### DIFF
--- a/config/fluentbit/values.yaml.template
+++ b/config/fluentbit/values.yaml.template
@@ -74,6 +74,11 @@ config:
         HTTP_Listen  0.0.0.0
         HTTP_PORT    2020
         storage.path /var/lib/fluent-bit
+dnsConfig:
+  nameservers:
+  - 8.8.8.8
+  - 8.8.4.4
+dnsPolicy: None
 env:
 - name: GOOGLE_APPLICATION_CREDENTIALS
   value: /etc/fluentbit/keys/fluentbit.json

--- a/config/prometheus/prometheus.yml
+++ b/config/prometheus/prometheus.yml
@@ -142,16 +142,6 @@ scrape_configs:
         action: replace
         target_label: machine
 
-      # Add a site label for SNMP metrics from DISCO. DISCOv2 collects switch
-      # metrics from each machine in a pod, and hence there is not site label
-      # by default, but rather only a machine label, from which we can extract
-      # the site.
-      - source_labels: [__meta_kubernetes_pod_container_name, __meta_kubernetes_pod_node_name]
-        action: replace
-        regex: disco;mlab[1-4]-([a-z]{3}[0-9t]{2}).*
-        replacement: $1
-        target_label: site
-
       # Identify the deployment name for replica set or daemon set.  Pods
       # created by deployments or daemon sets are processed here. The
       # following two rules recognize these two cases.

--- a/config/prometheus/prometheus.yml
+++ b/config/prometheus/prometheus.yml
@@ -181,6 +181,7 @@ scrape_configs:
         target_label: site
         replacement: ${1}
 
+
     # This relabel config is the last relabel processed before ingesting data
     # into the datastore.
     metric_relabel_configs:
@@ -195,6 +196,17 @@ scrape_configs:
         regex: (uplink)-.*
         target_label: ifAlias
         replacement: ${1}
+
+      # The relabel_config that adds a 'site' label works for a lot of metrics,
+      # but not for workloads that aren't running on a platform node.
+      # Specifically, kube-state-metrics. This rule will extract a 'site' label
+      # from the source label 'node' for all metrics gathered from
+      # kube-state-metrics.
+      - source_labels: [container, node]
+        action: replace
+        regex: kube-state-metrics;mlab[1-4]-([a-z]{3}[0-9t]{2}).*
+        replacement: $1
+        target_label: site
 
   # Scrape config for kubernetes service endpoints.
   - job_name: 'kubernetes-service-endpoints'

--- a/config/prometheus/prometheus.yml
+++ b/config/prometheus/prometheus.yml
@@ -186,7 +186,6 @@ scrape_configs:
 
       # Extract the a node's site from the node name, and add a new 'site'
       # label using the value.
-      - source_labels: [node]
       - source_labels: [__meta_kubernetes_pod_node_name]
         regex: mlab[1-4]-([a-z]{3}[0-9tc]{2}).*
         target_label: site

--- a/config/prometheus/prometheus.yml
+++ b/config/prometheus/prometheus.yml
@@ -187,6 +187,7 @@ scrape_configs:
       # Extract the a node's site from the node name, and add a new 'site'
       # label using the value.
       - source_labels: [node]
+      - source_labels: [__meta_kubernetes_pod_node_name]
         regex: mlab[1-4]-([a-z]{3}[0-9tc]{2}).*
         target_label: site
         replacement: ${1}

--- a/config/prometheus/prometheus.yml
+++ b/config/prometheus/prometheus.yml
@@ -317,6 +317,13 @@ scrape_configs:
         action: replace
         target_label: container
 
+      # Extract the a node's site from the node name, and add a new 'site'
+      # label using the value.
+      - source_labels: [__meta_kubernetes_pod_node_name]
+        regex: mlab[1-4]-([a-z]{3}[0-9tc]{2}).*
+        target_label: site
+        replacement: ${1}
+
   # Scrape the token-server. The address we are scraping is actually a GCP
   # internal load balancer. Scraping the load balancer address won't guarantee
   # that all token-server instances are up and running, but more importantly

--- a/config/prometheus/prometheus.yml
+++ b/config/prometheus/prometheus.yml
@@ -329,8 +329,8 @@ scrape_configs:
         action: replace
         target_label: container
 
-      # Extract the a node's site from the node name, and add a new 'site'
-      # label using the value.
+      # Extract a node's site from the node name, and add a new 'site' label
+      # using the value.
       - source_labels: [__meta_kubernetes_pod_node_name]
         regex: mlab[1-4]-([a-z]{3}[0-9tc]{2}).*
         target_label: site

--- a/config/prometheus/prometheus.yml
+++ b/config/prometheus/prometheus.yml
@@ -184,6 +184,13 @@ scrape_configs:
         action: replace
         target_label: container
 
+      # Extract the a node's site from the node name, and add a new 'site'
+      # label using the value.
+      - source_labels: [node]
+        regex: mlab[1-4]-([a-z]{3}[0-9tc]{2}).*
+        target_label: site
+        replacement: ${1}
+
     # This relabel config is the last relabel processed before ingesting data
     # into the datastore.
     metric_relabel_configs:

--- a/config/prometheus/rules.yml
+++ b/config/prometheus/rules.yml
@@ -2,6 +2,12 @@ groups:
 - name: rules.yml
   rules:
 
+# NOTE: in a number of the recording rules below you will encounter the patten
+# "on(machine) group_left(label_mlab_type) label_replace(kube_node_labels".
+# This pattern allow us to select on virtual vs physical nodes in dashboard.
+# The group_left statement brings the "label_mlab_type" label over to the
+# right side label set, allow us to query on it.
+
 ## CPU METRICS
 
   #  Calculates aggregate 1h rate of CPU usage for a DaemonSet across all

--- a/config/prometheus/rules.yml
+++ b/config/prometheus/rules.yml
@@ -8,13 +8,15 @@ groups:
   #  machines.
   - record: daemonset:container_cpu_usage_seconds:sum_rate1h
     expr: |
-      sum by (daemonset) (
+      sum by (daemonset, label_mlab_type) (
         label_replace(
           rate (container_cpu_usage_seconds_total{
             container_label_io_kubernetes_container_name != "",
             machine=~"mlab[1-4].*"
           }[1h]),
           "daemonset", "$1", "container_label_io_kubernetes_pod_name", "^(.*)-[a-z0-9]+$"
+        ) * on(machine) group_left(label_mlab_type) label_replace(
+          kube_node_labels, "machine", "$1", "node", "(.*)"
         )
       )
 
@@ -28,13 +30,15 @@ groups:
   # Calculates aggregate DaemonSet CPU usage on a machine.
   - record: machine_daemonset:container_cpu_usage_seconds:sum_rate1h
     expr: |
-      sum by (machine, daemonset) (
+      sum by (machine, daemonset, label_mlab_type) (
         label_replace(
           rate (container_cpu_usage_seconds_total{
             container_label_io_kubernetes_container_name != "",
             machine=~"mlab[1-4].*"
           }[1h]),
           "daemonset", "$1", "container_label_io_kubernetes_pod_name", "^(.*)-[a-z0-9]+$"
+        ) * on(machine) group_left(label_mlab_type) label_replace(
+          kube_node_labels, "machine", "$1", "node", "(.*)"
         )
       )
 
@@ -51,13 +55,15 @@ groups:
   #  Calculates aggregate DaemonSet memory usage across all machines.
   - record: daemonset:container_memory_working_set_bytes:sum
     expr: |
-      sum by (daemonset) (
+      sum by (daemonset, label_mlab_type) (
         label_replace(
           container_memory_working_set_bytes{
             container_label_io_kubernetes_container_name != "",
             machine=~"mlab[1-4].*"
           },
           "daemonset", "$1", "container_label_io_kubernetes_pod_name", "^(.*)-[a-z0-9]+$"
+        ) * on(machine) group_left(label_mlab_type) label_replace(
+          kube_node_labels, "machine", "$1", "node", "(.*)"
         )
       )
 
@@ -71,13 +77,15 @@ groups:
   # Calculates aggregate DaemonSet memory usage on a machine.
   - record: machine_daemonset:container_memory_working_set_bytes:sum
     expr: |
-      sum by (machine, daemonset) (
+      sum by (machine, daemonset, label_mlab_type) (
         label_replace(
           container_memory_working_set_bytes{
             container_label_io_kubernetes_container_name != "",
             machine=~"mlab[1-4].*"
           },
           "daemonset", "$1", "container_label_io_kubernetes_pod_name", "^(.*)-[a-z0-9]+$"
+        ) * on(machine) group_left(label_mlab_type) label_replace(
+          kube_node_labels, "machine", "$1", "node", "(.*)"
         )
       )
 
@@ -100,53 +108,61 @@ groups:
   # Calculates aggregate DaemonSet network trasmit bytes on the platform.
   - record: workload:container_network_transmit_bytes_total:sum
     expr: |
-      sum by (container_label_workload) (
+      sum by (container_label_workload, label_mlab_type) (
         rate(
           container_network_transmit_bytes_total{
             container_label_workload != "",
             container_label_workload !~ "(flannel-virtual|flannel-physical|host|node-exporter|utilization)",
             machine =~ "mlab[1-4].*"
           }
-        [1h]) * 8
+        [1h]) * 8 * on(machine) group_left(label_mlab_type) label_replace(
+          kube_node_labels, "machine", "$1", "node", "(.*)"
+        )
       )
 
   # Calculates aggregate DaemonSet network receive bytes on the platform.
   - record: workload:container_network_receive_bytes_total:sum
     expr: |
-      sum by (container_label_workload) (
+      sum by (container_label_workload, label_mlab_type) (
         rate(
           container_network_receive_bytes_total{
             container_label_workload != "",
             container_label_workload !~ "(flannel-virtual|flannel-physical|host|node-exporter|utilization)",
             machine =~ "mlab[1-4].*"
           }
-        [1h]) * 8
+        [1h]) * 8 * on(machine) group_left(label_mlab_type) label_replace(
+          kube_node_labels, "machine", "$1", "node", "(.*)"
+        )
       )
 
   # Calculates aggregate DaemonSet network trasmit bytes on a machine.
   - record: machine_workload:container_network_transmit_bytes_total:sum
     expr: |
-      sum by (machine, container_label_workload) (
+      sum by (machine, container_label_workload, label_mlab_type) (
         rate(
           container_network_transmit_bytes_total{
             container_label_workload != "",
             container_label_workload !~ "(flannel-virtual|flannel-physical|host|node-exporter|utilization)",
             machine =~ "mlab[1-4].*"
           }
-        [1h]) * 8
+        [1h]) * 8 * on(machine) group_left(label_mlab_type) label_replace(
+          kube_node_labels, "machine", "$1", "node", "(.*)"
+        )
       )
 
   # Calculates aggregate DaemonSet network receive bytes on a machine.
   - record: machine_workload:container_network_receive_bytes_total:sum
     expr: |
-      sum by (machine, container_label_workload) (
+      sum by (machine, container_label_workload, label_mlab_type) (
         rate(
           container_network_receive_bytes_total{
             container_label_workload != "",
             container_label_workload !~ "(flannel-virutal|flannel-physical|host|node-exporter|utilization)",
             machine =~ "mlab[1-4].*"
           }
-        [1h]) * 8
+        [1h]) * 8 * on(machine) group_left(label_mlab_type) label_replace(
+          kube_node_labels, "machine", "$1", "node", "(.*)"
+        )
       )
 
 ## Pusher Daily Volume metrics

--- a/k8s/daemonsets/core/cadvisor.jsonnet
+++ b/k8s/daemonsets/core/cadvisor.jsonnet
@@ -26,13 +26,13 @@
             args: [
               '-housekeeping_interval=60s',
               '-max_housekeeping_interval=75s',
-              '-disable_metrics=accelerator,cpu_topology,disk,diskIO,memory_numa,tcp,udp,percpu,sched,process,hugetlb,referenced_memory,resctrl,cpuset',
+              '-enable_metrics=cpu,memory,network',
               // Only show stats for docker containers.
               '-docker_only',
               '-store_container_labels=false',
               '-whitelisted_container_labels=io.kubernetes.container.name,io.kubernetes.pod.name,workload',
             ],
-            image: 'gcr.io/cadvisor/cadvisor:v0.39.3',
+            image: 'gcr.io/cadvisor/cadvisor:v0.44.1',
             name: 'cadvisor',
             ports: [
               {

--- a/k8s/daemonsets/core/cadvisor.jsonnet
+++ b/k8s/daemonsets/core/cadvisor.jsonnet
@@ -24,14 +24,13 @@
         containers: [
           {
             args: [
-              '--housekeeping_interval=60s',
-              '--max_housekeeping_interval=75s',
-              // Note: tcp,udp stats are expensive and are disabled by default.
-              '--enable_metrics=cpu,memory,network',
+              '-housekeeping_interval=60s',
+              '-max_housekeeping_interval=75s',
+              '-disable_metrics=accelerator,cpu_topology,disk,diskIO,memory_numa,tcp,udp,percpu,sched,process,hugetlb,referenced_memory,resctrl,cpuset',
               // Only show stats for docker containers.
-              '--docker_only',
-              '--store_container_labels=false',
-              '--whitelisted_container_labels=container_label_io_kubernetes_container_name,container_label_io_kubernetes_pod_name,container_label_workload',
+              '-docker_only',
+              '-store_container_labels=false',
+              '-whitelisted_container_labels=container_label_io_kubernetes_container_name,container_label_io_kubernetes_pod_name,container_label_workload',
             ],
             image: 'gcr.io/cadvisor/cadvisor:v0.39.3',
             name: 'cadvisor',

--- a/k8s/daemonsets/core/cadvisor.jsonnet
+++ b/k8s/daemonsets/core/cadvisor.jsonnet
@@ -27,9 +27,11 @@
               '--housekeeping_interval=60s',
               '--max_housekeeping_interval=75s',
               // Note: tcp,udp stats are expensive and are disabled by default.
-              '--disable_metrics=percpu,process,sched,tcp,udp',
+              '--enable_metrics=cpu,memory,network',
               // Only show stats for docker containers.
               '--docker_only',
+              '--store_container_labels=false',
+              '--whitelisted_container_labels=container_label_io_kubernetes_container_name,container_label_io_kubernetes_pod_name,container_label_workload',
             ],
             image: 'gcr.io/cadvisor/cadvisor:v0.39.3',
             name: 'cadvisor',

--- a/k8s/daemonsets/core/cadvisor.jsonnet
+++ b/k8s/daemonsets/core/cadvisor.jsonnet
@@ -30,7 +30,7 @@
               // Only show stats for docker containers.
               '-docker_only',
               '-store_container_labels=false',
-              '-whitelisted_container_labels=container_label_io_kubernetes_container_name,container_label_io_kubernetes_pod_name,container_label_workload',
+              '-whitelisted_container_labels=io.kubernetes.container.name,io.kubernetes.pod.name',
             ],
             image: 'gcr.io/cadvisor/cadvisor:v0.39.3',
             name: 'cadvisor',

--- a/k8s/daemonsets/core/cadvisor.jsonnet
+++ b/k8s/daemonsets/core/cadvisor.jsonnet
@@ -30,7 +30,7 @@
               // Only show stats for docker containers.
               '-docker_only',
               '-store_container_labels=false',
-              '-whitelisted_container_labels=io.kubernetes.container.name,io.kubernetes.pod.name',
+              '-whitelisted_container_labels=io.kubernetes.container.name,io.kubernetes.pod.name,workload',
             ],
             image: 'gcr.io/cadvisor/cadvisor:v0.39.3',
             name: 'cadvisor',

--- a/k8s/daemonsets/core/cadvisor.jsonnet
+++ b/k8s/daemonsets/core/cadvisor.jsonnet
@@ -32,7 +32,7 @@
               '-store_container_labels=false',
               '-whitelisted_container_labels=io.kubernetes.container.name,io.kubernetes.pod.name,workload',
             ],
-            image: 'gcr.io/cadvisor/cadvisor:v0.44.1',
+            image: 'gcr.io/cadvisor/cadvisor:v0.44.0',
             name: 'cadvisor',
             ports: [
               {

--- a/k8s/deployments/kube-state-metrics.jsonnet
+++ b/k8s/deployments/kube-state-metrics.jsonnet
@@ -62,7 +62,7 @@
           },
         ],
         nodeSelector: {
-          'mlab/type': 'virtual',
+          'run': 'prometheus-server',
         },
         serviceAccountName: 'kube-state-metrics',
       },


### PR DESCRIPTION
The majority of changes in this PR are to allow better support for switching on virtual/physical in various Grafana dashboards, mostly be updating recording rules, but also by adding a `site` label to more metrics.

While working on the dashboard updates, we also realized that cAdvisor was exporting far too many metrics we don't use, with far too many labels. This PR also reconfigures cAdvisor to export fewer metrics with fewer labels.

Additionally this PR causes kube-state-metrics to run on the Prometheus VM. Currently, the nodeSelector for the pod is `mlab/type="virtual"`, which in the past would have ensured that it was running on one of the control plane nodes or on the Prometheus node. Today, we have virtual sites, and I found that kube-state-metrics was running on random virtual nodes, which didn't seem desirable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/701)
<!-- Reviewable:end -->
