### PR TITLE
Auto-reboot for virtual nodes + updated alerts

### DIFF
--- a/config/prometheus/alerts.yml
+++ b/config/prometheus/alerts.yml
@@ -240,7 +240,7 @@ groups:
       dashboard: https://grafana.mlab-oti.measurementlab.net/d/_fugwnWZk/ops-tactical-and-sre-overview
 
   # Too many OS releases on the platform for too long. This could happen, for
-  # example, if a new epoxy-images version was onlhy partially deployed to the
+  # example, if a new epoxy-images version was only partially deployed to the
   # platform.
   - alert: PlatformCluster_TooManyOSVersions
     expr: |

--- a/config/prometheus/alerts.yml
+++ b/config/prometheus/alerts.yml
@@ -239,40 +239,42 @@ groups:
       description: https://github.com/m-lab/ops-tracker/wiki/Alerts-&-Troubleshooting#platformhardware_machineuptoolong
       dashboard: https://grafana.mlab-oti.measurementlab.net/d/_fugwnWZk/ops-tactical-and-sre-overview
 
-  # Too many kubelet or kernel versions on the platform for too long. This is
-  # an indication that a rolling reboot has stalled.
-  - alert: PlatformCluster_TooManyKubeletOrKernelVersions
+  # Too many OS releases on the platform for too long. This could happen, for
+  # example, if a new epoxy-images version was onlhy partially deployed to the
+  # platform.
+  - alert: PlatformCluster_TooManyOSVersions
     expr: |
