### PR TITLE
Configure nodeinfo to use jostler for autoloading

### DIFF
--- a/config/nodeinfo/config.jsonnet
+++ b/config/nodeinfo/config.jsonnet
@@ -1,52 +1,34 @@
 [
   {
-    Datatype: 'lshw',
-    Filename: 'lshw.json',
-    Cmd: ['lshw', '-json'],
+    Name: 'lshw',
+    Cmd: ['lshw'],
   },
   {
-    Datatype: 'lspci',
-    Filename: 'lspci.txt',
+    Name: 'lspci',
     Cmd: ['lspci', '-mm', '-vv', '-k', '-nn'],
   },
   {
-    Datatype: 'lsusb',
-    Filename: 'lsusb.txt',
+    Name: 'lsusb',
     Cmd: ['lsusb', '-v'],
   },
   {
-    Datatype: 'ipaddress',
-    Filename: 'ip-address.txt',
+    Name: 'ipaddress',
     Cmd: ['ip', 'address', 'show'],
   },
   {
-    Datatype: 'iproute4',
-    Filename: 'ip-route-4.txt',
+    Name: 'iproute4',
     Cmd: ['ip', '-4', 'route', 'show'],
   },
   {
-    Datatype: 'iproute6',
-    Filename: 'ip-route-6.txt',
+    Name: 'iproute6',
     Cmd: ['ip', '-6', 'route', 'show'],
   },
   {
-    Datatype: 'uname',
-    Filename: 'uname.txt',
+    Name: 'uname',
     Cmd: ['uname', '-a'],
   },
   {
-    Datatype: 'osrelease',
-    Filename: 'os-release.txt',
+    Name: 'osrelease',
     Cmd: ['cat', '/etc/os-release'],
-  },
-  {
-    Datatype: 'biosversion',
-    Filename: 'bios_version.txt',
-    Cmd: ['cat', '/sys/class/dmi/id/bios_version'],
-  },
-  {
-    Datatype: 'chassisserial',
-    Filename: 'chassis_serial.txt',
-    Cmd: ['cat', '/sys/class/dmi/id/chassis_serial'],
   },
 ]

--- a/k8s/daemonsets/core/host.jsonnet
+++ b/k8s/daemonsets/core/host.jsonnet
@@ -4,16 +4,15 @@ local exp = import '../templates.jsonnet';
 local expName = 'host';
 
 local nodeinfoconfig = import '../../../config/nodeinfo/config.jsonnet';
-local nodeinfo_datatypes = [d.Datatype for d in nodeinfoconfig];
 
-exp.ExperimentNoIndex(expName, 'pusher-' + std.extVar('PROJECT_ID'), "none", nodeinfo_datatypes, [], true) + {
+exp.ExperimentNoIndex(expName, 'pusher-' + std.extVar('PROJECT_ID'), "none", [], ['nodeinfo1'], true) + {
   spec+: {
     template+: {
       spec+: {
         containers+: [
           {
             name: 'nodeinfo',
-            image: 'measurementlab/nodeinfo:v1.2.1',
+            image: 'measurementlab/nodeinfo:v1.3.4',
             args: [
               '-datadir=/var/spool/' + expName,
               '-wait=6h',
@@ -30,6 +29,11 @@ exp.ExperimentNoIndex(expName, 'pusher-' + std.extVar('PROJECT_ID'), "none", nod
                 mountPath: '/etc/os-release',
                 name: 'etc-os-release',
                 readOnly: true,
+              },
+              {
+                mountPath: '/var/spool/datatypes',
+                name: 'var-spool-datatypes',
+                readOnly: false,
               },
               exp.VolumeMount(expName),
             ],


### PR DESCRIPTION
This commit configures nodeinfo:v1.3.4 to use jostler:v1.0.3, the upload agent on M-Lab nodes.

Changes were tested by verifying the contents of nodeinfo1 and index1 bundles in the pusher-mlab-sandbox/autoload/v1 bucket.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/779)
<!-- Reviewable:end -->
