### PR TITLE
Updates flanneld container image repo

### DIFF
--- a/k8s/daemonsets/core/flannel-physical.jsonnet
+++ b/k8s/daemonsets/core/flannel-physical.jsonnet
@@ -59,7 +59,7 @@
                 },
               },
             ],
-            image: 'rancher/mirrored-flannelcni-flannel:' + std.extVar('K8S_FLANNEL_VERSION') + '-amd64',
+            image: 'flannel/flannel:' + std.extVar('K8S_FLANNEL_VERSION') + '-amd64',
             name: 'flannel',
             resources: {
               limits: {
@@ -103,7 +103,7 @@
             command: [
               'cp',
             ],
-            image: 'rancher/mirrored-flannelcni-flannel:' + std.extVar('K8S_FLANNEL_VERSION') + '-amd64',
+            image: 'flannel/flannel:' + std.extVar('K8S_FLANNEL_VERSION') + '-amd64',
             name: 'install-cni',
             volumeMounts: [
               {

--- a/k8s/daemonsets/core/flannel-virtual.jsonnet
+++ b/k8s/daemonsets/core/flannel-virtual.jsonnet
@@ -62,7 +62,7 @@
                 },
               },
             ],
-            image: 'rancher/mirrored-flannelcni-flannel:' + std.extVar('K8S_FLANNEL_VERSION') + '-amd64',
+            image: 'flannel/flannel:' + std.extVar('K8S_FLANNEL_VERSION') + '-amd64',
             name: 'flannel',
             resources: {
               limits: {
@@ -106,7 +106,7 @@
             command: [
               'cp',
             ],
-            image: 'rancher/mirrored-flannelcni-flannel:' + std.extVar('K8S_FLANNEL_VERSION') + '-amd64',
+            image: 'flannel/flannel:' + std.extVar('K8S_FLANNEL_VERSION') + '-amd64',
             name: 'install-cni',
             volumeMounts: [
               {


### PR DESCRIPTION
Flannels own sample DaemonSet manifests uses to point to the odd Rancher Docker Hub repo. I just noticed that they now point to flannel/flannel, and that rancher repo doesn't have the lastest versions of flannel.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/773)
<!-- Reviewable:end -->
