### PR TITLE
Runs set-up-uuid-prefix-file initContainer as root

### DIFF
--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -40,6 +40,9 @@ local uuid = {
         },
       },
     ],
+    securityContext: {
+      runAsUser: 0,
+    },
     volumeMounts: [
       uuid.volumemount {
         readOnly: false,


### PR DESCRIPTION
For some reason it seems to run okay as non-root most of the time, but I noticed a few instances in production where this initContainer was getting a permission denied error when writing out the prefix file. I think its okay to run this initContainer as root.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/800)
<!-- Reviewable:end -->
