### PR TITLE
Remove the -maxdepth flag from find

### DIFF
--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -127,7 +127,7 @@ local setDataDirOwnership(name) = {
       '/bin/sh',
       '-c',
       'cd ' + dataDir + ' && chown -R 65534:65534 . && ' +
-      'find . -type d -exec chmod 2775 {} +',
+      'find . -type d -exec chmod 2775 {} \\;',
     ],
     securityContext: {
       runAsUser: 0,

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -127,7 +127,7 @@ local setDataDirOwnership(name) = {
       '/bin/sh',
       '-c',
       'cd ' + dataDir + ' && chown -R 65534:65534 . && ' +
-      'find . -maxdepth 1 -type d -exec chmod 2775 {} +',
+      'find . -type d -exec chmod 2775 {} +',
     ],
     securityContext: {
       runAsUser: 0,


### PR DESCRIPTION
This makes sure all the folders that already exist when the pod starts are group-writable.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/807)
<!-- Reviewable:end -->
