### PR TITLE
Sets ndots=2 in dnsPolicy for fluentbit and disco DaemonSets + fix flannel

### DIFF
--- a/config/fluentbit/values.yaml.template
+++ b/config/fluentbit/values.yaml.template
@@ -74,6 +74,10 @@ config:
         HTTP_Listen  0.0.0.0
         HTTP_PORT    2020
         storage.path /var/lib/fluent-bit
+dnsConfig:
+  options:
+  - name: ndots
+    value: 2
 env:
 - name: GOOGLE_APPLICATION_CREDENTIALS
   value: /etc/fluentbit/keys/fluentbit.json

--- a/config/fluentbit/values.yaml.template
+++ b/config/fluentbit/values.yaml.template
@@ -78,6 +78,10 @@ dnsConfig:
   options:
   - name: ndots
     value: "2"
+  searches:
+  - cluster.local
+  - svc.cluster.local
+  - default.svc.cluster.local
 env:
 - name: GOOGLE_APPLICATION_CREDENTIALS
   value: /etc/fluentbit/keys/fluentbit.json

--- a/config/fluentbit/values.yaml.template
+++ b/config/fluentbit/values.yaml.template
@@ -125,6 +125,12 @@ initContainers:
         # Default timeout is 10s. Increase this a bit to workaround a slow or
         # flaky network connection.
         net.connect_timeout 60
+        # We have been seeing a lot of "Timeout while contacting DNS servers"
+        # errors in fluent-bit logs and fluent bit not being able to upload
+        # logs. Several Github issues reporting this had users saying that this
+        # was at least partially mitigated by this setting (using TCP instead
+        # of UDP).
+        net.dns.mode TCP
         # Don't continue to fill up the filesystem with buffered chunks when
         # pushing logs to Stackdriver isn't working for some reason.
         storage.total_limit_size 1G

--- a/config/fluentbit/values.yaml.template
+++ b/config/fluentbit/values.yaml.template
@@ -78,10 +78,6 @@ dnsConfig:
   options:
   - name: ndots
     value: "2"
-  searches:
-  - cluster.local
-  - svc.cluster.local
-  - default.svc.cluster.local
 env:
 - name: GOOGLE_APPLICATION_CREDENTIALS
   value: /etc/fluentbit/keys/fluentbit.json

--- a/config/fluentbit/values.yaml.template
+++ b/config/fluentbit/values.yaml.template
@@ -77,7 +77,7 @@ config:
 dnsConfig:
   options:
   - name: ndots
-    value: 2
+    value: "2"
 env:
 - name: GOOGLE_APPLICATION_CREDENTIALS
   value: /etc/fluentbit/keys/fluentbit.json

--- a/k8s/daemonsets/core/disco.jsonnet
+++ b/k8s/daemonsets/core/disco.jsonnet
@@ -105,6 +105,14 @@ local version = 'v0.1.13';
             },
           },
         ],
+        dnsConfig: {
+          options: [
+            {
+              name: 'ndots',
+              value: '2',
+            },
+          ],
+        }
       },
     },
     updateStrategy: {

--- a/k8s/daemonsets/core/flannel-physical.jsonnet
+++ b/k8s/daemonsets/core/flannel-physical.jsonnet
@@ -59,7 +59,7 @@
                 },
               },
             ],
-            image: 'quay.io/coreos/flannel:' + std.extVar('K8S_FLANNEL_VERSION') + '-amd64',
+            image: 'rancher/mirrored-flannelcni-flannel:' + std.extVar('K8S_FLANNEL_VERSION') + '-amd64',
             name: 'flannel',
             resources: {
               limits: {

--- a/k8s/daemonsets/core/flannel-physical.jsonnet
+++ b/k8s/daemonsets/core/flannel-physical.jsonnet
@@ -97,7 +97,7 @@
             command: [
               'cp',
             ],
-            image: 'quay.io/coreos/flannel:' + std.extVar('K8S_FLANNEL_VERSION') + '-amd64',
+            image: 'rancher/mirrored-flannelcni-flannel:' + std.extVar('K8S_FLANNEL_VERSION') + '-amd64',
             name: 'install-cni',
             volumeMounts: [
               {

--- a/k8s/daemonsets/core/flannel-virtual.jsonnet
+++ b/k8s/daemonsets/core/flannel-virtual.jsonnet
@@ -100,7 +100,7 @@
             command: [
               'cp',
             ],
-            image: 'quay.io/coreos/flannel:' + std.extVar('K8S_FLANNEL_VERSION') + '-amd64',
+            image: 'rancher/mirrored-flannelcni-flannel:' + std.extVar('K8S_FLANNEL_VERSION') + '-amd64',
             name: 'install-cni',
             volumeMounts: [
               {

--- a/k8s/daemonsets/core/flannel-virtual.jsonnet
+++ b/k8s/daemonsets/core/flannel-virtual.jsonnet
@@ -62,7 +62,7 @@
                 },
               },
             ],
-            image: 'quay.io/coreos/flannel:' + std.extVar('K8S_FLANNEL_VERSION') + '-amd64',
+            image: 'rancher/mirrored-flannelcni-flannel:' + std.extVar('K8S_FLANNEL_VERSION') + '-amd64',
             name: 'flannel',
             resources: {
               limits: {


### PR DESCRIPTION
Currently, and by default in k8s, pods have a resolver policy of `ndots:5`, which means that if a host name has fewer than 5 dots, the resolver will assume it is a relative name, and will proceed to append each search domain to the name and do a lookup. For example, if the resolver sees a name like "logging.googleapis.com" (which only has 2 dots), it will first do lookups of things like "logging.googleapis.com.default.svc.cluster.local" (which will fail), and then "logging.googleapis.com.svc.cluster.local", and so on, until it has exhausted all search domains, _then_ and finally it will issue a final FQDN recursive search for "logging.googleapis.com." (dot at end), which will succeed. This means that just to lookup "logging.googleapis.com" will always entail at least 4 DNS lookups before an IP is received.

On the M-Lab platform we mostly do resolution using Google's public DNS servers, and very few intra cluster lookup are done. It turns out that fluentbit and disco are two services that mostly use the cluster's CoreDNS instances for resolvers. This PR sets `ndots:2` for both of those DaemonSets. This means that cluster-local lookups may take require two queries, but observation shows that the vast majority of lookups these services are doing are for names like "oauth2.googleapis.com" and "logging.googleapis.com", etc. This change is a pretty big optimization for these services.

Consider this dashboard panel for CoreOS in production:

![Screenshot from 2022-07-27 10-52-39](https://user-images.githubusercontent.com/1392825/181305050-9435cc93-7ad6-4a5b-97fe-6cedd617d798.png)

The NXDOMAIN responses are triple the rate of NOERROR. Compare that with sandbox, which contains this optimization:

![Screenshot from 2022-07-27 10-52-56](https://user-images.githubusercontent.com/1392825/181305208-f056e069-0cd2-4230-8d63-57122828e2f5.png)

You can see how things used to be yesterday, with NXDOMAINs prominent. But with this change, the NXDOMAIN responses have dropped to nearly 0, and now NOERROR responses comprise the majority of responses.

**Additionally**: a bug was introduced in a previous PR, which had flannel containers looking for the container image in the wrong place. This PR fixes that too.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/707)
<!-- Reviewable:end -->
