### PR TITLE
Add -- to end flag processing for ndt-server

### DIFF
--- a/k8s/daemonsets/experiments/ndt-canary.jsonnet
+++ b/k8s/daemonsets/experiments/ndt-canary.jsonnet
@@ -40,6 +40,7 @@ exp.Experiment(expName, 2, 'pusher-' + std.extVar('PROJECT_ID'), "none", datatyp
               '/bin/sh',
               '-c',
               '/ndt-server -txcontroller.max-rate=$(cat /metadata/iface-max-rate) $@',
+              '--',
             ],
             args: [
               '-uuid-prefix-file=' + exp.uuid.prefixfile,

--- a/k8s/daemonsets/experiments/ndt.jsonnet
+++ b/k8s/daemonsets/experiments/ndt.jsonnet
@@ -29,6 +29,7 @@ exp.Experiment(expName, 2, 'pusher-' + std.extVar('PROJECT_ID'), "none", datatyp
               '/bin/sh',
               '-c',
               '/ndt-server -txcontroller.max-rate=$(cat /metadata/iface-max-rate) $@',
+              '--',
             ],
             args: [
               '-uuid-prefix-file=' + exp.uuid.prefixfile,


### PR DESCRIPTION
This change corrects a typo that prevented the `-uuid-prefix-file` flag from being passed to the ndt-server.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/747)
<!-- Reviewable:end -->
