### PR TITLE
Expose containerPort 9990 in msak container

### DIFF
--- a/k8s/daemonsets/experiments/msak.jsonnet
+++ b/k8s/daemonsets/experiments/msak.jsonnet
@@ -94,6 +94,11 @@ exp.Experiment(expName, 1, 'pusher-' + std.extVar('PROJECT_ID'), "none", [], dat
             ] + [
               exp.VolumeMount(expName + '/' + d) for d in datatypes
             ],
+            ports: [
+              {
+                containerPort: 9990,
+              },
+            ],
           },
           {
             args: [


### PR DESCRIPTION
As discussed on a VC earlier, this exposes port 9990 in the msak container. There are now 8 targets with `container="msak"` in the prometheus-platform-cluster instance's targets age.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/810)
<!-- Reviewable:end -->
