### PR TITLE
Use M-Lab specific landing page for ndt-virtual configuration

### DIFF
--- a/k8s/daemonsets/experiments/ndt-virtual.jsonnet
+++ b/k8s/daemonsets/experiments/ndt-virtual.jsonnet
@@ -58,6 +58,7 @@ exp.ExperimentNoIndex(expName, 'pusher-' + std.extVar('PROJECT_ID'), 'none', dat
               '-ndt5_ws_addr=:3001',
               '-ndt5.token.required=true',
               '-ndt7.token.required=true',
+              '-htmldir=html/mlab',
               '-uuid-prefix-file=' + exp.uuid.prefixfile,
               '-prometheusx.listen-address=127.0.0.1:9990',
               '-datadir=/var/spool/' + expName,


### PR DESCRIPTION
This change adds the same `-htmldir` flag used by the physical deployment for NDT to report an mlab specific landing page with pointers to the M-Lab website and support address.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/720)
<!-- Reviewable:end -->
