### PR TITLE
Configures containerd to use systemd cgroup driver

### DIFF
--- a/manage-cluster/add_k8s_virtual_node.sh
+++ b/manage-cluster/add_k8s_virtual_node.sh
@@ -214,6 +214,15 @@ gcloud compute ssh "${GCE_NAME}" "${GCE_ARGS[@]}" <<EOF
   # https://kubernetes.io/docs/concepts/architecture/nodes/#addresses
   echo "KUBELET_EXTRA_ARGS='--node-ip=${INTERNAL_IP}'" > /etc/default/kubelet
 
+  # Fix the containerd config to use the systemd cgroup driver.
+  mkdir -p /etc/containerd
+  containerd config default \
+    | sed 's/SystemdCgroup.*/SystemdCgroup = true/' \
+    > /etc/containerd/config.toml
+
+  # Restart container so it picks up the above change.
+  systemctl restart containerd
+
   # Enable and start the kubelet service
   systemctl enable --now kubelet.service
   systemctl daemon-reload


### PR DESCRIPTION
Without this containerd does not function on Ubuntu 22.04 (jammy)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/768)
<!-- Reviewable:end -->
