### PR TITLE
Removes --hostname-override from /etc/default/kubelet

### DIFF
--- a/manage-cluster/add_k8s_virtual_node.sh
+++ b/manage-cluster/add_k8s_virtual_node.sh
@@ -212,7 +212,7 @@ gcloud compute ssh "${GCE_NAME}" "${GCE_ARGS[@]}" <<EOF
   # Override the node name, which without this will be something like:
   #     ${K8S_NODE_NAME}.c.mlab-sandbox.internal
   # https://kubernetes.io/docs/concepts/architecture/nodes/#addresses
-  echo "KUBELET_EXTRA_ARGS='--hostname-override ${K8S_NODE_NAME} --node-ip ${INTERNAL_IP}'" > /etc/default/kubelet
+  echo "KUBELET_EXTRA_ARGS='--node-ip=${INTERNAL_IP}'" > /etc/default/kubelet
 
   # Enable and start the kubelet service
   systemctl enable --now kubelet.service


### PR DESCRIPTION
The kubelet flag in this location is redundant, as it is already specified in the kubeadm config:

https://github.com/m-lab/k8s-support/blob/main/manage-cluster/kubeadm-config.yml.template#L51

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/731)
<!-- Reviewable:end -->
