### PR TITLE
Do not drop privileges in ndt-virtual's ndt containers

### DIFF
--- a/k8s/daemonsets/experiments/ndt-virtual.jsonnet
+++ b/k8s/daemonsets/experiments/ndt-virtual.jsonnet
@@ -94,9 +94,6 @@ exp.ExperimentNoIndex(expName, 'pusher-' + std.extVar('PROJECT_ID'), 'none', dat
                 add: [
                   'NET_BIND_SERVICE',
                 ],
-                drop: [
-                  'all',
-                ],
               },
               runAsUser: 0,
             },


### PR DESCRIPTION
For the past few days, the ndt-server instances running on virtual nodes were not able to write to the output folder due to permission issues. This temporary workaround was put in place by @stephen-soltesz through manual editing of the ndt-virtual DS in production.

This PR aligns the ndt-virtual DS with what's currently running in production so we can deploy k8s-support while looking for a better long-term solution.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/802)
<!-- Reviewable:end -->
