### PR TITLE
Allow API nodes to start with "api" + Vector loglevel to "info"

### DIFF
--- a/config/prometheus/alerts.yml
+++ b/config/prometheus/alerts.yml
@@ -227,7 +227,7 @@ groups:
 
   - alert: PlatformCluster_MachineUpTooLong
     expr: |
-      (time() - node_boot_time_seconds{node=~"(master|mlab[1-4])-.+"}) / (60 * 60 * 24) > 90
+      (time() - node_boot_time_seconds{node=~"(api|master|mlab[1-4])-.+"}) / (60 * 60 * 24) > 90
     for: 10m
     labels:
       repo: ops-tracker

--- a/config/prometheus/prometheus.yml
+++ b/config/prometheus/prometheus.yml
@@ -48,7 +48,7 @@ scrape_configs:
     relabel_configs:
       - source_labels: [__meta_kubernetes_node_name]
         action: keep
-        regex: master-platform-cluster-.*
+        regex: (api|master)-platform-cluster-.*
 
       - source_labels: [__meta_kubernetes_node_address_InternalIP]
         regex: (.*)

--- a/helm/vector-values-overrides.yaml.template
+++ b/helm/vector-values-overrides.yaml.template
@@ -29,6 +29,9 @@ customConfig:
       - journald
       # This catches anything with priority warning (4) to critical (0).
       condition: .SYSLOG_IDENTIFIER == "kernel" && includes(["0", "1", "2", "3", "4"], .PRIORITY)
+env:
+- name: VECTOR_LOG
+  value: info
 extraVolumes:
 - name: credentials
   secret:


### PR DESCRIPTION
A couple of Prometheus rules assumed that control plane nodes are only named like master-platform-cluster.+, but as we transition to Terraform control plane nodes will be named like api-platform-cluster.+. This PR just modifies the regexps to allow for "api", along with "master".

Additionally, since we are technically using a debug Vector container image, the default loglevel is "debug", which is far too chatty for normal usage. This PR just changes the loglevel to "info".

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/811)
<!-- Reviewable:end -->
