### PR TITLE
Updates Kured to v1.10.0

### DIFF
--- a/k8s/daemonsets/core/kured.jsonnet
+++ b/k8s/daemonsets/core/kured.jsonnet
@@ -51,7 +51,7 @@
                 },
               },
             ],
-            image: 'weaveworks/kured:1.8.2',
+            image: 'weaveworks/kured:1.10.0',
             imagePullPolicy: 'IfNotPresent',
             name: 'kured',
             ports: [


### PR DESCRIPTION
The release notes for v1.10.0 say this:

> With this release kured will retry to cordon and uncordon a node in
> case it fails.  This should prevent nodes from being "Unschedulable"
> forever.

Hopefully this resolves the issue we have of nodes remaining cordoned
when they fail to come back up after a reboot in a timely fashion and
Kured moves on to the next node after 4h.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/715)
<!-- Reviewable:end -->
