### PR TITLE
Adds a new alert for when configuration of the fq qdisc fails

### DIFF
--- a/config/prometheus/alerts.yml
+++ b/config/prometheus/alerts.yml
@@ -276,6 +276,20 @@ groups:
       description: https://github.com/m-lab/ops-tracker/wiki/Alerts-&-Troubleshooting#platformcluster_toomanykubeletversions
       dashboard: https://grafana.mlab-oti.measurementlab.net/d/_fugwnWZk/ops-tactical-and-sre-overview?orgId=1&viewPanel=22
 
+  # Configuration of the "fq" qdisc on the primary network interface failed, or
+  # the metric is missing for a machine.
+  - alert: PlatformCluster_ConfigureQdiscFailedOrMissing
+    expr: |
+      kube_node_info{node=~"mlab[1-4].*"} unless on(node) node_configure_qdisc_success == 1
+    for: 1h
+    labels:
+      repo: ops-tracker
+      severity: ticket
+      cluster: platform
+    annotations:
+      summary: Configuration of the fq qdisc failed, or the metric is missing.
+      description: https://github.com/m-lab/ops-tracker/wiki/Alerts-&-Troubleshooting#platformcluster_configureqdiscfailedormissing
+
   # There is version skew among the core k8s components on one or more API
   # cluster servers.
   - alert: PlatformCluster_ApiClusterComponentVersionSkew


### PR DESCRIPTION
In this alert, we filter the list of all nodes that either don't have the metric `node_configure_qdisc_success == 1` or the metric is missing for that node.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/712)
<!-- Reviewable:end -->
