### PR TITLE
Updates Vector to v0.30.0

### DIFF
--- a/manage-cluster/k8s_deploy.conf
+++ b/manage-cluster/k8s_deploy.conf
@@ -42,8 +42,8 @@ K8S_TOOLING_VERSION="v0.15.0" # https://github.com/kubernetes/release/releases
 # https://github.com/kubernetes/kubernetes/blob/v1.23.16/cmd/kubeadm/app/constants/constants.go#L304
 ETCDCTL_VERSION="v3.5.6"
 K8S_HELM_VERSION="v3.11.1" # https://github.com/helm/helm/releases
-K8S_VECTOR_VERSION="0.28.0-debian"
-K8S_VECTOR_CHART="0.20.0"
+K8S_VECTOR_VERSION="0.30.0-debian"
+K8S_VECTOR_CHART="0.22.0"
 K8S_KURED_VERSION="1.10.2"
 K8S_KURED_CHART="4.4.1"
 K8S_CERTMANAGER_VERSION="v1.11.0"


### PR DESCRIPTION
This new version apparently contains the fix for the ACCESS_TOKEN_EXPIRED errors we have been seeing in Vector pods.

https://github.com/vectordotdev/vector/pull/17297
https://vector.dev/releases/0.30.0/

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/806)
<!-- Reviewable:end -->
