### PR TITLE
Use -exclude-srcport flag for tcp-info:v1.7.0

### DIFF
--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -188,7 +188,7 @@ local uuidannotatorServiceVolume = {
 local Tcpinfo(expName, tcpPort, hostNetwork, anonMode) = [
   {
     name: 'tcp-info',
-    image: 'measurementlab/tcp-info:v1.6.0',
+    image: 'measurementlab/tcp-info:v1.7.0',
     args: [
       if hostNetwork then
         '-prometheusx.listen-address=127.0.0.1:' + tcpPort
@@ -198,6 +198,7 @@ local Tcpinfo(expName, tcpPort, hostNetwork, anonMode) = [
       '-output=' + VolumeMount(expName).mountPath + '/tcpinfo',
       '-uuid-prefix-file=' + uuid.prefixfile,
       '-tcpinfo.eventsocket=' + tcpinfoServiceVolume.socketFilename,
+      '-exclude-srcport=9100,9990,9991,9992,9993,9994,9995,9996,9997',
       '-anonymize.ip=' + anonMode,
     ],
     env: if hostNetwork then [] else [


### PR DESCRIPTION
This change updates the TCPInfo configuration to use tcp-info:v1.7.0 and use the new flag `-exclude-srcport` to prevent archival collection of known operational ports for pod metrics.

Part of:
* https://github.com/m-lab/dev-tracker/issues/760

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/815)
<!-- Reviewable:end -->
