### PR TITLE
Add anonMode parameters to pcap and traceroute sidecars

### DIFF
--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -173,7 +173,7 @@ local Traceroute(expName, tcpPort, hostNetwork, anonMode) = [
       else
         '-prometheusx.listen-address=$(PRIVATE_IP):' + tcpPort,
       '-traceroute-output=' + VolumeMount(expName).mountPath + '/scamper1',
-      '-uuid-prefix-file=' + uuid.prefixfile,
+      # '-uuid-prefix-file=' + uuid.prefixfile,
       '-tcpinfo.eventsocket=' + tcpinfoServiceVolume.socketFilename,
       '-IPCacheTimeout=10m',
       '-IPCacheUpdatePeriod=1m',

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -173,7 +173,6 @@ local Traceroute(expName, tcpPort, hostNetwork, anonMode) = [
       else
         '-prometheusx.listen-address=$(PRIVATE_IP):' + tcpPort,
       '-traceroute-output=' + VolumeMount(expName).mountPath + '/scamper1',
-      # '-uuid-prefix-file=' + uuid.prefixfile,
       '-tcpinfo.eventsocket=' + tcpinfoServiceVolume.socketFilename,
       '-IPCacheTimeout=10m',
       '-IPCacheUpdatePeriod=1m',


### PR DESCRIPTION
This change adds the `anonMode` parameter to the pcap and traceroute sidecars. The Traceroute container version update now supports ip anonymization (i.e. v4/24 or v6/48 truncation). This change also includes a bug fix to propagate the anonMode to the pcap sidecar.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/758)
<!-- Reviewable:end -->
