### PR TITLE
Strips random suffix from -token.machine flag value

### DIFF
--- a/k8s/daemonsets/experiments/ndt-virtual.jsonnet
+++ b/k8s/daemonsets/experiments/ndt-virtual.jsonnet
@@ -48,9 +48,10 @@ exp.ExperimentNoIndex(expName, 'pusher-' + std.extVar('PROJECT_ID'), 'none', dat
               // MIGs are currently only present in sandbox, so limit stripping
               // anything from the node name to sandbox.
               if std.extVar('PROJECT_ID') == 'mlab-sandbox' then 
-                '/ndt-server -token.machine=${NODE_NAME%-*} $@',
+                '/ndt-server -token.machine=${NODE_NAME%-*} $@'
               else
-                '/ndt-server -token.machine=${NODE_NAME} $@',
+                '/ndt-server -token.machine=${NODE_NAME} $@'
+              ,
               '--',
             ],
             args: [

--- a/k8s/daemonsets/experiments/ndt-virtual.jsonnet
+++ b/k8s/daemonsets/experiments/ndt-virtual.jsonnet
@@ -37,15 +37,20 @@ exp.ExperimentNoIndex(expName, 'pusher-' + std.extVar('PROJECT_ID'), 'none', dat
           {
             name: 'ndt-server',
             image: 'measurementlab/ndt-server:' + exp.ndtVersion,
-            // Virtual machines are part of managed instances groups, and each
-            // VM name ends in a random suffix. The load balancer name for the
-            // machine (no suffix) is the name used to generate tokens, so we
-            // strip off suffix and use that name as the value for the
+            // Virtual machines are part of managed instances groups (MIG), and
+            // each VM name ends in a random suffix. The load balancer name for
+            // the machine (no suffix) is the name used to generate tokens, so
+            // we strip off suffix and use that name as the value for the
             // -token.machine flag.
             command: [
               '/bin/sh',
               '-c',
-              '/ndt-server -token.machine=${NODE_NAME%-*} $@',
+              // MIGs are currently only present in sandbox, so limit stripping
+              // anything from the node name to sandbox.
+              if std.extVar('PROJECT_ID') == 'mlab-sandbox' then 
+                '/ndt-server -token.machine=${NODE_NAME%-*} $@',
+              else
+                '/ndt-server -token.machine=${NODE_NAME} $@',
               '--',
             ],
             args: [

--- a/k8s/daemonsets/experiments/ndt-virtual.jsonnet
+++ b/k8s/daemonsets/experiments/ndt-virtual.jsonnet
@@ -37,6 +37,17 @@ exp.ExperimentNoIndex(expName, 'pusher-' + std.extVar('PROJECT_ID'), 'none', dat
           {
             name: 'ndt-server',
             image: 'measurementlab/ndt-server:' + exp.ndtVersion,
+            // Virtual machines are part of managed instances groups, and each
+            // VM name ends in a random suffix. The load balancer name for the
+            // machine (no suffix) is the name used to generate tokens, so we
+            // strip off suffix and use that name as the value for the
+            // -token.machine flag.
+            command: [
+              '/bin/sh',
+              '-c',
+              '/ndt-server -token.machine=${NODE_NAME%-*} $@',
+              '--',
+            ],
             args: [
               '-ndt5_addr=127.0.0.1:3002', // any non-public port.
               '-ndt5_ws_addr=:3001', // default, public ndt5 port.
@@ -48,7 +59,6 @@ exp.ExperimentNoIndex(expName, 'pusher-' + std.extVar('PROJECT_ID'), 'none', dat
               '-datadir=/var/spool/' + expName,
               '-key=/certs/tls.key',
               '-cert=/certs/tls.crt',
-              '-token.machine=$(NODE_NAME)',
               '-token.verify-key=/verify/jwk_sig_EdDSA_locate_20200409.pub',
               '-txcontroller.device=ens4',
               // GCE VMs have an egress rate limit of 7Gbps to Internet


### PR DESCRIPTION
Machines that are part of managed instance groups have a random suffix. This change feeds the -token.machine flag the node name minus the suffix, since this name is used when generating access tokens.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/771)
<!-- Reviewable:end -->
