### PR TITLE
Adds scripts k8s scripts to initialize the control plane

### DIFF
--- a/helm/cert-manager/helm-values-overrides.yaml
+++ b/helm/cert-manager/helm-values-overrides.yaml
@@ -6,8 +6,12 @@ cainjector:
 ingressShim:
   defaultIssuerName: letsencrypt
   defaultIssuerKind: ClusterIssuer
+installCRDs: true
 nodeSelector:
   "node-role.kubernetes.io/control-plane": ""
+startupapicheck:
+  tolerations:
+  - operator: Exists
 strategy:
   type: Recreate
 tolerations:
@@ -17,3 +21,4 @@ webhook:
     "node-role.kubernetes.io/control-plane": ""
   tolerations:
   - operator: Exists
+

--- a/helm/cert-manager/helm-values-overrides.yaml
+++ b/helm/cert-manager/helm-values-overrides.yaml
@@ -6,7 +6,6 @@ cainjector:
 ingressShim:
   defaultIssuerName: letsencrypt
   defaultIssuerKind: ClusterIssuer
-installCRDs: true
 nodeSelector:
   "node-role.kubernetes.io/control-plane": ""
 startupapicheck:

--- a/manage-cluster/apply_k8s_configs.sh
+++ b/manage-cluster/apply_k8s_configs.sh
@@ -69,8 +69,6 @@ kubectl create namespace logging --dry-run=client -o json | kubectl apply -f -
 
 # Install cert-manager and configure it to use the "letsencrypt" ClusterIssuer
 # by default.
-# https://docs.cert-manager.io/en/latest/getting-started/install/kubernetes.html
-kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/${K8S_CERTMANAGER_VERSION}/cert-manager.crds.yaml
 ./linux-amd64/helm upgrade --install cert-manager \
   --namespace cert-manager \
   --version ${K8S_CERTMANAGER_VERSION} \

--- a/manage-cluster/apply_k8s_configs.sh
+++ b/manage-cluster/apply_k8s_configs.sh
@@ -69,6 +69,8 @@ kubectl create namespace logging --dry-run=client -o json | kubectl apply -f -
 
 # Install cert-manager and configure it to use the "letsencrypt" ClusterIssuer
 # by default.
+# https://docs.cert-manager.io/en/latest/getting-started/install/kubernetes.html
+kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/${K8S_CERTMANAGER_VERSION}/cert-manager.crds.yaml
 ./linux-amd64/helm upgrade --install cert-manager \
   --namespace cert-manager \
   --version ${K8S_CERTMANAGER_VERSION} \

--- a/manage-cluster/apply_k8s_configs_cluster-init.sh
+++ b/manage-cluster/apply_k8s_configs_cluster-init.sh
@@ -39,6 +39,8 @@ kubectl create namespace logging --dry-run=client -o json | kubectl apply -f -
 
 # Install cert-manager and configure it to use the "letsencrypt" ClusterIssuer
 # by default.
+# https://docs.cert-manager.io/en/latest/getting-started/install/kubernetes.html
+kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/${K8S_CERTMANAGER_VERSION}/cert-manager.crds.yaml
 ./linux-amd64/helm upgrade --install cert-manager \
   --namespace cert-manager \
   --version ${K8S_CERTMANAGER_VERSION} \

--- a/manage-cluster/apply_k8s_configs_cluster-init.sh
+++ b/manage-cluster/apply_k8s_configs_cluster-init.sh
@@ -39,8 +39,6 @@ kubectl create namespace logging --dry-run=client -o json | kubectl apply -f -
 
 # Install cert-manager and configure it to use the "letsencrypt" ClusterIssuer
 # by default.
-# https://docs.cert-manager.io/en/latest/getting-started/install/kubernetes.html
-kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/${K8S_CERTMANAGER_VERSION}/cert-manager.crds.yaml
 ./linux-amd64/helm upgrade --install cert-manager \
   --namespace cert-manager \
   --version ${K8S_CERTMANAGER_VERSION} \

