### PR TITLE
Allows cAdvisor to add pod.namespace label

### DIFF
--- a/k8s/daemonsets/core/cadvisor.jsonnet
+++ b/k8s/daemonsets/core/cadvisor.jsonnet
@@ -30,7 +30,7 @@
               // Only show stats for docker containers.
               '-docker_only',
               '-store_container_labels=false',
-              '-whitelisted_container_labels=io.kubernetes.container.name,io.kubernetes.pod.name,workload',
+              '-whitelisted_container_labels=io.kubernetes.container.name,io.kubernetes.pod.name,io.kubernetes.pod.namespace,workload',
             ],
             image: 'gcr.io/cadvisor/cadvisor:v0.44.0',
             name: 'cadvisor',


### PR DESCRIPTION
The SiteOverview dashboard uses that label.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/703)
<!-- Reviewable:end -->
