### PR TITLE
Update ndt to v0.20.16

### DIFF
--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -1,7 +1,7 @@
-local ndtVersion = 'v0.20.15';
+local ndtVersion = 'v0.20.16';
 // The canary version is expected to be greater than or equal to
 // the current stable version.
-local ndtCanaryVersion = 'v0.20.15';
+local ndtCanaryVersion = 'v0.20.16';
 local PROJECT_ID = std.extVar('PROJECT_ID');
 
 // The default grace period after k8s sends SIGTERM is 30s. We


### PR DESCRIPTION
Update ndt to latest version. This incorporates changes to reduce default log levels and add new error message label to the `ndt7_measurer_bbr_enabled_total` metric so we can effectively alert on failures enabling BBR.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/724)
<!-- Reviewable:end -->
