### PR TITLE
Fix bbr metric name w/ v0.20.12

### DIFF
--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -1,7 +1,7 @@
-local ndtVersion = 'v0.20.11';
+local ndtVersion = 'v0.20.12';
 // The canary version is expected to be greater than or equal to
 // the current stable version.
-local ndtCanaryVersion = 'v0.20.11';
+local ndtCanaryVersion = 'v0.20.12';
 local PROJECT_ID = std.extVar('PROJECT_ID');
 
 // The default grace period after k8s sends SIGTERM is 30s. We


### PR DESCRIPTION
Include metric name fix from https://github.com/m-lab/ndt-server/pull/366

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/713)
<!-- Reviewable:end -->
