### PR TITLE
Set 5Gi memory limit for the wehe container

### DIFF
--- a/k8s/daemonsets/experiments/wehe.jsonnet
+++ b/k8s/daemonsets/experiments/wehe.jsonnet
@@ -132,7 +132,7 @@ exp.Experiment(expName, 5, 'pusher-' + std.extVar('PROJECT_ID'), 'netblock', ['r
             },
             resources+: {
               limits: {
-                [if std.extVar('PROJECT_ID') != "mlab-oti" then 'memory']: "5Gi",
+                [if std.extVar('PROJECT_ID') == "mlab-oti" then 'memory']: "5Gi",
               },
             },
             // Advertise the prometheus port so it can be discovered by Prometheus.

--- a/k8s/daemonsets/experiments/wehe.jsonnet
+++ b/k8s/daemonsets/experiments/wehe.jsonnet
@@ -131,8 +131,8 @@ exp.Experiment(expName, 5, 'pusher-' + std.extVar('PROJECT_ID'), 'netblock', ['r
               periodSeconds: 30,
             },
             resources+: {
-              requests: {
-                memory: 5Gi,
+              limits: {
+                memory: "5Gi",
               },
             },
             // Advertise the prometheus port so it can be discovered by Prometheus.

--- a/k8s/daemonsets/experiments/wehe.jsonnet
+++ b/k8s/daemonsets/experiments/wehe.jsonnet
@@ -130,6 +130,11 @@ exp.Experiment(expName, 5, 'pusher-' + std.extVar('PROJECT_ID'), 'netblock', ['r
               timeoutSeconds: 10,
               periodSeconds: 30,
             },
+            resources+: {
+              requests: {
+                memory: 5Gi,
+              },
+            },
             // Advertise the prometheus port so it can be discovered by Prometheus.
             ports: [
               {

--- a/k8s/daemonsets/experiments/wehe.jsonnet
+++ b/k8s/daemonsets/experiments/wehe.jsonnet
@@ -132,7 +132,7 @@ exp.Experiment(expName, 5, 'pusher-' + std.extVar('PROJECT_ID'), 'netblock', ['r
             },
             resources+: {
               limits: {
-                [if std.extVar('PROJECT_ID') == "mlab-oti" then 'memory']: "5Gi",
+                [if std.extVar('PROJECT_ID') != "mlab-oti" then 'memory']: "5Gi",
               },
             },
             // Advertise the prometheus port so it can be discovered by Prometheus.

--- a/k8s/daemonsets/experiments/wehe.jsonnet
+++ b/k8s/daemonsets/experiments/wehe.jsonnet
@@ -132,7 +132,7 @@ exp.Experiment(expName, 5, 'pusher-' + std.extVar('PROJECT_ID'), 'netblock', ['r
             },
             resources+: {
               limits: {
-                memory: "5Gi",
+                [if std.extVar('PROJECT_ID') != "mlab-oti" then 'memory']: "5Gi",
               },
             },
             // Advertise the prometheus port so it can be discovered by Prometheus.


### PR DESCRIPTION
This PR sets an experimental 5Gi memory limit for the wehe container that will only apply to sandbox and staging for now.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/794)
<!-- Reviewable:end -->
