### PR TITLE
Don't run wehe containers as root

### DIFF
--- a/k8s/daemonsets/experiments/wehe.jsonnet
+++ b/k8s/daemonsets/experiments/wehe.jsonnet
@@ -153,7 +153,6 @@ exp.Experiment(expName, 5, 'pusher-' + std.extVar('PROJECT_ID'), 'netblock', ['r
                   'all'
                 ],
               },
-              runAsUser: 0,
             },
             startupProbe+: {
               httpGet: {


### PR DESCRIPTION
I thought that this should have already been the case, but was surprised to see wehe processes running as root in staging, and then getting permission denied errors to write to /var/spool/wehe/replay (owned by nobody:nogroup). I had to manually resolve numerous conflicts manually in the wehe manifest when I rebased my "non-root" branch changes on main, and it's not impossible that I made a mistake in there.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/796)
<!-- Reviewable:end -->
