### PR TITLE
Change output datatypes for annotation2 and hopanntation2

### DIFF
--- a/config/prometheus/alerts.yml
+++ b/config/prometheus/alerts.yml
@@ -577,20 +577,7 @@ groups:
           label_replace(datatype:pusher_bytes_per_tarfile:increase24h offset 1d, "delay", "1d", "", ".*") or
           label_replace(datatype:pusher_bytes_per_tarfile:increase24h offset 3d, "delay", "3d", "", ".*") or
           label_replace(datatype:pusher_bytes_per_tarfile:increase24h offset 5d, "delay", "5d", "", ".*") or
-            label_replace(datatype:pusher_bytes_per_tarfile:increase24h offset 1w, "delay", "7d", "", ".*") or
-            label_replace(label_replace(vector(0), "delay", "c1", "", ".*"), "datatype", "ndt5", "", ".*") or
-            label_replace(label_replace(vector(0), "delay", "c2", "", ".*"), "datatype", "ndt5", "", ".*") or
-            label_replace(label_replace(vector(0), "delay", "c1", "", ".*"), "datatype", "pcap", "", ".*") or
-            label_replace(label_replace(vector(0), "delay", "c2", "", ".*"), "datatype", "pcap", "", ".*") or
-            label_replace(label_replace(vector(0), "delay", "c1", "", ".*"), "datatype", "switch", "", ".*") or
-            label_replace(label_replace(vector(0), "delay", "c2", "", ".*"), "datatype", "switch", "", ".*") or
-            label_replace(label_replace(vector(0), "delay", "c1", "", ".*"), "datatype", "tcpinfo", "", ".*") or
-            label_replace(label_replace(vector(0), "delay", "c2", "", ".*"), "datatype", "tcpinfo", "", ".*") or
-            label_replace(label_replace(vector(0), "delay", "c1", "", ".*"), "datatype", "scamper1", "", ".*") or
-            label_replace(label_replace(vector(0), "delay", "c2", "", ".*"), "datatype", "scamper1", "", ".*") or
-            label_replace(label_replace(vector(0), "delay", "c1", "", ".*"), "datatype", "hopannotation1", "", ".*") or
-            label_replace(label_replace(vector(0), "delay", "c2", "", ".*"), "datatype", "hopannotation1", "", ".*")
-            ))
+          label_replace(datatype:pusher_bytes_per_tarfile:increase24h offset 1w, "delay", "7d", "", ".*")))
     for: 2h
     labels:
       repo: dev-tracker
@@ -613,8 +600,7 @@ groups:
           label_replace(datatype:pusher_bytes_per_tarfile:increase24h{datatype="replay"} offset 1d, "delay", "1d", "", ".*") or
           label_replace(datatype:pusher_bytes_per_tarfile:increase24h{datatype="replay"} offset 3d, "delay", "3d", "", ".*") or
           label_replace(datatype:pusher_bytes_per_tarfile:increase24h{datatype="replay"} offset 5d, "delay", "5d", "", ".*") or
-          label_replace(datatype:pusher_bytes_per_tarfile:increase24h offset 1w, "delay", "7d", "", ".*")
-          ))
+          label_replace(datatype:pusher_bytes_per_tarfile:increase24h{datatype="replay"} offset 1w, "delay", "7d", "", ".*")))
     for: 2h
     labels:
       repo: dev-tracker

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -183,7 +183,7 @@ local Traceroute(expName, tcpPort, hostNetwork, anonMode) = [
       '-IPCacheUpdatePeriod=1m',
       '-scamper.timeout=30m',
       '-scamper.tracelb-W=15',
-      '-hopannotation-output=' + VolumeMount(expName).mountPath + '/hopannotation1',
+      '-hopannotation-output=' + VolumeMount(expName).mountPath + '/hopannotation2',
       '-ipservice.sock=' + uuidannotatorServiceVolume.socketFilename,
       '-anonymize.ip=' + anonMode,
     ],
@@ -403,7 +403,7 @@ local UUIDAnnotator(expName, tcpPort, hostNetwork) = [
         '-prometheusx.listen-address=127.0.0.1:' + tcpPort
       else
         '-prometheusx.listen-address=$(PRIVATE_IP):' + tcpPort,
-      '-datadir=' + VolumeMount(expName).mountPath + '/annotation',
+      '-datadir=' + VolumeMount(expName).mountPath + '/annotation2',
       '-tcpinfo.eventsocket=' + tcpinfoServiceVolume.socketFilename,
       '-ipservice.sock=' + uuidannotatorServiceVolume.socketFilename,
       '-maxmind.url=gs://downloader-' + PROJECT_ID + '/Maxmind/current/GeoLite2-City.tar.gz',
@@ -556,7 +556,7 @@ local Metadata = {
 };
 
 local ExperimentNoIndex(name, bucket, anonMode, datatypes, datatypesAutoloaded, hostNetwork, siteType='physical') = {
-  local allDatatypes =  ['tcpinfo', 'pcap', 'annotation', 'scamper1', 'hopannotation1'] + datatypes,
+  local allDatatypes =  ['tcpinfo', 'pcap', 'annotation2', 'scamper1', 'hopannotation2'] + datatypes,
   local allVolumes = datatypes + datatypesAutoloaded,
   apiVersion: 'apps/v1',
   kind: 'DaemonSet',


### PR DESCRIPTION
This change is part of the [Correcting Network Annotations](https://docs.google.com/document/d/1Aro-2G0pGBNfR5sweUcioraik3PXdZRwphwcZzkovB0/edit) design. This change modifies the output datatypes for the annotation2 and hopannotation2 datatypes so that the reannotator and renamer can operate on a complete set of archives.

This change is part of steps to repair:
* https://github.com/m-lab/data-annotations/issues/34

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/789)
<!-- Reviewable:end -->
