### PR TITLE
Use custom built prometheus image with 30k idle connection limit

### DIFF
--- a/k8s/deployments/prometheus.jsonnet
+++ b/k8s/deployments/prometheus.jsonnet
@@ -41,7 +41,7 @@ local prometheusConfig = import '../../config/prometheus.jsonnet';
               '--storage.tsdb.retention.time=120d',
               '--enable-feature=memory-snapshot-on-shutdown',
             ],
-            image: 'prom/prometheus:v2.32.1',
+            image: 'measurementlab/prometheus:v2.32.1-idle30k',
             name: 'prometheus',
             ports: [
               {


### PR DESCRIPTION
This change temporarily uses a custom built prometheus server image that increases the `MaxIdleConns` limit from 20000 to 30000.

Steps taken to create the custom image:
* Clone prometheus/prometheus repo
* Checkout tag v2.32.1
* `go mod vendor` - to vendor dependencies so we can modify them
* Manually edit vendor/github.com/prometheus/common/config/http_config.go from 20000 to 30000.
* Manually edit Makefile to remove architectures other than amd64.
* `make build`; copy binaries to .build/linux-amd64/ ; `make docker`
* Rename docker image to `measurementlab/prometheus:v2.32.1-idle30k` and push to measurementlab repo

Note:
* The README.md suggests that there is another way to locally build the docker image but it always failed for me in the npm build steps with exit code 243.

Steps to verify custom build:
* I temporarily added an `init()` method to `prometheus/common/config/http_config.go` to print a message, now removed.
* After deploying to sandbox, the [build information reports](https://prometheus-platform-cluster.mlab-sandbox.measurementlab.net/status): 
    ```
    Build Information
    Version	2.32.1
    Revision	41f1a8125e664985dd30674e5bdf6b683eff5d32
    Branch	HEAD
    BuildUser	parallels@parallels-Parallels-Virtual-Platform
    BuildDate	20230606-03:17:48
    GoVersion	go1.20.4
    ```

Part of:
* https://github.com/m-lab/dev-tracker/issues/760

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/812)
<!-- Reviewable:end -->
