### PR TITLE
Upgrade to latest version of ndt-server and heartbeat

### DIFF
--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -385,7 +385,7 @@ local UUIDAnnotator(expName, tcpPort, hostNetwork) = [
 local Heartbeat(expName, tcpPort, hostNetwork, services) = [
   {
     name: 'heartbeat',
-    image: 'measurementlab/heartbeat:v0.0',
+    image: 'measurementlab/heartbeat:latest',
     args: [
       if hostNetwork then
         '-prometheusx.listen-address=127.0.0.1:' + tcpPort

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -385,7 +385,7 @@ local UUIDAnnotator(expName, tcpPort, hostNetwork) = [
 local Heartbeat(expName, tcpPort, hostNetwork, services) = [
   {
     name: 'heartbeat',
-    image: 'measurementlab/heartbeat:v0.8',
+    image: 'measurementlab/heartbeat:v0.13.0',
     args: [
       if hostNetwork then
         '-prometheusx.listen-address=127.0.0.1:' + tcpPort

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -385,7 +385,7 @@ local UUIDAnnotator(expName, tcpPort, hostNetwork) = [
 local Heartbeat(expName, tcpPort, hostNetwork, services) = [
   {
     name: 'heartbeat',
-    image: 'measurementlab/heartbeat:latest',
+    image: 'measurementlab/heartbeat:v0.13.1',
     args: [
       if hostNetwork then
         '-prometheusx.listen-address=127.0.0.1:' + tcpPort

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -385,7 +385,7 @@ local UUIDAnnotator(expName, tcpPort, hostNetwork) = [
 local Heartbeat(expName, tcpPort, hostNetwork, services) = [
   {
     name: 'heartbeat',
-    image: 'measurementlab/heartbeat:v0.13.0',
+    image: 'measurementlab/heartbeat:v0.8',
     args: [
       if hostNetwork then
         '-prometheusx.listen-address=127.0.0.1:' + tcpPort

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -385,7 +385,7 @@ local UUIDAnnotator(expName, tcpPort, hostNetwork) = [
 local Heartbeat(expName, tcpPort, hostNetwork, services) = [
   {
     name: 'heartbeat',
-    image: 'measurementlab/heartbeat:v0.13.0',
+    image: 'measurementlab/heartbeat:v0.0',
     args: [
       if hostNetwork then
         '-prometheusx.listen-address=127.0.0.1:' + tcpPort

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -1,7 +1,7 @@
-local ndtVersion = 'v0.20.16';
+local ndtVersion = 'v0.20.17';
 // The canary version is expected to be greater than or equal to
 // the current stable version.
-local ndtCanaryVersion = 'v0.20.16';
+local ndtCanaryVersion = 'v0.20.17';
 local PROJECT_ID = std.extVar('PROJECT_ID');
 
 // The default grace period after k8s sends SIGTERM is 30s. We
@@ -385,7 +385,7 @@ local UUIDAnnotator(expName, tcpPort, hostNetwork) = [
 local Heartbeat(expName, tcpPort, hostNetwork, services) = [
   {
     name: 'heartbeat',
-    image: 'measurementlab/heartbeat:v0.12.1',
+    image: 'measurementlab/heartbeat:v0.13.0',
     args: [
       if hostNetwork then
         '-prometheusx.listen-address=127.0.0.1:' + tcpPort


### PR DESCRIPTION
Relevant changes for ndt-server:
* https://github.com/m-lab/ndt-server/pull/375
* https://github.com/m-lab/ndt-server/pull/376

Relevant changes for heartbeat:
* https://github.com/m-lab/locate/pull/83
* https://github.com/m-lab/locate/pull/88
* https://github.com/m-lab/locate/pull/89

Monitoring for the health checks functionality being picked up is in the "Health Checks (per min)" panel. There are 12 ndt instances in sandbox and there are 72 checks per min (12 instances * check every 6 secs = 72 checks/min).

https://grafana.mlab-sandbox.measurementlab.net/d/8O9tInk4k/locate-service?orgId=1&refresh=5s&from=now-12h&to=now&var-datasource=Prometheus%20%28mlab-sandbox%29&var-platformdatasource=Platform%20Cluster%20%28mlab-sandbox%29&var-experiment=ndt

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/744)
<!-- Reviewable:end -->
