### PR TITLE
Causes fluent-bit to tolerate lame-duck node taint

### DIFF
--- a/config/fluentbit/values.yaml.template
+++ b/config/fluentbit/values.yaml.template
@@ -150,5 +150,8 @@ podAnnotations:
   prometheus.io/metrics_path: /api/v1/metrics/prometheus
 podLabels:
   workload: fluentbit
-
+tolerations:
+- effect: NoSchedule
+  key: lame-duck
+  operator: Exists
 


### PR DESCRIPTION
If fluent-bit is not running on a node, then alerts will start to fire about container logs missing in Stackdriver. This PR causes fluent-bit to tolerate the "lame-duck" taint we occasionally use to take a node of production.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/728)
<!-- Reviewable:end -->
