### PR TITLE
Prototype: Add experimental revtr sidecar

### DIFF
--- a/k8s/daemonsets/experiments/ndt.jsonnet
+++ b/k8s/daemonsets/experiments/ndt.jsonnet
@@ -100,7 +100,7 @@ exp.Experiment(expName, 2, 'pusher-' + std.extVar('PROJECT_ID'), "none", datatyp
           // NOTE: exclude from production until design doc is approved, service
           // is monitored and scales to millions of requests/day.
           if PROJECT_ID == 'mlab-sandbox' then [ exp.Revtr(expName) ] else []
-        ),
+        ]),
         volumes+: [
           {
             name: 'measurement-lab-org-tls',

--- a/k8s/daemonsets/experiments/ndt.jsonnet
+++ b/k8s/daemonsets/experiments/ndt.jsonnet
@@ -95,6 +95,10 @@ exp.Experiment(expName, 2, 'pusher-' + std.extVar('PROJECT_ID'), "none", datatyp
           }
         ] + std.flattenArrays([
           exp.Heartbeat(expName, false, services),
+        ]) + std.flattenArrays([
+          // NOTE: exclude from production until design doc is approved, service
+          // is monitored and scales to millions of requests/day.
+          exp.Revtr(expName),
         ]),
         volumes+: [
           {
@@ -110,6 +114,12 @@ exp.Experiment(expName, 2, 'pusher-' + std.extVar('PROJECT_ID'), "none", datatyp
             },
           },
           exp.Metadata.volume,
+          {
+            name: 'revtr-apikey',
+            secret: {
+              secretName: 'revtr-apikey',
+            },
+          },
         ],
       },
     },

