### PR TITLE
Deploy MSAK daemonset in staging

### DIFF
--- a/k8s/daemonsets/experiments/msak.jsonnet
+++ b/k8s/daemonsets/experiments/msak.jsonnet
@@ -37,7 +37,7 @@ exp.Experiment(expName, 1, 'pusher-' + std.extVar('PROJECT_ID'), "none", datatyp
                 },
               },
             ],
-            image: 'measurementlab/msak:latest',
+            image: 'measurementlab/msak:v0.0-alpha1',
             name: 'msak',
             command: [
               '/msak/msak-server',

--- a/system.jsonnet
+++ b/system.jsonnet
@@ -27,9 +27,9 @@
       import 'k8s/daemonsets/experiments/msak.jsonnet',
     ] else []
   ) + (
-    if std.extVar('PROJECT_ID') == "mlab-staging' then [
+    if std.extVar('PROJECT_ID') == 'mlab-staging' then [
       import 'k8s/daemonsets/experiments/msak.jsonnet',
-    ]
+    ] else []
   ) + [
     import 'k8s/daemonsets/experiments/wehe.jsonnet',
     // Deployments

--- a/system.jsonnet
+++ b/system.jsonnet
@@ -26,6 +26,10 @@
       import 'k8s/daemonsets/experiments/responsiveness.jsonnet',
       import 'k8s/daemonsets/experiments/msak.jsonnet',
     ] else []
+  ) + (
+    if std.extVar('PROJECT_ID') == "mlab-staging' then [
+      import 'k8s/daemonsets/experiments/msak.jsonnet',
+    ]
   ) + [
     import 'k8s/daemonsets/experiments/wehe.jsonnet',
     // Deployments


### PR DESCRIPTION
This PR adds a conditional to system.jsonnet to deploy MSAK's `latest` image from Docker Hub in staging, too. This will give people working on MSAK clients a larger platform to experiment with than just sandbox servers, ever if there is no tagged release of msak-server yet.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/787)
<!-- Reviewable:end -->
