### PR TITLE
Update MSAK container image and configuration

### DIFF
--- a/k8s/daemonsets/experiments/msak.jsonnet
+++ b/k8s/daemonsets/experiments/msak.jsonnet
@@ -1,8 +1,8 @@
-local datatypes = ['ndtm'];
+local datatypes = ['ndt8'];
 local exp = import '../templates.jsonnet';
 local expName = 'msak';
 local services = [
-  'msak/ndtm=ws:///msak/ndtm/download,ws:///msak/ndtm/upload,wss:///msak/ndtm/download,wss:///msak/ndtm/upload',
+  'msak/ndt8=ws:///msak/ndt8/download,ws:///msak/ndt8/upload,wss:///msak/ndt8/download,wss:///msak/ndt8/upload',
 ];
 
 exp.Experiment(expName, 1, 'pusher-' + std.extVar('PROJECT_ID'), "none", datatypes, []) + {
@@ -26,7 +26,6 @@ exp.Experiment(expName, 1, 'pusher-' + std.extVar('PROJECT_ID'), "none", datatyp
               '-token.machine=$(NODE_NAME)',
               '-token.verify-key=/verify/jwk_sig_EdDSA_locate_20200409.pub',
               '-token.verify=true',
-              '-debug=true',
             ],
             env: [
               {
@@ -38,7 +37,7 @@ exp.Experiment(expName, 1, 'pusher-' + std.extVar('PROJECT_ID'), "none", datatyp
                 },
               },
             ],
-            image: 'evfirerob/msak:latest',
+            image: 'measurementlab/msak:latest',
             name: 'msak',
             command: [
               '/msak/msak-server',

--- a/k8s/daemonsets/experiments/msak.jsonnet
+++ b/k8s/daemonsets/experiments/msak.jsonnet
@@ -2,7 +2,7 @@ local datatypes = ['ndt8'];
 local exp = import '../templates.jsonnet';
 local expName = 'msak';
 local services = [
-  'msak/ndt8=ws:///msak/ndt8/download,ws:///msak/ndt8/upload,wss:///msak/ndt8/download,wss:///msak/ndt8/upload',
+  'msak/ndt8=ws:///ndt/v8/download,ws:///ndt/v8/upload,wss:///ndt/v8/download,wss:///ndt/v8/upload',
 ];
 
 exp.Experiment(expName, 1, 'pusher-' + std.extVar('PROJECT_ID'), "none", datatypes, []) + {


### PR DESCRIPTION
Updates the MSAK image name to be the one in the measurementlab namespace rather than the one in my own namespace. Also, the datatype's name is now officially `ndt8` and the URLs have been updated to reflect the MSAK design document.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/786)
<!-- Reviewable:end -->
