### PR TITLE
Use hostNetwork=false for physical daemonsets

### DIFF
--- a/k8s/daemonsets/experiments/ndt-canary.jsonnet
+++ b/k8s/daemonsets/experiments/ndt-canary.jsonnet
@@ -97,7 +97,7 @@ exp.Experiment(expName, 2, 'pusher-' + std.extVar('PROJECT_ID'), "none", datatyp
 
           },
         ] + std.flattenArrays([
-          exp.Heartbeat(expName, true, services),
+          exp.Heartbeat(expName, false, services),
         ]),
         volumes+: [
           {

--- a/k8s/daemonsets/experiments/ndt.jsonnet
+++ b/k8s/daemonsets/experiments/ndt.jsonnet
@@ -86,7 +86,7 @@ exp.Experiment(expName, 2, 'pusher-' + std.extVar('PROJECT_ID'), "none", datatyp
 
           }
         ] + std.flattenArrays([
-          exp.Heartbeat(expName, true, services),
+          exp.Heartbeat(expName, false, services),
         ]),
         volumes+: [
           {


### PR DESCRIPTION
This PR updates the hostNetwork option for `ndt` and `ndt-canary` to false. Only virtual pods should have access to the hostNetwork.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/743)
<!-- Reviewable:end -->
