### PR TITLE
Updates k8s to v1.23.16 + updates related components and services

### DIFF
--- a/manage-cluster/add_k8s_api_node.sh
+++ b/manage-cluster/add_k8s_api_node.sh
@@ -111,7 +111,7 @@ gcloud compute ssh "${BOOTSTRAP_MASTER}" "${GCP_ARGS[@]}" --zone "${BOOTSTRAP_MA
   kubectl create configmap kubeadm-config -n kube-system \
       --from-file ClusterConfiguration \
       --from-file ClusterStatus \
-      -o yaml --dry-run | kubectl replace -f -
+      -o yaml --dry-run=client | kubectl replace -f -
 EOF
 
 # If they exist, delete the node name from various loadbalancer group resources.

--- a/manage-cluster/create_k8s_configs.sh
+++ b/manage-cluster/create_k8s_configs.sh
@@ -53,25 +53,25 @@ gsutil cp -R gs://${!GCS_BUCKET_K8S}/locate-heartbeat secrets/.
 
 # Convert secret data into configs.
 kubectl create secret generic uuid-annotator-credentials --from-file secrets/uuid-annotator.json \
-    --dry-run -o json > secret-configs/uuid-annotator-credentials.json
+    --dry-run=client -o json > secret-configs/uuid-annotator-credentials.json
 kubectl create secret generic pusher-credentials --from-file secrets/pusher.json \
-    --dry-run -o json > secret-configs/pusher-credentials.json
+    --dry-run=client -o json > secret-configs/pusher-credentials.json
 kubectl create secret generic cert-manager-credentials --namespace cert-manager \
     --from-file secrets/cert-manager.json \
-    --dry-run -o json > secret-configs/cert-manager-credentials.json
+    --dry-run=client -o json > secret-configs/cert-manager-credentials.json
 kubectl create secret generic ndt-tls --from-file secrets/ndt-tls/ \
-    --dry-run -o json > secret-configs/ndt-tls.json
+    --dry-run=client -o json > secret-configs/ndt-tls.json
 kubectl create secret generic wehe-ca --from-file secrets/wehe-ca/ \
-    --dry-run -o json > secret-configs/wehe-ca.json
+    --dry-run=client -o json > secret-configs/wehe-ca.json
 kubectl create secret generic vector-credentials --from-file secrets/vector.json \
-    --dry-run -o json > secret-configs/vector.json
+    --dry-run=client -o json > secret-configs/vector.json
 kubectl create secret generic snmp-community --from-file secrets/snmp.community \
-    --dry-run -o json > secret-configs/snmp-community.json
+    --dry-run=client -o json > secret-configs/snmp-community.json
 # NB: The file containing the user/password pair must be called 'auth'.
 kubectl create secret generic prometheus-htpasswd --from-file secrets/auth \
-    --dry-run -o json > secret-configs/prometheus-htpasswd.json
+    --dry-run=client -o json > secret-configs/prometheus-htpasswd.json
 kubectl create secret generic locate-verify-keys --from-file secrets/locate/ \
-    --dry-run -o json > secret-configs/locate-verify-keys.json
+    --dry-run=client -o json > secret-configs/locate-verify-keys.json
 kubectl create secret generic locate-heartbeat-key --from-file secrets/locate-heartbeat/ \
-    --dry-run -o json > secret-configs/locate-heartbeat-key.json
+    --dry-run=client -o json > secret-configs/locate-heartbeat-key.json
 

--- a/manage-cluster/k8s_deploy.conf
+++ b/manage-cluster/k8s_deploy.conf
@@ -28,22 +28,26 @@ PROM_BASE_NAME="prometheus-${GCE_BASE_NAME}"
 # we learn more.
 GCE_API_SCOPES="cloud-platform"
 
