### PR TITLE
Updates Vector to v0.28.0

### DIFF
--- a/manage-cluster/k8s_deploy.conf
+++ b/manage-cluster/k8s_deploy.conf
@@ -43,10 +43,10 @@ K8S_TOOLING_VERSION="v0.15.0" # https://github.com/kubernetes/release/releases
 ETCDCTL_VERSION="v3.5.6"
 K8S_HELM_VERSION="v3.11.1" # https://github.com/helm/helm/releases
 # The Vector helm chart version we want to install.
-K8S_VECTOR_CHART="0.18.0"
+K8S_VECTOR_CHART="0.20.0"
 # The Docker Hub image tag for Vector (timeberio/vector:<tag>). The default
 # image is not suitable for our use case (some sort of distroless-based image).
-K8S_VECTOR_IMAGE="0.27.0-debian"
+K8S_VECTOR_IMAGE="0.28.0-debian"
 K8S_CERTMANAGER_VERSION="v1.11.0"
 K8S_CERTMANAGER_DNS01_SA="cert-manager-dns01-solver"
 K8S_CERTMANAGER_SA_KEY="cert-manager-credentials.json"


### PR DESCRIPTION
The release contains this:

> Vector GCP sinks now correctly refresh authentication tokens when healthchecks are disabled. Thanks to [punkerpunker](https://github.com/punkerpunker) for contributing this change!

... which hopefully could resolve the issues we've been seeing with auth tokens expiring.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/775)
<!-- Reviewable:end -->