--- a/manage-cluster/apply_k8s_configs_cluster-init.sh
+++ b/manage-cluster/apply_k8s_configs_cluster-init.sh
@@ -5,10 +5,7 @@ set -euxo pipefail
 # Source the main configuration file.
 source ./k8s_deploy.conf
 
-if [[ -z $KUBECONFIG ]]; then
-  echo "KUBECONFIG not defined. Exiting..."
-  exit 1
-fi
+export KUBECONFIG=/etc/kubernetes/admin.conf
 
 # Upload the evaluated setup_k8s.sh template to GCS.
 # TODO(kinkade): Move setup_k8s.sh to the epoxy-images repo to be baked into

--- a/manage-cluster/apply_k8s_configs_cluster-init.sh
+++ b/manage-cluster/apply_k8s_configs_cluster-init.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+# Source the main configuration file.
+source ./k8s_deploy.conf
+
+if [[ -z $KUBECONFIG ]]; then
+  echo "KUBECONFIG not defined. Exiting..."
+  exit 1
+fi
+
+# Upload the evaluated setup_k8s.sh template to GCS.
+# TODO(kinkade): Move setup_k8s.sh to the epoxy-images repo to be baked into
+# stage3 images, obviating the need for the static "version" path in GCS of
+# "latest": https://github.com/m-lab/k8s-support/issues/569
+cache_control="Cache-Control:private, max-age=0, no-transform"
+gsutil -h "$cache_control" cp ./setup_k8s.sh gs://epoxy-${project}/latest/stage3_ubuntu/setup_k8s.sh
+
+# Download helm and use it to install cert-manager and ingress-nginx
+curl -O https://get.helm.sh/helm-${K8S_HELM_VERSION}-linux-amd64.tar.gz
+tar -zxvf helm-${K8S_HELM_VERSION}-linux-amd64.tar.gz
+
+# Add the required Helm repositories.
+./linux-amd64/helm repo add jetstack https://charts.jetstack.io
+./linux-amd64/helm repo add ingress-nginx https://kubernetes.github.io/ingress-nginx
+./linux-amd64/helm repo add vector https://helm.vector.dev
+
+# Helm 3 does not automatically create namespaces anymore.
+kubectl create namespace cert-manager --dry-run=client -o json | kubectl apply -f -
+kubectl create namespace ingress-nginx --dry-run=client -o json | kubectl apply -f -
+kubectl create namespace logging --dry-run=client -o json | kubectl apply -f -
+
+# Install ingress-nginx and set it to run on the same node as prometheus-server.
+./linux-amd64/helm upgrade --install ingress-nginx \
+  --namespace ingress-nginx \
+  --values ../helm/ingress-nginx/helm-values-overrides.yaml \
+  ingress-nginx/ingress-nginx
+
+# Install cert-manager and configure it to use the "letsencrypt" ClusterIssuer
+# by default.
+# https://docs.cert-manager.io/en/latest/getting-started/install/kubernetes.html
+kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/${K8S_CERTMANAGER_VERSION}/cert-manager.crds.yaml
+./linux-amd64/helm upgrade --install cert-manager \
+  --namespace cert-manager \
+  --version ${K8S_CERTMANAGER_VERSION} \
+  --values ../helm/cert-manager/helm-values-overrides.yaml \
+  --debug \
+  jetstack/cert-manager
+
+# Replace per-project variables in Vector's values.yaml and install Vector.
+sed -e "s|{{PROJECT}}|${project}|g" \
+    -e "s|{{IMAGE}}|${K8S_VECTOR_IMAGE}|g" \
+    ../helm/vector/values.yaml.template > \
+    ../helm/vector/values.yaml
+
+./linux-amd64/helm upgrade --install vector \
+  --values ../helm/vector/values.yaml \
+  --version ${K8S_VECTOR_CHART} \
+  vector/vector
+
+# Apply the configuration
+
+# The configurations of the secrets for the cluster happen in a separate
+# directory. We might publicly archive system.json. We should never make any
+# part of secret-configs public.  They are our passwords and private keys!
+kubectl apply -f secret-configs/
+
+# We call 'kubectl apply -f system.json' three times because kubectl doesn't
+# support defining and declaring certain objects in the same file. This is a
+# bug in kubectl, and so we call it three times as a workaround for the bug.
+kubectl apply -f system.json || true
+kubectl apply -f system.json || true
+# Sleep for a bit to give all pods a chance to start. Specifically, this
+# command will fail, causing the build to fail, if cert-manager-webhook is
+# not up and running.
+sleep 60
+kubectl apply -f system.json

