### PR TITLE
Update packet-headers to v0.7.0 w/ -maxheap for virtual servers

### DIFF
--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -212,7 +212,7 @@ local Traceroute(expName, tcpPort, hostNetwork) = [
 local Pcap(expName, tcpPort, hostNetwork, siteType) = [
   {
     name: 'packet-headers',
-    image: 'measurementlab/packet-headers:v0.6.0',
+    image: 'measurementlab/packet-headers:sandbox-soltesz-maxramratio',
     args: [
       if hostNetwork then
         '-prometheusx.listen-address=127.0.0.1:' + tcpPort
@@ -221,6 +221,7 @@ local Pcap(expName, tcpPort, hostNetwork, siteType) = [
       '-datadir=' + VolumeMount(expName).mountPath + '/pcap',
       '-tcpinfo.eventsocket=' + tcpinfoServiceVolume.socketFilename,
       '-stream=false',
+      '-maxramratio=0.5',
     // The "host" experiment is currently the only experiment where
     // packet-headers needs to listen explictly on interface eth0.
     ] + if expName == 'host' then [

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -212,7 +212,7 @@ local Traceroute(expName, tcpPort, hostNetwork) = [
 local Pcap(expName, tcpPort, hostNetwork, siteType) = [
   {
     name: 'packet-headers',
-    image: 'measurementlab/packet-headers:sandbox-soltesz-maxramratio',
+    image: 'measurementlab/packet-headers:v0.7.0',
     args: [
       if hostNetwork then
         '-prometheusx.listen-address=127.0.0.1:' + tcpPort
@@ -221,11 +221,14 @@ local Pcap(expName, tcpPort, hostNetwork, siteType) = [
       '-datadir=' + VolumeMount(expName).mountPath + '/pcap',
       '-tcpinfo.eventsocket=' + tcpinfoServiceVolume.socketFilename,
       '-stream=false',
+    ] + if siteType == 'virtual' then [
+      // Only virtual nodes need to limit RAM beyond default values.
       '-maxidleram=1.5G',
       '-maxheap=2G',
-    // The "host" experiment is currently the only experiment where
-    // packet-headers needs to listen explictly on interface eth0.
+    ] else [
     ] + if expName == 'host' then [
+      // The "host" experiment is currently the only experiment where
+      // packet-headers needs to listen explictly on interface eth0.
       '-interface=eth0',
     ] else [],
     env: if hostNetwork then [] else [

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -221,7 +221,8 @@ local Pcap(expName, tcpPort, hostNetwork, siteType) = [
       '-datadir=' + VolumeMount(expName).mountPath + '/pcap',
       '-tcpinfo.eventsocket=' + tcpinfoServiceVolume.socketFilename,
       '-stream=false',
-      '-maxramratio=0.5',
+      '-maxidleram=1.5G',
+      '-maxheap=2G',
     // The "host" experiment is currently the only experiment where
     // packet-headers needs to listen explictly on interface eth0.
     ] + if expName == 'host' then [
@@ -244,7 +245,7 @@ local Pcap(expName, tcpPort, hostNetwork, siteType) = [
     ],
     resources: if siteType == 'virtual' then {
       limits: {
-        memory: '2G',
+        memory: '3G',
       },
     } else {},
     volumeMounts: [

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -223,8 +223,8 @@ local Pcap(expName, tcpPort, hostNetwork, siteType) = [
       '-stream=false',
     ] + if siteType == 'virtual' then [
       // Only virtual nodes need to limit RAM beyond default values.
-      '-maxidleram=1.5G',
-      '-maxheap=2G',
+      '-maxidleram=1500MB',
+      '-maxheap=2GB',
     ] else [
     ] + if expName == 'host' then [
       // The "host" experiment is currently the only experiment where


### PR DESCRIPTION
This change updates packet-headers to the latest version, which includes a build using go1.19 and the new `-maxheap` flag to limit total RAM usage. Given our current virtual node configuration, this change uses a `-maxheap=2GB` and `-maxidleram=1500MB` (less than maxheap). The combination of these flags should prevent nodes from reaching the k8s resource limit of 3GB in a controlled way without requiring a process kill / restart.

