### PR TITLE
Enable msak deployment in every project

### DIFF
--- a/k8s/daemonsets/experiments/msak.jsonnet
+++ b/k8s/daemonsets/experiments/msak.jsonnet
@@ -46,6 +46,8 @@ exp.Experiment(expName, 1, 'pusher-' + std.extVar('PROJECT_ID'), "none", [], dat
               '-token.machine=$(NODE_NAME)',
               '-token.verify-key=/verify/jwk_sig_EdDSA_locate_20200409.pub',
               '-token.verify=true',
+              '-uuid-prefix-file=' + exp.uuid.prefixfile,
+              '-prometheusx.listen-address=$(PRIVATE_IP):9990',
             ],
             env: [
               {
@@ -80,6 +82,7 @@ exp.Experiment(expName, 1, 'pusher-' + std.extVar('PROJECT_ID'), "none", [], dat
                 name: 'locate-verify-keys',
                 readOnly: true,
               },
+              exp.uuid.volumemount,
             ] + [
               exp.VolumeMount(expName + '/' + d) for d in datatypes
             ],

--- a/k8s/daemonsets/experiments/msak.jsonnet
+++ b/k8s/daemonsets/experiments/msak.jsonnet
@@ -58,6 +58,14 @@ exp.Experiment(expName, 1, 'pusher-' + std.extVar('PROJECT_ID'), "none", [], dat
                   },
                 },
               },
+              {
+                name: 'PRIVATE_IP',
+                valueFrom: {
+                  fieldRef: {
+                    fieldPath: 'status.podIP',
+                  },
+                },
+              },
             ],
             image: 'measurementlab/msak:' + expVersion,
             name: 'msak',

--- a/system.jsonnet
+++ b/system.jsonnet
@@ -28,13 +28,9 @@
       // hostNetwork=true. If we want to resume the experiment we can just
       // uncomment the following line.
       //import 'k8s/daemonsets/experiments/responsiveness.jsonnet',
-      import 'k8s/daemonsets/experiments/msak.jsonnet',
-    ] else []
-  ) + (
-    if std.extVar('PROJECT_ID') == 'mlab-staging' then [
-      import 'k8s/daemonsets/experiments/msak.jsonnet',
     ] else []
   ) + [
+    import 'k8s/daemonsets/experiments/msak.jsonnet',
     import 'k8s/daemonsets/experiments/wehe.jsonnet',
     // Deployments
     import 'k8s/deployments/kube-state-metrics.jsonnet',


### PR DESCRIPTION
This PR makes deploying the msak experiment unconditional so that it will be deployed in production, too.

It also adds the `-uuid-prefix-file` command-line flag that I previously missed and configures Prometheus to only listen on the pod's private IP address.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/808)
<!-- Reviewable:end -->
