### PR TITLE
Configurations necessary for upgrade to k8s v1.22.15

### DIFF
--- a/config/fluentbit/values.yaml.template
+++ b/config/fluentbit/values.yaml.template
@@ -138,7 +138,7 @@ initContainers:
     [FILTER]
         Name kubernetes
         Match kube.*
-        Buffer_Size 2MB
+        Buffer_Size 0
         Use_Kubelet true
         Kubelet_Host ${KUBELET_HOST}
         tls.verify Off

--- a/config/fluentbit/values.yaml.template
+++ b/config/fluentbit/values.yaml.template
@@ -138,7 +138,7 @@ initContainers:
     [FILTER]
         Name kubernetes
         Match kube.*
-        Buffer_Size 1MB
+        Buffer_Size 2MB
         Use_Kubelet true
         Kubelet_Host ${KUBELET_HOST}
         tls.verify Off

--- a/manage-cluster/bootstrap_prometheus.sh
+++ b/manage-cluster/bootstrap_prometheus.sh
@@ -232,4 +232,8 @@ EOF2
       # TODO: replace with native k8s persistent volumes, if possible.
       chown nobody:nogroup /mnt/local/prometheus/
   fi
+
+  # The kubelet will complain about this directory not existing every few
+  # seconds, terribly polluting the logs.
+  mkdir -p /etc/kubernetes/manifests
 EOF

--- a/manage-cluster/k8s_deploy.conf
+++ b/manage-cluster/k8s_deploy.conf
@@ -28,18 +28,18 @@ PROM_BASE_NAME="prometheus-${GCE_BASE_NAME}"
 # we learn more.
 GCE_API_SCOPES="cloud-platform"
 
-K8S_VERSION="v1.21.14"
+K8S_VERSION="v1.22.15"
 K8S_CNI_VERSION="v1.1.1"
-K8S_CRICTL_VERSION="v1.21.0"
+K8S_CRICTL_VERSION="v1.22.1"
 # FLANNEL is for the flannel DaemonSet, whereas FLANNELCNI is for the CNI
 # plugin located at /opt/cni/bin (used by the kubelet).
-K8S_FLANNEL_VERSION="v0.19.0"
+K8S_FLANNEL_VERSION="v0.19.2"
 K8S_FLANNELCNI_VERSION=v1.1.0
 K8S_TOOLING_VERSION="v0.14.0"
-ETCDCTL_VERSION="v3.4.14"
-K8S_HELM_VERSION="v3.7.1"
+ETCDCTL_VERSION="v3.5.5"
+K8S_HELM_VERSION="v3.10.0"
 K8S_FLUENTBIT_VERSION="1.9.8-debug"
-K8S_CERTMANAGER_VERSION="v1.6.1"
+K8S_CERTMANAGER_VERSION="v1.9.0"
 K8S_CERTMANAGER_DNS01_SA="cert-manager-dns01-solver"
 K8S_CERTMANAGER_SA_KEY="cert-manager-credentials.json"
 K8S_CA_FILES="ca.crt ca.key sa.key sa.pub front-proxy-ca.crt front-proxy-ca.key etcd/ca.crt etcd/ca.key"

--- a/manage-cluster/kubeadm-config.yml.template
+++ b/manage-cluster/kubeadm-config.yml.template
@@ -1,15 +1,16 @@
-apiVersion: kubeadm.k8s.io/v1beta2
+apiVersion: kubeadm.k8s.io/v1beta3
 kind: InitConfiguration
 nodeRegistration:
   name: "{{MASTER_NAME}}"
   kubeletExtraArgs:
     container-runtime: "remote"
     container-runtime-endpoint: "unix:///run/containerd/containerd.sock"
+  criSocket: "unix:///run/containerd/containerd.sock"
 localAPIEndpoint:
   advertiseAddress: "{{INTERNAL_IP}}"
   bindPort: 6443
 ---
-apiVersion: kubeadm.k8s.io/v1beta2
+apiVersion: kubeadm.k8s.io/v1beta3
 kind: JoinConfiguration
 discovery:
   bootstrapToken:
@@ -28,7 +29,7 @@ nodeRegistration:
     container-runtime: "remote"
     container-runtime-endpoint: "unix:///run/containerd/containerd.sock"
 ---
-apiVersion: kubeadm.k8s.io/v1beta2
+apiVersion: kubeadm.k8s.io/v1beta3
 kind: ClusterConfiguration
 kubernetesVersion: {{K8S_VERSION}}
 apiServer:

--- a/node/setup_k8s.sh.template
+++ b/node/setup_k8s.sh.template
@@ -41,8 +41,7 @@ MASTER_NODE="api-platform-cluster.${GCP_PROJECT}.measurementlab.net"
 RELEASE=$(kubelet --version | awk '{print $2}')
 
 NODE_LABELS="mlab/machine=${MACHINE},mlab/site=${SITE},mlab/metro=${METRO},mlab/type=physical,mlab/project=${GCP_PROJECT},mlab/ndt-version=production"
-DYNAMIC_CONFIG_DIR="/var/lib/kubelet/dynamic-configs"
-sed -ie "s|KUBELET_KUBECONFIG_ARGS=|KUBELET_KUBECONFIG_ARGS=--node-labels=$NODE_LABELS --dynamic-config-dir=$DYNAMIC_CONFIG_DIR |g" \
+sed -ie "s|KUBELET_KUBECONFIG_ARGS=|KUBELET_KUBECONFIG_ARGS=--node-labels=$NODE_LABELS |g" \
   /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
 
 # Make the directory /etc/kubernetes/manifests. The declaration staticPodPath in


### PR DESCRIPTION
Most of the changes in this PR are related to upgrading k8s to v1.22.15.

The other two unrelated changes are:

* Sets fluent-bit's kubernetes filter setting `Buffer_Size` to 0, which means the buffer can grow as large as needed. We had a situation where a bunch of evicted pods were causing the kubelet's response to its `/pods` endpoint to return more than 1MB of data, causing the filter to fail.
* Creates directory /etc/kubernetes/manifests when bootstrapping a Prometheus VM to avoid log-polluting messages about that directory not existing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/732)
<!-- Reviewable:end -->
