### PR TITLE
Always apply limits/requests to the wehe container

### DIFF
--- a/k8s/daemonsets/experiments/wehe.jsonnet
+++ b/k8s/daemonsets/experiments/wehe.jsonnet
@@ -139,10 +139,10 @@ exp.Experiment(expName, 5, 'pusher-' + std.extVar('PROJECT_ID'), 'netblock', ['r
             ],
             resources+: {
               limits: {
-                [if std.extVar('PROJECT_ID') != "mlab-oti" then 'memory']: "5Gi",
+                memory: "5Gi",
               },
               requests: {
-                [if std.extVar('PROJECT_ID') != "mlab-oti" then 'memory']: "1Gi",
+                memory: "1Gi",
               },
             },
             // Wehe runs packet captures, which requires being root. Run as


### PR DESCRIPTION
This limit was previous under testing in the sandbox and staging environments. With this change, it will be applied in production, too.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/799)
<!-- Reviewable:end -->
