### PR TITLE
Updates virtual OS to Ubuntu 22.04

### DIFF
--- a/manage-cluster/k8s_deploy.conf
+++ b/manage-cluster/k8s_deploy.conf
@@ -1,5 +1,5 @@
 GCE_BASE_NAME="platform-cluster"
-GCE_IMAGE_FAMILY="ubuntu-minimal-2004-lts"
+GCE_IMAGE_FAMILY="ubuntu-minimal-2204-lts"
 GCE_IMAGE_PROJECT="ubuntu-os-cloud"
 GCE_DISK_SIZE="100"
 GCE_DISK_TYPE="pd-ssd"


### PR DESCRIPTION
The physical fleet is migrating to 22.04 as I write this. This make any new virtual nodes use 22.04. We won't be using this script for too much longer, hopefully, as we migrate to using Terraform.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/756)
<!-- Reviewable:end -->
