### PR TITLE
Fixes fluentbit alert + removes custom DNS config

### DIFF
--- a/config/fluentbit/values.yaml.template
+++ b/config/fluentbit/values.yaml.template
@@ -74,11 +74,6 @@ config:
         HTTP_Listen  0.0.0.0
         HTTP_PORT    2020
         storage.path /var/lib/fluent-bit
-dnsConfig:
-  nameservers:
-  - 8.8.8.8
-  - 8.8.4.4
-dnsPolicy: None
 env:
 - name: GOOGLE_APPLICATION_CREDENTIALS
   value: /etc/fluentbit/keys/fluentbit.json

--- a/config/prometheus/alerts.yml
+++ b/config/prometheus/alerts.yml
@@ -52,7 +52,7 @@ groups:
       dashboard: https://grafana.mlab-staging.measurementlab.net/d/tZHLFQRZk/k8s-workload-overview
 
   - alert: PlatformCluster_FluentbitMissing
-    expr: absent(up{deployment="fluent-bit"})
+    expr: absent(up{deployment="fluentbit"})
     for: 15m
     labels:
       repo: ops-tracker
@@ -61,7 +61,7 @@ groups:
     annotations:
       summary: The Fluentbit DaemonSet is missing or has no metrics.
       description: The Fluentbit DaemonSet is missing or has no metrics. Verify
-        that the DaemonSet is healthy (`kubectl describe ds fluent-bit`).
+        that the DaemonSet is healthy (`kubectl describe ds fluentbit`).
       dashboard: https://grafana.mlab-oti.measurementlab.net/d/tZHLFQRZk/k8s-workload-overview
 
   - alert: PlatformCluster_NdtMissing


### PR DESCRIPTION
The fluentbit DaemonSet named changed from "fluent-bit" to "fluentbit", but the alert was mistakenly never updated.

We noticed DNS lookup failures in some problem fluentbit containers, and wondered whether using Google public DNS servers would help, much like we do in NDT containers. However, we failed to take into account that fluentbit needs to resolve cluster-local addresses, which are private and not resolvable by public nameservers. This PR reverts that change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/702)
<!-- Reviewable:end -->
