### PR TITLE
Fix ndt-virtual's permission issue

### DIFF
--- a/k8s/daemonsets/experiments/ndt-virtual.jsonnet
+++ b/k8s/daemonsets/experiments/ndt-virtual.jsonnet
@@ -99,7 +99,6 @@ exp.ExperimentNoIndex(expName, 'pusher-' + std.extVar('PROJECT_ID'), 'none', dat
                 ],
               },
               runAsUser: 0,
-              runAsGroup: 65534,
             },
             volumeMounts: [
               {

--- a/k8s/daemonsets/experiments/ndt-virtual.jsonnet
+++ b/k8s/daemonsets/experiments/ndt-virtual.jsonnet
@@ -94,6 +94,9 @@ exp.ExperimentNoIndex(expName, 'pusher-' + std.extVar('PROJECT_ID'), 'none', dat
                 add: [
                   'NET_BIND_SERVICE',
                 ],
+                drop: [
+                  'all',
+                ],
               },
               runAsUser: 0,
             },

--- a/k8s/daemonsets/experiments/ndt-virtual.jsonnet
+++ b/k8s/daemonsets/experiments/ndt-virtual.jsonnet
@@ -99,6 +99,7 @@ exp.ExperimentNoIndex(expName, 'pusher-' + std.extVar('PROJECT_ID'), 'none', dat
                 ],
               },
               runAsUser: 0,
+              runAsGroup: 65534,
             },
             volumeMounts: [
               {

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -126,7 +126,7 @@ local setDataDirOwnership(name) = {
     command: [
       '/bin/sh',
       '-c',
-      'cd ' + dataDir + ' && chown -R 65534:65534 . && chmod 2775 .',
+      'cd ' + dataDir + ' && chown -R 65534:65534 . && chmod -R 2775 .',
     ],
     securityContext: {
       runAsUser: 0,

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -126,7 +126,7 @@ local setDataDirOwnership(name) = {
     command: [
       '/bin/sh',
       '-c',
-      'cd ' + dataDir + ' && chown -R 65534:65534 . && chmod -R 2775 .',
+      'cd ' + dataDir + ' && chown -R 65534:65534 . && chmod 2775 . && chmod 2775 *',
     ],
     securityContext: {
       runAsUser: 0,


### PR DESCRIPTION
The ndt/ndt5 and ndt/ndt7 folders are created by Kubernetes as soon as the pod is created, with owner root/root and permissions 0755.

The set-data-dir-perms initContainer then sets the owner of /var/spool/ndt to nobody/nogroup (recursively) and permissions to `2775` (775 + setgid bit) but does not do so for subfolders, leaving the ndt/ndt5 and ndt/ndt7 with their original 0755 permissions which only allow the `nobody` user to write there. 

In the ndt-virtual DS, ndt-server runs as capability-less root (so, uid=0 but no root privileges), thus it cannot write to the output folder.

This PR fixes that by:
1. Applying the 2775 permissions to subfolders, so ndt/ndt5 and ndt/ndt7 become group-writable
2. Restoring the `drop: all` that was introduced by #802 as a workaround