### PR TITLE
Sets repo to ops-tracker for PusherFinderMtime alert

### DIFF
--- a/config/prometheus/alerts.yml
+++ b/config/prometheus/alerts.yml
@@ -657,14 +657,12 @@ groups:
         unless on(machine) kube_node_spec_taint{key="lame-duck"}
     for: 8h
     labels:
-      repo: dev-tracker
+      repo: ops-tracker
       severity: ticket
       cluster: platform
     annotations:
       summary: Data on disk are too old and should have been uploaded already
-      description: The min file mtime seen by pusher has been older than 16
-        hours for at least 8 hours. If uploads are failing then data will be lost
-        if the node reboots.
+      description: https://github.com/m-lab/ops-tracker/wiki/Alerts-&-Troubleshooting#platformcluster_pusherfindermtimelowerboundistooold
       dashboard: https://grafana.mlab-oti.measurementlab.net/d/WnaxPZJZz
 
   - alert: PlatformCluster_TokenServerClusterDownOrMissing


### PR DESCRIPTION
Also updates the description to be a link to a more thorough description of the problem in the ops-tracker wiki.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/746)
<!-- Reviewable:end -->