--- a/k8s/daemonsets/experiments/ndt.jsonnet
+++ b/k8s/daemonsets/experiments/ndt.jsonnet
@@ -99,7 +99,7 @@ exp.Experiment(expName, 2, 'pusher-' + std.extVar('PROJECT_ID'), "none", datatyp
         ]) + std.flattenArrays([
           // NOTE: exclude from production until design doc is approved, service
           // is monitored and scales to millions of requests/day.
-          if PROJECT_ID == 'mlab-sandbox' then [ exp.Revtr(expName) ] else []
+          if PROJECT_ID == 'mlab-sandbox' then exp.Revtr(expName) else []
         ]),
         volumes+: [
           {

--- a/k8s/daemonsets/experiments/ndt.jsonnet
+++ b/k8s/daemonsets/experiments/ndt.jsonnet
@@ -5,6 +5,7 @@ local services = [
   'ndt/ndt7=ws:///ndt/v7/download,ws:///ndt/v7/upload,wss:///ndt/v7/download,wss:///ndt/v7/upload',
   'ndt/ndt5=ws://:3001/ndt_protocol,wss://:3010/ndt_protocol',
 ];
+local PROJECT_ID = std.extVar('PROJECT_ID');
 
 exp.Experiment(expName, 2, 'pusher-' + std.extVar('PROJECT_ID'), "none", datatypes, []) + {
   spec+: {
@@ -98,8 +99,8 @@ exp.Experiment(expName, 2, 'pusher-' + std.extVar('PROJECT_ID'), "none", datatyp
         ]) + std.flattenArrays([
           // NOTE: exclude from production until design doc is approved, service
           // is monitored and scales to millions of requests/day.
-          exp.Revtr(expName),
-        ]),
+          if PROJECT_ID == 'mlab-sandbox' then [ exp.Revtr(expName) ] else []
+        ),
         volumes+: [
           {
             name: 'measurement-lab-org-tls',

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -610,8 +610,9 @@ local Revtr(expName, tcpPort) = [
         },
       },
     ],
-    // TODO: add ports for monitoring the revtr sidecar.
-    ports: [],
+    ports: [
+      tcpPort,
+    ],
     volumeMounts: [
       tcpinfoServiceVolume.volumemount,
     ],

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -207,7 +207,7 @@ local Tcpinfo(expName, tcpPort, hostNetwork, anonMode) = [
       '-output=' + data.mount(expName).mountPath + '/tcpinfo',
       '-uuid-prefix-file=' + uuid.prefixfile,
       '-tcpinfo.eventsocket=' + tcpinfoServiceVolume.socketFilename,
-      '-exclude-srcport=9100,9090,9091,9989,9990,9991,9992,9993,9994,9995,9996,9997',
+      '-exclude-srcport=9100,9090,9091,9989,9990,9991,9992,9993,9994,9995,9996,9997,9998',
       // Exclude k8s api server, kube-ip static ips mlab-oti and mlab-staging.
       '-exclude-dstip=172.25.0.1,35.202.153.90,35.188.150.110,35.185.54.7,35.243.193.167',
       '-anonymize.ip=' + anonMode,
@@ -594,6 +594,8 @@ local Revtr(expName, tcpPort) = [
       '-tcpinfo.eventsocket=' + tcpinfoServiceVolume.socketFilename,
       '-revtr.hostname=revtr.ccs.neu.edu',
       '-revtr.grpcPort=9999',
+      '-prometheus.port='+tcpPort,
+      '-revtr.sampling=100',
       '-revtr.APIKey=$(REVTR_APIKEY)',
       '-loglevel=debug',
     ],
@@ -883,7 +885,7 @@ local Experiment(name, index, bucket, anonMode, datatypes=[], datatypesAutoloade
   Metadata:: Metadata,
 
   // Returns a "container" configuration for the revtr sidecar container.
-  Revtr(expName):: Revtr(expName, 9997),
+  Revtr(expName):: Revtr(expName, 9998),
 
   // Helper object containing uuid-related filenames, volumes, and volumemounts.
   uuid: uuid,

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -589,7 +589,7 @@ local UUIDAnnotator(expName, tcpPort, hostNetwork) = [
 local Revtr(expName, tcpPort) = [
   {
     name: 'revtr-sidecar',
-    image: 'kvermeul/revtr-sidecar:1.0',
+    image: 'kvermeul/revtr-sidecar:v1.1.1',
     args: [
       '-tcpinfo.eventsocket=' + tcpinfoServiceVolume.socketFilename,
       '-revtr.hostname=revtr.ccs.neu.edu',

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -586,6 +586,37 @@ local UUIDAnnotator(expName, tcpPort, hostNetwork) = [
   else []
 ;
 
+local Revtr(expName, tcpPort) = [
+  {
+    name: 'revtr-sidecar',
+    image: 'kvermeul/revtr-sidecar:1.0',
+    args: [
+      '-tcpinfo.eventsocket=' + tcpinfoServiceVolume.socketFilename,
+      '-revtr.hostname=revtr.ccs.neu.edu',
+      '-revtr.grpcPort=9999',
+      '-revtr.APIKey=$(REVTR_APIKEY)',
+      '-loglevel=debug',
+    ],
+    env: [
+      {
+        name: 'REVTR_APIKEY',
+        valueFrom: {
+          secretKeyRef: {
+            name: 'revtr-apikey',
+            key: 'revtr-apikey-txt',
+          },
+        },
+      },
+    ],
+    // TODO: add ports for monitoring the revtr sidecar.
+    ports: [],
+    volumeMounts: [
+      tcpinfoServiceVolume.volumemount,
+    ],
+  }
+]
+;
+
 local Heartbeat(expName, tcpPort, hostNetwork, services) = [
   {
     name: 'heartbeat',
@@ -850,6 +881,9 @@ local Experiment(name, index, bucket, anonMode, datatypes=[], datatypesAutoloade
 
   // Volumes, volumemounts and other data and configs for experiment metadata.
   Metadata:: Metadata,
+
+  // Returns a "container" configuration for the revtr sidecar container.
+  Revtr(expName):: Revtr(expName, 9997),
 
   // Helper object containing uuid-related filenames, volumes, and volumemounts.
   uuid: uuid,

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -611,7 +611,7 @@ local Revtr(expName, tcpPort) = [
       },
     ],
     ports: [
-      tcpPort,
+      {containerPort: tcpPort},
     ],
     volumeMounts: [
       tcpinfoServiceVolume.volumemount,

--- a/manage-cluster/create_k8s_configs.sh
+++ b/manage-cluster/create_k8s_configs.sh
@@ -50,6 +50,7 @@ gsutil cp gs://${!GCS_BUCKET_K8S}/prometheus-htpasswd secrets/auth
 gsutil cp gs://${!GCS_BUCKET_K8S}/alertmanager-basicauth.yaml secret-configs/.
 gsutil cp -R gs://${!GCS_BUCKET_K8S}/locate secrets/.
 gsutil cp -R gs://${!GCS_BUCKET_K8S}/locate-heartbeat secrets/.
+gsutil cp -R gs://${!GCS_BUCKET_K8S}/revtr-apikey secrets/.
 
 # Convert secret data into configs.
 kubectl create secret generic uuid-annotator-credentials --from-file secrets/uuid-annotator.json \
@@ -74,4 +75,6 @@ kubectl create secret generic locate-verify-keys --from-file secrets/locate/ \
     --dry-run=client -o json > secret-configs/locate-verify-keys.json
 kubectl create secret generic locate-heartbeat-key --from-file secrets/locate-heartbeat/ \
     --dry-run=client -o json > secret-configs/locate-heartbeat-key.json
+kubectl create secret generic revtr-apikey --from-file secrets/revtr-apikey/ \
+    --dry-run=client -o json > secret-configs/revtr-apikey.json
 


### PR DESCRIPTION
This change adds the first proof of concept for the revtr sidecar. This will explicitly pin the service to the sandbox and later staging before enabling production deployment after the design doc is approved, service is monitored, and scales to millions of requests/day.

See design in: https://docs.google.com/document/d/144T41U2HWq_wmunjK-d-iYRYa2oZ_Yj5s2stLGKPjAY/edit#heading=h.h36iwjyf1xe3

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/717)
<!-- Reviewable:end -->
