### PR TITLE
Sets Vector log level to "info"

### DIFF
--- a/helm/vector-values-overrides.yaml.template
+++ b/helm/vector-values-overrides.yaml.template
@@ -29,6 +29,9 @@ customConfig:
       - journald
       # This catches anything with priority warning (4) to critical (0).
       condition: .SYSLOG_IDENTIFIER == "kernel" && includes(["0", "1", "2", "3", "4"], .PRIORITY)
+env:
+- name: VECTOR_LOG
+  value: info
 extraVolumes:
 - name: credentials
   secret:


### PR DESCRIPTION
We are using what Vector considers to be a debug image, so apparently debug logging is enabled by default. This commit  overrides the VECTOR_LOG env variable set by the container image and sets its value to "info", which is all we need.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/809)
<!-- Reviewable:end -->
