### PR TITLE
Increase ndt-virtual rate limit to match 10g uplinks

### DIFF
--- a/k8s/daemonsets/experiments/ndt-virtual.jsonnet
+++ b/k8s/daemonsets/experiments/ndt-virtual.jsonnet
@@ -66,7 +66,7 @@ exp.ExperimentNoIndex(expName, 'pusher-' + std.extVar('PROJECT_ID'), 'none', dat
               '-token.machine=$(NODE_NAME)',
               '-token.verify-key=/verify/jwk_sig_EdDSA_locate_20200409.pub',
               '-txcontroller.device=ens4',
-              '-txcontroller.max-rate=150000000',
+              '-txcontroller.max-rate=2500000000',
               '-label=type=virtual',
               '-label=deployment=canary',
               '-label=external-ip=@' + metadata.path + '/external-ip',


### PR DESCRIPTION
This change increases the txcontroller max rate for virtual nodes to the limit suitable for 10Gbps uplinks.

This change is a work around for the known issue with the txcontroller failing to be direction aware (https://github.com/m-lab/ndt-server/issues/334). So, after a fast download test, the upload connection fails. Since the previous ndt-server txcontroller rate limit was set for 1Gbps uplinks, many clients are able to exceed this threshold. And, few ndt clients support "trying the next locate result" (https://github.com/m-lab/ndt7-js/issues/9) which makes the frequency of this higher for cloud nodes.

FYI: @mattmathis

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/714)
<!-- Reviewable:end -->
