### PR TITLE
Autoload the ndt8 datatype

### DIFF
--- a/k8s/daemonsets/experiments/msak.jsonnet
+++ b/k8s/daemonsets/experiments/msak.jsonnet
@@ -1,7 +1,7 @@
 local datatypes = ['ndt8'];
 local exp = import '../templates.jsonnet';
 local expName = 'msak';
-local expVersion = 'v0.0-alpha1',
+local expVersion = 'v0.0-alpha1';
 local services = [
   'msak/ndt8=ws:///ndt/v8/download,ws:///ndt/v8/upload,wss:///ndt/v8/download,wss:///ndt/v8/upload',
 ];

--- a/k8s/daemonsets/experiments/msak.jsonnet
+++ b/k8s/daemonsets/experiments/msak.jsonnet
@@ -22,7 +22,9 @@ exp.Experiment(expName, 1, 'pusher-' + std.extVar('PROJECT_ID'), "none", [], dat
             // for the ndt8 datatype.
             name: 'generate-jostler-schema',
             image: 'measurementlab/msak:' + expVersion,
-            command: 'generate-schema',
+            command: [
+              'generate-schema',
+            ],
             volumeMounts: [
               {
                 mountPath: '/var/spool/datatypes',

--- a/k8s/daemonsets/experiments/msak.jsonnet
+++ b/k8s/daemonsets/experiments/msak.jsonnet
@@ -23,7 +23,9 @@ exp.Experiment(expName, 1, 'pusher-' + std.extVar('PROJECT_ID'), "none", [], dat
             name: 'generate-jostler-schema',
             image: 'measurementlab/msak:' + expVersion,
             command: [
-              'generate-schema',
+              '/bin/sh',
+              '-c',
+              './generate-schema',
             ],
             volumeMounts: [
               {

--- a/k8s/daemonsets/experiments/msak.jsonnet
+++ b/k8s/daemonsets/experiments/msak.jsonnet
@@ -25,7 +25,7 @@ exp.Experiment(expName, 1, 'pusher-' + std.extVar('PROJECT_ID'), "none", [], dat
             command: [
               '/bin/sh',
               '-c',
-              './generate-schema',
+              '/msak/generate-schema',
             ],
             volumeMounts: [
               {

--- a/k8s/daemonsets/experiments/msak.jsonnet
+++ b/k8s/daemonsets/experiments/msak.jsonnet
@@ -1,6 +1,7 @@
 local datatypes = ['ndt8'];
 local exp = import '../templates.jsonnet';
 local expName = 'msak';
+local expVersion = 'v0.0-alpha1',
 local services = [
   'msak/ndt8=ws:///ndt/v8/download,ws:///ndt/v8/upload,wss:///ndt/v8/download,wss:///ndt/v8/upload',
 ];
@@ -15,6 +16,22 @@ exp.Experiment(expName, 1, 'pusher-' + std.extVar('PROJECT_ID'), "none", [], dat
       },
       spec+: {
         serviceAccountName: 'heartbeat-experiment',
+        initContainers+: [
+          {
+            // Run the generate-schema utility to create the JSON schema file
+            // for the ndt8 datatype.
+            name: 'generate-jostler-schema',
+            image: 'measurementlab/msak:' + expVersion,
+            command: 'generate-schema',
+            volumeMounts: [
+              {
+                mountPath: '/var/spool/datatypes',
+                name: 'var-spool-datatypes',
+                readOnly: false,
+              },
+            ],
+          },
+        ],
         containers+: [
           {
             args: [
@@ -37,7 +54,7 @@ exp.Experiment(expName, 1, 'pusher-' + std.extVar('PROJECT_ID'), "none", [], dat
                 },
               },
             ],
-            image: 'measurementlab/msak:v0.0-alpha1',
+            image: 'measurementlab/msak:' + expVersion,
             name: 'msak',
             command: [
               '/msak/msak-server',

--- a/k8s/daemonsets/experiments/msak.jsonnet
+++ b/k8s/daemonsets/experiments/msak.jsonnet
@@ -5,7 +5,7 @@ local services = [
   'msak/ndt8=ws:///ndt/v8/download,ws:///ndt/v8/upload,wss:///ndt/v8/download,wss:///ndt/v8/upload',
 ];
 
-exp.Experiment(expName, 1, 'pusher-' + std.extVar('PROJECT_ID'), "none", datatypes, []) + {
+exp.Experiment(expName, 1, 'pusher-' + std.extVar('PROJECT_ID'), "none", [], datatypes) + {
   spec+: {
     template+: {
       metadata+: {

--- a/k8s/daemonsets/experiments/msak.jsonnet
+++ b/k8s/daemonsets/experiments/msak.jsonnet
@@ -18,14 +18,13 @@ exp.Experiment(expName, 1, 'pusher-' + std.extVar('PROJECT_ID'), "none", [], dat
         serviceAccountName: 'heartbeat-experiment',
         initContainers+: [
           {
-            // Run the generate-schema utility to create the JSON schema file
-            // for the ndt8 datatype.
-            name: 'generate-jostler-schema',
+            // Copy the JSON schema where jostler expects it to be.
+            name: 'copy-schema',
             image: 'measurementlab/msak:' + expVersion,
             command: [
               '/bin/sh',
               '-c',
-              '/msak/generate-schema',
+              'cp /msak/ndt8.json /var/spool/datatypes/ndt8.json',
             ],
             volumeMounts: [
               {


### PR DESCRIPTION
This PR replaces pusher with jostler in the msak daemonset.

The schema file is expected to be provided in the Docker image's root as `ndt8.json` (see https://github.com/m-lab/msak/pull/12). An initContainer to copy the schema where jostler expects it to be seemed cleaner than running `cp ... && /msak/msak-server` in the main container.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/801)
<!-- Reviewable:end -->
