### PR TITLE
Set memory requests for wehe to 1Gi

### DIFF
--- a/k8s/daemonsets/experiments/wehe.jsonnet
+++ b/k8s/daemonsets/experiments/wehe.jsonnet
@@ -141,6 +141,9 @@ exp.Experiment(expName, 5, 'pusher-' + std.extVar('PROJECT_ID'), 'netblock', ['r
               limits: {
                 [if std.extVar('PROJECT_ID') != "mlab-oti" then 'memory']: "5Gi",
               },
+              requests: {
+                [if std.extVar('PROJECT_ID') != "mlab-oti" then 'memory']: "1Gi",
+              },
             },
             // Wehe runs packet captures, which requires being root. Run as
             // root, but with only the NET_RAW capability.


### PR DESCRIPTION
This [PR](https://github.com/m-lab/k8s-support/pull/794) previously set the memory limit for the wehe container to 5Gi, but I hadn't realized that it would also set a corresponding `requests` to the same value, meaning that 5Gi of free memory are currently needed for a wehe pod to be scheduled on a node -- not the intended effect.

This change explicitly sets the `requests.memory` value for wehe to the much lower value of 1Gi.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/797)
<!-- Reviewable:end -->
