### PR TITLE
Adds memory limit of 1500M to pcap on virtual nodes

### DIFF
--- a/k8s/daemonsets/experiments/ndt-virtual.jsonnet
+++ b/k8s/daemonsets/experiments/ndt-virtual.jsonnet
@@ -6,7 +6,7 @@ local services = [
   'ndt/ndt5=ws://:3001/ndt_protocol,wss://:3010/ndt_protocol',
 ];
 
-exp.ExperimentNoIndex(expName, 'pusher-' + std.extVar('PROJECT_ID'), 'none', datatypes, true) + {
+exp.ExperimentNoIndex(expName, 'pusher-' + std.extVar('PROJECT_ID'), 'none', datatypes, true, 'virtual') + {
   metadata+: {
     name: expName + '-virtual',
   },

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -209,7 +209,7 @@ local Traceroute(expName, tcpPort, hostNetwork) = [
   else []
 ;
 
-local Pcap(expName, tcpPort, hostNetwork) = [
+local Pcap(expName, tcpPort, hostNetwork, siteType) = [
   {
     name: 'packet-headers',
     image: 'measurementlab/packet-headers:v0.6.0',
@@ -241,11 +241,11 @@ local Pcap(expName, tcpPort, hostNetwork) = [
         containerPort: tcpPort,
       },
     ],
-    resources: if expName == 'ndt-virtual' then [
+    resources: if siteType == 'virtual' then {
       limits: {
         memory: '1500M',
       },
-    ] else [],
+    } else {},
     volumeMounts: [
       VolumeMount(expName),
       tcpinfoServiceVolume.volumemount,
@@ -481,7 +481,7 @@ local Metadata = {
   },
 };
 
-local ExperimentNoIndex(name, bucket, anonMode, datatypes, hostNetwork) = {
+local ExperimentNoIndex(name, bucket, anonMode, datatypes, hostNetwork, siteType="physical") = {
   // TODO(m-lab/k8s-support/issues/358): make this unconditional once traceroute
   // supports anonymization.
   local allDatatypes =  ['tcpinfo', 'pcap', 'annotation'] + datatypes +
@@ -515,7 +515,7 @@ local ExperimentNoIndex(name, bucket, anonMode, datatypes, hostNetwork) = {
             Tcpinfo(name, 9991, hostNetwork, anonMode),
             if anonMode == "none" then
               Traceroute(name, 9992, hostNetwork) else [],
-            Pcap(name, 9993, hostNetwork),
+            Pcap(name, 9993, hostNetwork, siteType),
             UUIDAnnotator(name, 9994, hostNetwork),
             Pusher(name, 9995, allDatatypes, hostNetwork, bucket),
           ]),
@@ -591,7 +591,7 @@ local Experiment(name, index, bucket, anonMode, datatypes=[]) = ExperimentNoInde
   // Returns a minimal experiment, suitable for adding a unique network config
   // before deployment. It is expected that most users of this library will use
   // Experiment().
-  ExperimentNoIndex(name, bucket, anonMode, datatypes, hostNetwork):: ExperimentNoIndex(name, bucket, anonMode, datatypes, hostNetwork),
+  ExperimentNoIndex(name, bucket, anonMode, datatypes, hostNetwork, siteType='physical'):: ExperimentNoIndex(name, bucket, anonMode, datatypes, hostNetwork, siteType),
 
   // RBACProxy creates a https proxy for an http port. This allows us to serve
   // metrics securely over https, andto https-authenticate to only serve them to

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -243,7 +243,7 @@ local Pcap(expName, tcpPort, hostNetwork, siteType) = [
     ],
     resources: if siteType == 'virtual' then {
       limits: {
-        memory: '1500M',
+        memory: '2G',
       },
     } else {},
     volumeMounts: [

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -481,7 +481,7 @@ local Metadata = {
   },
 };
 
-local ExperimentNoIndex(name, bucket, anonMode, datatypes, hostNetwork, siteType="physical") = {
+local ExperimentNoIndex(name, bucket, anonMode, datatypes, hostNetwork, siteType='physical') = {
   // TODO(m-lab/k8s-support/issues/358): make this unconditional once traceroute
   // supports anonymization.
   local allDatatypes =  ['tcpinfo', 'pcap', 'annotation'] + datatypes +

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -241,6 +241,11 @@ local Pcap(expName, tcpPort, hostNetwork) = [
         containerPort: tcpPort,
       },
     ],
+    resources: if expName == 'ndt-virtual' then [
+      limits: {
+        memory: '1500M',
+      },
+    ] else [],
     volumeMounts: [
       VolumeMount(expName),
       tcpinfoServiceVolume.volumemount,


### PR DESCRIPTION
This PR is a stab at a temporary workaround for this issue: https://github.com/m-lab/ops-tracker/issues/1682

I'm not very happy with this PR... adding new function parameters, etc. It WAI, but seems ugly. Additionally, I'm not fully convinced that this will 100% resolve the issue. It may keep the VM from crashing, however. Another side effect could _possibly_ be that the kernel will repeatedly oom-kill the packet-headers container, which will cause the kubelet to flag the ndt-virtual pod as `NotReady`, which may cause an alert to fire.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/741)
<!-- Reviewable:end -->
