### PR TITLE
Updates Prometheus to v2.32.1

### DIFF
--- a/k8s/deployments/prometheus.jsonnet
+++ b/k8s/deployments/prometheus.jsonnet
@@ -41,7 +41,7 @@ local prometheusConfig = import '../../config/prometheus.jsonnet';
               '--storage.tsdb.retention.time=120d',
               '--enable-feature=memory-snapshot-on-shutdown',
             ],
-            image: 'prom/prometheus:v2.31.1',
+            image: 'prom/prometheus:v2.32.1',
             name: 'prometheus',
             ports: [
               {


### PR DESCRIPTION
The motiviation for this is inexplicable query issues we are seeing in
the staging instance of Prometheus. This erro was present on Prom
startup in staging:

```
ts=2022-07-20T20:00:12.090Z caller=head.go:479 level=info component=tsdb msg="Replaying on-disk memory mappable chunks if any"
ts=2022-07-20T20:00:12.091Z caller=head.go:486 level=info component=tsdb msg="Chunk snapshot is enabled, replaying from the snapshot"
ts=2022-07-20T20:00:12.091Z caller=head.go:492 level=error component=tsdb msg="Failed to load chunk snapshot" err="find last chunk snapshot: chunk snapshot chunk_snapshot.197710.0082313216.tmp is not in the right format"
```

These may be related:

https://github.com/prometheus/prometheus/issues/9725
https://github.com/prometheus/prometheus/pull/9980

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/704)
<!-- Reviewable:end -->
