### PR TITLE
Removes privileged=true for flannel containers

### DIFF
--- a/k8s/daemonsets/core/flannel-physical.jsonnet
+++ b/k8s/daemonsets/core/flannel-physical.jsonnet
@@ -72,7 +72,13 @@
               },
             },
             securityContext: {
-              privileged: true,
+              privileged: false,
+              capabilities: {
+                add: [
+                  'NET_ADMIN',
+                  'NET_RAW',
+                ],
+              },
             },
             volumeMounts: [
               {

--- a/k8s/daemonsets/core/flannel-virtual.jsonnet
+++ b/k8s/daemonsets/core/flannel-virtual.jsonnet
@@ -75,7 +75,13 @@
               },
             },
             securityContext: {
-              privileged: true,
+              privileged: false,
+              capabilities: {
+                add: [
+                  'NET_ADMIN',
+                  'NET_RAW',
+                ],
+              },
             },
             volumeMounts: [
               {


### PR DESCRIPTION
The ROS security audit of the M-Lab platform noted that flannel containers were running with CAP_SYS_ADMIN, and that we should determine if we could remove that capability. This was the result of setting privileged=true in the securityContext for the pods. Looking at the current documentation for flannel, their [sample configurations](https://github.com/flannel-io/flannel/blob/master/Documentation/kube-flannel.yml#L171-L174) explicity set privileged=false, and grant only NET_ADMIN and NET_RAW capabilities. This PR follows this same pattern for M-Lab's flannel pods.

All flannel pods, of course, restarted with this change in sandbox, and all started back up normally with no apparently problems. As a small test I logged into a pusher container on mlab2-lga0t and was able to ping the private IP address of Vector on mlab1-pdx0t, which tells me that flannel is still working as intended, ostensibly.

This PR is intended to address security audit issue https://github.com/m-lab/ops-tracker/issues/1656

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/755)
<!-- Reviewable:end -->
