### PR TITLE
Adds an alert for when ndt-server can't enable BBR

### DIFF
--- a/config/prometheus/alerts.yml
+++ b/config/prometheus/alerts.yml
@@ -297,9 +297,9 @@ groups:
   # module is not loaded.
   - alert: PlatformCluster_BBRmoduleMissing
     expr: |
-      ndt7_measurer_bbr_enabled_total{error="no such file or directory"} > 0
+      increase(ndt7_measurer_bbr_enabled_total{error="no such file or directory"}[5m]) > 0
         unless on(node) gmx_machine_maintenance == 1
-    for: 10m
+    for: 15m
     labels:
       repo: ops-tracker
       severity: ticket

--- a/config/prometheus/alerts.yml
+++ b/config/prometheus/alerts.yml
@@ -293,6 +293,21 @@ groups:
       summary: Configuration of the fq qdisc failed, or the metric is missing.
       description: https://github.com/m-lab/ops-tracker/wiki/Alerts-&-Troubleshooting#platformcluster_configureqdiscfailedormissing
 
+  # The ndt-server is unable to enable BBR for ndt7 tests because the tcp_bbr
+  # module is not loaded.
+  - alert: PlatformCluster_BBRmoduleMissing
+    expr: |
+      ndt7_measurer_bbr_enabled_total{error="no such file or directory"} > 0
+        unless on(node) gmx_machine_maintenance == 1
+    for: 10m
+    labels:
+      repo: ops-tracker
+      severity: ticket
+      cluster: platform
+    annotations:
+      summary: The ndt-server is unable to enable BBR because the kernel module isn't loaded
+      description: https://github.com/m-lab/ops-tracker/wiki/Alerts-&-Troubleshooting#platformcluster_bbrmodulemissing
+
   # There is version skew among the core k8s components on one or more API
   # cluster servers.
   - alert: PlatformCluster_ApiClusterComponentVersionSkew


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/725)
<!-- Reviewable:end -->
