### PR TITLE
Update scrape job and alert for epoxy-extension-server

### DIFF
--- a/config/prometheus/alerts.yml
+++ b/config/prometheus/alerts.yml
@@ -650,23 +650,17 @@ groups:
       description: https://github.com/m-lab/ops-tracker/wiki/Alerts-&-Troubleshooting#platformcluster_pusherfindermtimelowerboundistooold
       dashboard: https://grafana.mlab-oti.measurementlab.net/d/WnaxPZJZz
 
-  - alert: PlatformCluster_TokenServerClusterDownOrMissing
+  - alert: PlatformCluster_EpoxyExtensionServerDownOrMissing
     expr: |
-      up{job="token-server"} == 0 OR absent(up{job="token-server"})
+      up{job="epoxy-extension-server"} == 0 OR absent(up{job="epoxy-extension-server"})
     for: 1h
     labels:
       repo: ops-tracker
       severity: ticket
       cluster: platform
     annotations:
-      summary: token-server metrics cannot be scraped or are missing.
-      description: The token-server is run as a Docker container on each API
-        server. The instsances sit behind a GCP internal load balancer.
-        Scraping the load balancer is failing, which means that something is
-        wrong with the load balancer, or possibly all three instances of the
-        token-server are down.  Login to one or all of the API servers to
-        discover why the token-server container is not running. Check the
-        status of the load balancer in the GCP console.
+      summary: epoxy-extension-server metrics cannot be scraped or are missing.
+      description: https://github.com/m-lab/ops-tracker/wiki/Alerts-&-Troubleshooting#platformcluster_epoxyextensionserverdownormissing
 
 # PlatformCluster_PrometheusPersistentDiskTooFull fires when the persistent
 # disk mounted on the Prometheus VM gets too full (less than 5% free).

--- a/config/prometheus/prometheus.yml
+++ b/config/prometheus/prometheus.yml
@@ -336,14 +336,15 @@ scrape_configs:
         target_label: site
         replacement: ${1}
 
-  # Scrape the token-server. The address we are scraping is actually a GCP
-  # internal load balancer. Scraping the load balancer address won't guarantee
-  # that all token-server instances are up and running, but more importantly
-  # will let us know whether enough are up to satisfy a booting machine.
-  - job_name: 'token-server'
+  # Scrape the epoxy-extension-server. The address we are scraping is actually
+  # a GCP internal load balancer. Scraping the load balancer address won't
+  # guarantee that all epoxy-extension-server instances are up and running, but
+  # more importantly will let us know whether enough are up to satisfy a
+  # booting machine.
+  - job_name: 'epoxy-extension-server'
     scheme: http
     static_configs:
-      - targets: ['token-server.{{PROJECT}}.measurementlab.net:8800']
+      - targets: ['epoxy-extension-server.{{PROJECT}}.measurementlab.net:8800']
 
   # Scrape the Github Maintenance Exporter.
   - job_name: 'github-maintenance-exporter'


### PR DESCRIPTION
The token-server and bmc-store-password containers no longer run on API machines, and are replaced by the epoxy-extension-server. This commit updates the Prometheus scrape job to scrape the extension server instead, and to alert when the extension server is down.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/813)
<!-- Reviewable:end -->
