### PR TITLE
Writes kernel version to the metadata dir

### DIFF
--- a/manage-cluster/add_k8s_virtual_node.sh
+++ b/manage-cluster/add_k8s_virtual_node.sh
@@ -301,6 +301,7 @@ gcloud compute ssh "${GCE_NAME}" "${GCE_ARGS[@]}" <<EOF
   echo -n $EXTERNAL_IPV6 > "\${metadata_dir}/external-ipv6"
   echo -n $MACHINE_TYPE > "\${metadata_dir}/machine-type"
   echo -n $NETWORK_TIER > "\${metadata_dir}/network-tier"
+  uname -r | tr -d '\n' > "\${metadata_dir}/kernel-version"
 EOF
 
 # Ssh to the master and fix the network annotation for the node.


### PR DESCRIPTION
The kernel version will be passed to ndt-server with the --label flag, which will propagate that data to experiment results, making it easier to canary and validate how new kernel versions may or may not affect test results.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/738)
<!-- Reviewable:end -->
