### PR TITLE
Add required ndt5 access token to virtual nodes

### DIFF
--- a/k8s/daemonsets/experiments/ndt-virtual.jsonnet
+++ b/k8s/daemonsets/experiments/ndt-virtual.jsonnet
@@ -38,6 +38,9 @@ exp.ExperimentNoIndex(expName, 'pusher-' + std.extVar('PROJECT_ID'), 'none', dat
             name: 'ndt-server',
             image: 'measurementlab/ndt-server:' + exp.ndtVersion,
             args: [
+              '-ndt5_addr=127.0.0.1:3002', // any non-public port.
+              '-ndt5_ws_addr=:3001', // default, public ndt5 port.
+              '-ndt5.token.required=true',
               '-ndt7.token.required=true',
               '-htmldir=html/mlab',
               '-uuid-prefix-file=' + exp.uuid.prefixfile,


### PR DESCRIPTION
With the [Locate v2 rollout to 100%](https://github.com/m-lab/locate/issues/102), virtual nodes no longer require support for ndt5+plain protocol on cloud nodes. This protocol does not support admission control. Going forward, only mlab-ns and physical nodes will support the ndt5+plain protocol. And, since mlab-ns will not be guaranteed, this is a soft deprecation of the ndt5+plain protocol as well.

This change deployment should follow updates to mlab-ns to source only physical servers, e.g. https://github.com/m-lab/siteinfo/pull/260

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/767)
<!-- Reviewable:end -->
