### PR TITLE
Adds "lame-duck" tolerations to several core DaemonSets

### DIFF
--- a/k8s/daemonsets/core/cadvisor.jsonnet
+++ b/k8s/daemonsets/core/cadvisor.jsonnet
@@ -69,6 +69,13 @@
             ],
           },
         ],
+        tolerations: [
+          {
+            effect: 'NoSchedule',
+            key: 'lame-duck',
+            operator: 'Exists',
+          },
+        ],
         volumes: [
           {
             hostPath: {

--- a/k8s/daemonsets/core/kured.jsonnet
+++ b/k8s/daemonsets/core/kured.jsonnet
@@ -68,6 +68,13 @@
         hostPID: true,
         restartPolicy: 'Always',
         serviceAccountName: 'kured',
+        tolerations: [
+          {
+            effect: 'NoSchedule',
+            key: 'lame-duck',
+            operator: 'Exists',
+          },
+        ],
       },
     },
     updateStrategy: {

--- a/k8s/daemonsets/core/node-exporter.jsonnet
+++ b/k8s/daemonsets/core/node-exporter.jsonnet
@@ -124,6 +124,11 @@
         tolerations: [
           {
             effect: 'NoSchedule',
+            key: 'lame-duck',
+            operator: 'Exists',
+          },
+          {
+            effect: 'NoSchedule',
             key: 'node-role.kubernetes.io/master',
           },
           {

--- a/manage-cluster/add_ndt_virtual_site.sh
+++ b/manage-cluster/add_ndt_virtual_site.sh
@@ -12,10 +12,6 @@ PROJECT=${1:? Please specify a GCP project: ${USAGE}}
 CLOUD_SITE=${2:? Please specify a cloud site name: ${USAGE}}
 CLOUD_ZONE=${3:? Please specify the GCP zone for this VM: ${USAGE}}
 
-# List of GCP regions which support external IPv6 addresses for GCE VMs:
-# https://cloud.google.com/vpc/docs/vpc#ipv6-regions
-IPV6_REGIONS="asia-east1 asia-south1 europe-west2 us-west2"
-
 if [[ "${PROJECT}" == "mlab-sandbox" ]]; then
   SITE_REGEX="[a-z]{3}[0-9]t"
 else
@@ -64,12 +60,6 @@ else
       "${GCP_ARGS[@]}")
 fi
 
-if echo $IPV6_REGIONS | grep "${GCE_REGION}"; then
-  IPV6_FLAGS=("--stack-type=IPV4_IPV6" "--ipv6-access-type=EXTERNAL")
-else
-  export IPV6_FLAGS=""
-fi
-
 # If a subnet for the region of this VM doesn't already exist, then create it.
 EXISTING_SUBNET=$(gcloud compute networks subnets list \
     --filter "name=${GCE_K8S_SUBNET} AND region:( ${GCE_REGION} )" \
@@ -82,7 +72,8 @@ if [[ -z "${EXISTING_SUBNET}" ]]; then
       --network "${GCE_NETWORK}" \
       --range "10.${N}.0.0/16" \
       --region "${GCE_REGION}" \
-      ${IPV6_FLAGS[@]} \
+      --stack-type "IPV4_IPV6" \
+      --ipv6-access-type "EXTERNAL" \
       "${GCP_ARGS[@]}"
 fi
 


### PR DESCRIPTION
We use a node taint with key "lame-duck" as a way to sometimes take a node out of production. The issue is that this taint will also cause certain essential workloads to not be scheduled on the node, if they weren't already running there. This PR adds tolerations for this taint to the `node-exporter`, `cadvisor` and `kured` DaemonSets so that essential metrics don't vanish when a node is in lame-duck mode.

Additionally, I accidentally discovered a week or so ago that GCP has apparently enabled IPv6 on GCE VMs in pretty much all GCP regions. To accommodate for this, this PR also includes changes to unconditionally create all virtual platform nodes with a dual stack configuration.

Finally, I discovered that the "n1" machine-type may not be available in all regions (e.g., us-east5), but "n2" should be, so this PR sets the default VM type to `n2-highcpu-4`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/727)
<!-- Reviewable:end -->