--- a/manage-cluster/apply_k8s_configs_cluster-init.sh
+++ b/manage-cluster/apply_k8s_configs_cluster-init.sh
@@ -14,6 +14,13 @@ export KUBECONFIG=/etc/kubernetes/admin.conf
 cache_control="Cache-Control:private, max-age=0, no-transform"
 gsutil -h "$cache_control" cp ./setup_k8s.sh gs://epoxy-${project}/latest/stage3_ubuntu/setup_k8s.sh
 
+# We call 'kubectl apply -f system.json' several times because kubectl doesn't
+# support defining and declaring certain objects in the same file. This is a
+# bug in kubectl, and so we call it two times here and a final time at the end
+# of this script as a workaround for the bug.
+kubectl apply -f system.json || true
+kubectl apply -f system.json || true
+
 # Download helm and use it to install cert-manager and ingress-nginx
 curl -O https://get.helm.sh/helm-${K8S_HELM_VERSION}-linux-amd64.tar.gz
 tar -zxvf helm-${K8S_HELM_VERSION}-linux-amd64.tar.gz
@@ -63,11 +70,6 @@ sed -e "s|{{PROJECT}}|${project}|g" \
 # part of secret-configs public.  They are our passwords and private keys!
 kubectl apply -f secret-configs/
 
-# We call 'kubectl apply -f system.json' three times because kubectl doesn't
-# support defining and declaring certain objects in the same file. This is a
-# bug in kubectl, and so we call it three times as a workaround for the bug.
-kubectl apply -f system.json || true
-kubectl apply -f system.json || true
 # Sleep for a bit to give all pods a chance to start. Specifically, this
 # command will fail, causing the build to fail, if cert-manager-webhook is
 # not up and running.

--- a/manage-cluster/create_k8s_configs_cluster-init.sh
+++ b/manage-cluster/create_k8s_configs_cluster-init.sh
@@ -5,6 +5,8 @@ set -euxo pipefail
 # Source the main configuration file.
 source ./k8s_deploy.conf
 
+export KUBECONFIG=/etc/kubernetes/admin.conf
+
 GCS_BUCKET_K8S="GCS_BUCKET_K8S_${project//-/_}"
 
 # Create the json configuration for the entire cluster (except for secrets)