-K8S_VERSION="v1.22.15"
-K8S_CNI_VERSION="v1.1.1"
-K8S_CRICTL_VERSION="v1.22.1"
+K8S_VERSION="v1.23.16" # https://github.com/kubernetes/kubernetes/releases
+K8S_CNI_VERSION="v1.2.0" # https://github.com/containernetworking/plugins/releases
+K8S_CRICTL_VERSION="v1.23.0" # https://github.com/kubernetes-sigs/cri-tools/releases
 # FLANNEL is for the flannel DaemonSet, whereas FLANNELCNI is for the CNI
 # plugin located at /opt/cni/bin (used by the kubelet).
-K8S_FLANNEL_VERSION="v0.19.2"
-K8S_FLANNELCNI_VERSION=v1.1.0
-K8S_TOOLING_VERSION="v0.14.0"
-ETCDCTL_VERSION="v3.5.5"
-K8S_HELM_VERSION="v3.10.0"
+K8S_FLANNEL_VERSION="v0.21.2" # https://github.com/flannel-io/flannel/releases
+K8S_FLANNELCNI_VERSION=v1.1.2 # https://github.com/flannel-io/cni-plugin/releases
+K8S_TOOLING_VERSION="v0.15.0" # https://github.com/kubernetes/release/releases
+# kubeadm installs and managed etcd automatically. Try to keep this version of
+# etcdctl more or less in line with the default etcd version that kubeadm uses
+# for any given release of k8s. For example, see this:
+# https://github.com/kubernetes/kubernetes/blob/v1.23.16/cmd/kubeadm/app/constants/constants.go#L304
+ETCDCTL_VERSION="v3.5.6"
+K8S_HELM_VERSION="v3.11.1" # https://github.com/helm/helm/releases
 # The Vector helm chart version we want to install.
 K8S_VECTOR_CHART="0.18.0"
 # The Docker Hub image tag for Vector (timeberio/vector:<tag>). The default
 # image is not suitable for our use case (some sort of distroless-based image).
-K8S_VECTOR_IMAGE="0.26.0-debian"
-K8S_CERTMANAGER_VERSION="v1.9.0"
+K8S_VECTOR_IMAGE="0.27.0-debian"
+K8S_CERTMANAGER_VERSION="v1.11.0"
 K8S_CERTMANAGER_DNS01_SA="cert-manager-dns01-solver"
 K8S_CERTMANAGER_SA_KEY="cert-manager-credentials.json"
 K8S_CA_FILES="ca.crt ca.key sa.key sa.pub front-proxy-ca.crt front-proxy-ca.key etcd/ca.crt etcd/ca.key"

--- a/manage-cluster/kubeadm-config.yml.template
+++ b/manage-cluster/kubeadm-config.yml.template
@@ -38,7 +38,7 @@ apiServer:
 controlPlaneEndpoint: {{LOAD_BALANCER_NAME}}.{{PROJECT}}.measurementlab.net:6443
 controllerManager:
   extraArgs:
-    node-cidr-mask-size: "26"
+    node-cidr-mask-size-ipv4: "26"
     # https://github.com/kubernetes-sigs/kubespray/blob/master/docs/kubernetes-reliability.md#medium-update-and-average-reaction
     node-monitor-grace-period: 2m
     pod-eviction-timeout: 1m


### PR DESCRIPTION
* A bare `--dry-run` has been deprecated for a long time now, and is removed in v1.23.
* `node-cidr-mask-size` is still a supported flag the kube-controller, but now that dual-stack clusters are GA, there are two new protocol-specific flags... that same flag with `-ipv4` and `-ipv6` suffixes. Just to be explicit, I'm choosing to use the new flag, rather than an implicit one.
* Control plane machine names (now that they are controlled by Terraform in sandbox) no longer begin with "master-", but instead "api-".
* Mounting a GCS bucket using gcsfuse is huge overkill for the purpose of simply uploading a single file a bucket. Instead, just us gsutil to upload the file.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/770)
<!-- Reviewable:end -->