-      count(
-        count by (kubelet_version) (
-          kube_node_info and on(node) kube_node_labels{label_mlab_type="physical"}
+      count (
+        count by (os_release) (
+          label_replace(kube_node_info, "os_release", "$1", "os_image", "Ubuntu ([0-9]{2}.[0-9]{2}).*")
         )
       ) > 1
-      or
-      count(
-        count by (kernel_version) (
-          kube_node_info and on(node) kube_node_labels{label_mlab_type="physical"}
-        )
-      ) > 1
-    for: 7d
+    for: 30d
     labels:
       repo: ops-tracker
       severity: ticket
       cluster: platform
     annotations:
-      summary: Too many kubelet or kernel versions in the cluster for too long.
-      description: >
-        There has been more than one kubelet or kernel version running in the
-        platform cluster for too long. Probably the only reason there should be
-        more than one version in the cluster is when kubernetes and/or CoreOS
-        has been upgraded in epoxy-images and a rolling reboot has not
-        completed to apply those changes. Since CLUO will only reboot a single
-        node at a time, stalls of rolling reboots can be easily caused by a
-        node in a NotReady state.  Check for nodes in a NotReady state, and if
-        necessary delete them from the cluster so the rolling reboot can
-        continue. Looks at the log of the update-operator pod in the
-        reboot-coordinator namespace to see which node it may be stuck on.
-      dashboard: https://grafana.mlab-oti.measurementlab.net/d/tZHLFQRZk/k8s-workload-overview
+      summary: Too many OS versions in the cluster for more than 30d.
+      description: https://github.com/m-lab/ops-tracker/wiki/Alerts-&-Troubleshooting#platformcluster_toomanyosversions 
+      dashboard: https://grafana.mlab-oti.measurementlab.net/d/_fugwnWZk/ops-tactical-and-sre-overview?orgId=1&viewPanel=22
+
+  # Too many kubelet versions on the platform for too long. This could happen, for
+  # example, if an upgrade to kubernetes is only partially completed.
+  - alert: PlatformCluster_TooManyKubeletVersions
+    expr: |
+      count(
+        count by (kubelet_version) (kube_node_info)
+      ) > 1
+    for: 30d
+    labels:
+      repo: ops-tracker
+      severity: ticket
+      cluster: platform
+    annotations:
+      summary: Too many kubelet versions in the cluster for more than 30d.
+      description: https://github.com/m-lab/ops-tracker/wiki/Alerts-&-Troubleshooting#platformcluster_toomanykubeletversions
+      dashboard: https://grafana.mlab-oti.measurementlab.net/d/_fugwnWZk/ops-tactical-and-sre-overview?orgId=1&viewPanel=22
 
   # There is version skew among the core k8s components on one or more API
   # cluster servers.

--- a/manage-cluster/cloud-config_node.yml
+++ b/manage-cluster/cloud-config_node.yml
@@ -102,6 +102,70 @@ write_files:
     [Install]
     WantedBy=multi-user.target
 
+# Instructs systemd to wait for 180s before shutting down or rebooting to give
+# all experiments time to stop serving running tests and Pusher time to upload
+# all data.
+- path: /etc/systemd/system.conf.d/10-timeoutstopsec.conf
+  permissions: 0644
+  owner: root:root
+  content: |
+    [Manager]
+    DefaultTimeoutStopSec=180
+
+# A onehost systemd service to check whether a node needs to be rebooted.
+- path: /etc/systemd/system/check-reboot.service
+  permissions: 0644
+  owner: root:root
+  content: |
+    [Unit]
+    Description=Check system uptime, and reboot the machine if it is too long
+    [Service]
+    Type=oneshot
+    ExecStart=/opt/mlab/bin/check-reboot.sh
+    [Install]
+    WantedBy=multi-user.target
+
+- path: /etc/systemd/system/check-reboot.timer
+  permissions: 0644
+  owner: root:root
+  content: |
+    [Unit]
+    Description=Run check-reboot.service daily
+    [Timer]
+    OnCalendar=daily
+    [Install]
+    WantedBy=multi-user.target
+
+- path: /opt/mlab/bin/check-reboot.sh
+  permissions: 0744
+  owner: root:root
+  content: |
+    #!/bin/bash
+    # The maximum amount of time, in days, that a machine can be up before it gets
+    # automatically rebooted.
+    MAX_DAYS_UP=60
+    # We use Kured (KUbernetes REboot Daemon) to help manage rolling reboots on the
+    # platform. Kured runs as a pod on every node (a DaemonSet) and watches for
+    # a configurable "sentinel" file, the existence of which signals that a reboot
+    # should be performed. When the file is found Kured queues the node for a
+    # reboot. The following value reflects the sentinel file configured for Kured:
+    # https://github.com/m-lab/k8s-support/blob/master/k8s/daemonsets/core/kured.jsonnet#L28
+    REBOOT_SENTINEL_FILE=/var/run/mlab-reboot
+    # Check if the Kured sentinel file already exists. If so, do nothing and exit.
+    if [[ -f $REBOOT_SENTINEL_FILE ]]; then
+      echo "Reboot sentinel file ${REBOOT_SENTINEL_FILE} already exists. Exiting..."
+      exit
+    fi
+    # The first field in /proc/uptime is the machine's uptime in seconds. Here we
+    # convert that to days to make things easier to understand for people.
+    days_up=$(awk '{print int($1 / 60 / 60/ 24)}' /proc/uptime)
+    if [[ $days_up -gt $MAX_DAYS_UP ]]; then
+      echo "Uptime of ${days_up}d exceeds MAX_DAYS_UP=${MAX_DAYS_UP}. Flagging node for reboot..."
+      touch "$REBOOT_SENTINEL_FILE"
+    else
+      echo "Uptime of ${days_up}d does not exceed MAX_DAYS_UP=${MAX_DAYS_UP}. Doing nothing..."
+    fi
+
 runcmd:
 - sysctl --system
 - systemctl restart systemd-modules-load.service
@@ -109,4 +173,6 @@ runcmd:
 - systemctl start containerd
 - systemctl enable configure-tc-fq.service
 - systemctl start configure-tc-fq.service
+- systemctl enable check-reboot.service
+- systemctl enable check-reboot.timer
 

--- a/manage-cluster/update_virtual_nodes_config.sh
+++ b/manage-cluster/update_virtual_nodes_config.sh
@@ -37,14 +37,13 @@ for instance in $(echo "$INSTANCES"); do
   # Normally, cloud-init only runs most modules a single time per VM (when it
   # is first created). However, running `cloud-init clean` will clean out all
   # cloud-init configuration data, causing cloud-init to run all modules on the
-  # next boot. Pipe all output to /dev/null, since gcloud gets upset when the
-  # SSH connection is disconnected by the reboot.
+  # next boot. Shutdown one minute in the future so that the SSH session can
+  # exit cleanly.
   echo "Running 'cloud-init clean' and rebooting ${vm}..."
   gcloud compute ssh $vm \
     --quiet \
     --project "$PROJECT" \
     --zone "$zone" -- \
-    'sudo cloud-init clean && sudo reboot' \
-    &> /dev/null
+    'sudo cloud-init clean && sudo shutdown -r +1'
 done
 

--- a/manage-cluster/update_virtual_nodes_config.sh
+++ b/manage-cluster/update_virtual_nodes_config.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+#
+# A script for applying an updated cloud-init config to all project VMs that
+# are part of the platform cluster.
+# 
+# NOTE: Running `cloud-init clean` causes the host's ssh private keys to be
+# regenerated, which will causes errors about the host key changing the next
+# time you try to ssh into the VM.
+
+PROJECT=${1:? Please provide a GCP project}
+CLOUDINIT_FILE=${2:-./cloud-config_node.yml}
+
+# Make sure that the cloud-init config file exists.
+if ! [[ -f $CLOUDINIT_FILE ]]; then
+  echo "cloud-init config file not found: ${CLOUDINIT_FILE}"
+  exit 1
+fi
+
+INSTANCES=$(
+  gcloud compute instances list \
+    --filter "name~^mlab[1-4].*" \
+    --project "$PROJECT" \
+    --format "csv[no-heading](name, zone)"
+)
+
+for instance in $(echo "$INSTANCES"); do
+  vm=$(echo "$instance" | cut -d, -f1)
+  zone=$(echo "$instance" | cut -d, -f2)
+
+  # Update the "user-data" metadata value for the instance, which is used by
+  # cloud-init to configure the VM.
+  gcloud compute instances add-metadata $vm \
+    --metadata-from-file="user-data=${CLOUDINIT_FILE}" \
+    --project "$PROJECT" \
+    --zone "$zone"
+
+  # Normally, cloud-init only runs most modules a single time per VM (when it
+  # is first created). However, running `cloud-init clean` will clean out all
+  # cloud-init configuration data, causing cloud-init to run all modules on the
+  # next boot. Pipe all output to /dev/null, since gcloud gets upset when the
+  # SSH connection is disconnected by the reboot.
+  echo "Running 'cloud-init clean' and rebooting ${vm}..."
+  gcloud compute ssh $vm \
+    --quiet \
+    --project "$PROJECT" \
+    --zone "$zone" -- \
+    'sudo cloud-init clean && sudo reboot' \
+    &> /dev/null
+done
+


### PR DESCRIPTION
This PR adds the appropriate systemd service and timer, as well as a shell script, which should cause the virtual nodes to be rebooted when uptime exceeds 60d. Also included is a change which should cause systemd to wait for 180s before shutting down or rebooting the node. These features have already existed for physical nodes for quite a while, and this PR now brings this same functionality to virtual nodes. 

I also took this opportunity to modify the old alert `PlatformCluster_TooManyKubeletOrKernelVersions`, and break it apart into two new alerts:

* `PlatformCluster_TooManyOSVersions`: this alert now takes the place of the part of the old one that checked kernel versions. With the introduction of virtual nodes onto the platform, we can no longer guarantee that exactly one kernel version is running. Kernel version was probably too specific to begin with. This alert now just checks to be sure that all nodes are running the same Ubuntu OS release (e.g., "20.04").
* `PlatformCluster_TooManyKubeletVersions`: Like before, this alert just makes sure that there is only a single kubelet version on all nodes.

I have also bumped up the time threshold from 7d to 30d for these alerts. Sometimes upgrading kubernetes or the base OS can take some time, and this change gives us plenty of time for those things to happen with no rush.

Additionally, this PR introduces a small operator script which can facilitate updating all virtual nodes. It can only introduce changes that are part of the cloud-init system. The script overwrites the `user-data` metadata field of a virtual node (which is what cloud-init uses for it's config), then "clean"s the cloud-init directory on the node, such that on the next reboot cloud-init will reprocess the newly uploaded config, as if this was a branch new VM. This script perhaps isn't ideal, but it is a small stopgap until we can find a more permanent solution like Terraform.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/711)
<!-- Reviewable:end -->