--- a/manage-cluster/create_k8s_configs_cluster-init.sh
+++ b/manage-cluster/create_k8s_configs_cluster-init.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+set -euxo pipefail
+
+# Source the main configuration file.
+source ./k8s_deploy.conf
+
+GCS_BUCKET_K8S="GCS_BUCKET_K8S_${project//-/_}"
+
+# Create the json configuration for the entire cluster (except for secrets)
+jsonnet \
+   --ext-str GCE_ZONE=${zone} \
+   --ext-str K8S_CLUSTER_CIDR=${cluster_cidr} \
+   --ext-str K8S_FLANNEL_VERSION=${K8S_FLANNEL_VERSION} \
+   --ext-str PROJECT_ID=${project} \
+   --ext-str DEPLOYMENTSTAMP=$(date +%s) \
+   ../system.jsonnet > system.json
+
+# Download every secret, and turn each one into a config.
+mkdir -p secrets
+mkdir -p secret-configs
+
+# Fetch and configure all the secrets.
+gsutil cp -R gs://${!GCS_BUCKET_K8S}/ndt-tls secrets/.
+gsutil cp -R gs://${!GCS_BUCKET_K8S}/wehe-ca secrets/.
+gsutil cp gs://${!GCS_BUCKET_K8S}/uuid-annotator-credentials.json secrets/uuid-annotator.json
+gsutil cp gs://${!GCS_BUCKET_K8S}/pusher-credentials.json secrets/pusher.json
+gsutil cp gs://${!GCS_BUCKET_K8S}/cert-manager-credentials.json secrets/cert-manager.json
+gsutil cp gs://${!GCS_BUCKET_K8S}/vector-credentials.json secrets/vector.json
+gsutil cp gs://${!GCS_BUCKET_K8S}/snmp-community/snmp.community secrets/snmp.community
+gsutil cp gs://${!GCS_BUCKET_K8S}/prometheus-htpasswd secrets/auth
+# The alertmanager-basicauth.yaml file is already a valid k8s YAML Secret
+# specification, so copy it directly to the secret-configs/ directory.
+gsutil cp gs://${!GCS_BUCKET_K8S}/alertmanager-basicauth.yaml secret-configs/.
+gsutil cp -R gs://${!GCS_BUCKET_K8S}/locate secrets/.
+gsutil cp -R gs://${!GCS_BUCKET_K8S}/locate-heartbeat secrets/.
+
+# Convert secret data into configs.
+kubectl create secret generic uuid-annotator-credentials --from-file secrets/uuid-annotator.json \
+    --dry-run=client -o json > secret-configs/uuid-annotator-credentials.json
+kubectl create secret generic pusher-credentials --from-file secrets/pusher.json \
+    --dry-run=client -o json > secret-configs/pusher-credentials.json
+kubectl create secret generic cert-manager-credentials --namespace cert-manager \
+    --from-file secrets/cert-manager.json \
+    --dry-run=client -o json > secret-configs/cert-manager-credentials.json
+kubectl create secret generic ndt-tls --from-file secrets/ndt-tls/ \
+    --dry-run=client -o json > secret-configs/ndt-tls.json
+kubectl create secret generic wehe-ca --from-file secrets/wehe-ca/ \
+    --dry-run=client -o json > secret-configs/wehe-ca.json
+kubectl create secret generic vector-credentials --from-file secrets/vector.json \
+    --dry-run=client -o json > secret-configs/vector.json
+kubectl create secret generic snmp-community --from-file secrets/snmp.community \
+    --dry-run=client -o json > secret-configs/snmp-community.json
+# NB: The file containing the user/password pair must be called 'auth'.
+kubectl create secret generic prometheus-htpasswd --from-file secrets/auth \
+    --dry-run=client -o json > secret-configs/prometheus-htpasswd.json
+kubectl create secret generic locate-verify-keys --from-file secrets/locate/ \
+    --dry-run=client -o json > secret-configs/locate-verify-keys.json
+kubectl create secret generic locate-heartbeat-key --from-file secrets/locate-heartbeat/ \
+    --dry-run=client -o json > secret-configs/locate-heartbeat-key.json
+
+# Evaluate the setup_k8s.sh.template using the generated hash of the CA cert.
+sed -e "s/{{CA_CERT_HASH}}/${ca_cert_hash}/" ../node/setup_k8s.sh.template \
+    > ./setup_k8s.sh
+


### PR DESCRIPTION
Currently, the control plane is bootstrapped via [a collection](https://github.com/m-lab/k8s-support/blob/main/manage-cluster/bootstrap_platform_cluster.sh) of [shell scripts](https://github.com/m-lab/k8s-support/blob/main/manage-cluster/bootstraplib.sh), which are run manually by an operator. Workloads are deployed by two scripts [create_k8s_configs.sh](https://github.com/m-lab/k8s-support/blob/main/manage-cluster/create_k8s_configs.sh) and [apply_k8s_configs.sh](https://github.com/m-lab/k8s-support/blob/main/manage-cluster/apply_k8s_configs.sh). After the cluster is bootstrapped, changes to the workloads are deployed by Cloud Builds, running these same "create" and "apply" scripts.

The current scripts are not suitable for running in an automated fashion directly on control plane nodes when a cluster is initialized. This PR contains essentially those same two scripts, but modified slightly to make them suitable for being run by a script on the control plane nodes when the cluster is bootstrapped automatically.

These changes are meant to be a stop-gap until we can find a way to have both cluster initialization and cluster updates use the same scripts. For now, the scripts should be functionally equivalent, resulting in the same workloads, but using different variables sourced from different locations, and some of the steps are reordered.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/761)
<!-- Reviewable:end -->
