### PR TITLE
Explicitly sets JSON credential file path

### DIFF
--- a/helm/vector/values.yaml.template
+++ b/helm/vector/values.yaml.template
@@ -5,6 +5,7 @@ customConfig:
   sinks:
     stackdriver:
       type: gcp_stackdriver_logs
+      credentials_path: "/etc/vector/keys/vector.json"
       inputs:
       - kernel_log
       - kubernetes_logs
@@ -28,9 +29,6 @@ customConfig:
       - journald
       # This catches anything with priority warning (4) to critical (0).
       condition: .SYSLOG_IDENTIFIER == "kernel" && includes(["0", "1", "2", "3", "4"], .PRIORITY)
-env:
-- name: GOOGLE_APPLICATION_CREDENTIALS
-  value: /etc/vector/keys/vector.json
 extraVolumes:
 - name: credentials
   secret:


### PR DESCRIPTION
Previously we were setting the env variable GOOGLE_APPLICATION_CREDENTIALS. The documentation for this sink says that in the absence of this configuration it will check that env variable. And indeed it appears to work that way, but over the weekend around 8 Vector pods started throwing errors about invalid tokens, when we don't even use tokens to authenticate Vector. This made me wonder if there could be some bug in Vector whereby it was not checking that env variable, or checking it too late, and falling back to some other authentication method that fails. This commit explicitly sets the path to the JSON key for authentication, which is probably a better configuration even if it doesn't turn out to solve any problems.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/757)
<!-- Reviewable:end -->
