### PR TITLE
Removes maxrate setting for fq qdisc on virtual nodes

### DIFF
--- a/manage-cluster/add_ndt_virtual_node.sh
+++ b/manage-cluster/add_ndt_virtual_node.sh
@@ -11,7 +11,7 @@ USAGE="USAGE: $0 <cloud-project> <cloud-site> <gce-zone> [<machine-name>]"
 PROJECT=${1:? Please specify a GCP project: ${USAGE}}
 CLOUD_SITE=${2:? Please specify a cloud site name: ${USAGE}}
 CLOUD_ZONE=${3:? Please specify the GCP zone for this VM: ${USAGE}}
-MACHINE_NAME=$4
+MACHINE_NAME=${4:-""}
 
 if [[ "${PROJECT}" == "mlab-sandbox" ]]; then
   SITE_REGEX="[a-z]{3}[0-9]t"

--- a/manage-cluster/add_ndt_virtual_node.sh
+++ b/manage-cluster/add_ndt_virtual_node.sh
@@ -7,7 +7,7 @@
 
 set -euxo pipefail
 
-USAGE="USAGE: $0 <cloud-project> <cloud-site> <gce-zone>"
+USAGE="USAGE: $0 <cloud-project> <cloud-site> <gce-zone> [<machine-name>]"
 PROJECT=${1:? Please specify a GCP project: ${USAGE}}
 CLOUD_SITE=${2:? Please specify a cloud site name: ${USAGE}}
 CLOUD_ZONE=${3:? Please specify the GCP zone for this VM: ${USAGE}}

--- a/manage-cluster/cloud-config_node.yml
+++ b/manage-cluster/cloud-config_node.yml
@@ -75,7 +75,7 @@ write_files:
       exit 1
     fi
     write_metric_file 1
-    echo "Set qdisc fq on root of dev ens4"
+    echo "Set qdisc fq on root of dev ${IFACE}"
 
 # systemd service for configuring the fq qdisc on boot.
 - path: /etc/systemd/system/configure-tc-fq.service

--- a/manage-cluster/cloud-config_node.yml
+++ b/manage-cluster/cloud-config_node.yml
@@ -53,9 +53,6 @@ write_files:
     #!/bin/bash
     # Determine the default/primary network interface of the VM.
     IFACE=$(ip -o -4 route show default | awk '{print $5}')
-    # For vitual machines we set the fq qdisc maxrate to 10g, here expressed as
-    # bytes per second.
-    MAXRATE="1250000000"
     # This script writes out a Prometheus metric file which will be collected by the
     # node_exporter textfile collector. Make sure that METRIC_DIR exists.
     METRIC_DIR=/cache/data/node-exporter
@@ -71,22 +68,14 @@ write_files:
       mv $METRIC_FILE_TEMP $METRIC_FILE
       chmod 644 $METRIC_FILE
     }
-    tc qdisc replace dev $IFACE root fq maxrate "${MAXRATE}bps"
+    tc qdisc replace dev $IFACE root fq
     if [[ $? -ne 0 ]]; then
-      echo "Failed to configure qdisc fq on dev ${IFACE} with max rate of: ${MAXRATE}"
-      write_metric_file 0
-      exit 1
-    fi
-    # Even though tc's exit code was 0, be 100% sure that the configured value for
-    # maxrate is what we expect.
-    configured_maxrate=$(tc -json qdisc show dev $IFACE | jq -r '.[0].options.maxrate')
-    if [[ $configured_maxrate != $MAXRATE ]]; then
-      echo "maxrate of qdisc fq on $IFACE is ${configured_maxrate}, but should be ${MAXRATE}"
+      echo "Failed to configure qdisc fq on dev ${IFACE}"
       write_metric_file 0
       exit 1
     fi
     write_metric_file 1
-    echo "Set maxrate for qdisc fq on dev eth0 to: ${MAXRATE}"
+    echo "Set qdisc fq on root of dev ens4"
 
 # systemd service for configuring the fq qdisc on boot.
 - path: /etc/systemd/system/configure-tc-fq.service


### PR DESCRIPTION
It was decided that the previous setting for `maxrate` on virtual nodes was incorrect, but probably not hurting anything, as is pretty well demonstrated in the data. However, having a misleading and largely unused config on the qdisc is not ideal. It was decided that we should just remove the `maxrate` config for the fq qdisc on virtual nodes. This PR removes those part from the `configure-tc-fq.sh` script that gets installed on virtual nodes.

An operator (me) will still need to login to existing virtual machines and make this update manually.

This PR also includes a small fix to the script for creating virtual nodes, and it renames the script.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/735)
<!-- Reviewable:end -->
