### PR TITLE
Update NDT server for directional TxController

### DIFF
--- a/k8s/daemonsets/experiments/ndt.jsonnet
+++ b/k8s/daemonsets/experiments/ndt.jsonnet
@@ -21,7 +21,7 @@ exp.Experiment(expName, 2, 'pusher-' + std.extVar('PROJECT_ID'), "none", datatyp
         containers+: [
           {
             name: 'ndt-server',
-            image: 'measurementlab/ndt-server:' + exp.ndtVersion,
+            image: 'soltesz/ndt-server:v0.21.0', // measurementlab/ndt-server:' + exp.ndtVersion,
             // This command section is somewhat of a workaround to get a value
             // to pass to the -max-rate flag of ndt-server. The default
             // ENTRYPOINT for the ndt-server image is /ndt-server, but this

--- a/k8s/daemonsets/experiments/ndt.jsonnet
+++ b/k8s/daemonsets/experiments/ndt.jsonnet
@@ -21,7 +21,7 @@ exp.Experiment(expName, 2, 'pusher-' + std.extVar('PROJECT_ID'), "none", datatyp
         containers+: [
           {
             name: 'ndt-server',
-            image: 'soltesz/ndt-server:v0.21.0', // measurementlab/ndt-server:' + exp.ndtVersion,
+            image: 'measurementlab/ndt-server:' + exp.ndtVersion,
             // This command section is somewhat of a workaround to get a value
             // to pass to the -max-rate flag of ndt-server. The default
             // ENTRYPOINT for the ndt-server image is /ndt-server, but this

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -1,7 +1,7 @@
-local ndtVersion = 'v0.20.12';
+local ndtVersion = 'v0.20.14';
 // The canary version is expected to be greater than or equal to
 // the current stable version.
-local ndtCanaryVersion = 'v0.20.12';
+local ndtCanaryVersion = 'v0.20.14';
 local PROJECT_ID = std.extVar('PROJECT_ID');
 
 // The default grace period after k8s sends SIGTERM is 30s. We


### PR DESCRIPTION
This change updates the ndt-server to v0.20.14 which includes recent changes to enable explicit TxController directional resources, in order to fix https://github.com/m-lab/ndt-server/issues/334

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/718)
<!-- Reviewable:end -->
