### PR TITLE
Drops all unneeded capabilities for containers + updates README

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,3 +134,37 @@ did for this repository, and then pushing to the epoxy-images repository.
 Pushing to the repository (or tagging, for production) will cause all boot
 images to be rebuilt, after which a rolling reboot of the cluster nodes should
 cause them to boot with the upgraded versions of Kubernetes components.
+
+# Running containers as non-root
+The following table outlines which processes run as which uid:gid, as well as
+which capabilities the process has and why. In the table, "root", "nobody"
+and "nogroup" represents uid/gid 0, uid 65534 and gid 65534, respectively. Our
+configs use uid and gid, but it's easier to think about the logical names, even
+though they may differ between systems.  Additionally, in several cases,
+capabilities are added to the binaries in the container, added as part of the
+container image build process. These so called "file" capabilities are extended
+filesystem attributes that the kernel reads when a binary is executed.
+
+access: root:nobody (CAP\_NET\_ADMIN, CAP\_NET\_RAW: needs to manipulate iptables rules)
+cadvisor: root:root (CAP\_DAC\_READ\_SEARCH: allows it to read all the files it needs to gather data)
+dash: nobody:nogroup
+disco: nobody:nogroup
+flannel: root:root (CAP\_NET\_ADMIN, CAP\_NET\_RAW: flannel needs to do various privileged network operations)
+heartbeat: nobody:nogroup
+jostler: nobody:nogroup
+kube-rbac-proxy: nobody:nogroup
+kured: root:root (privileged=true: [MLB-014: Kured container vulnerable to break out](https://github.com/m-lab/ops-tracker/issues/1653))
+msak: nobody:nogroup
+ndt-server: nobody:nogroup
+ndt-server (virtual): root:nogroup (CAP\_NET\_BIND\_SERVICE: to bind to port 80)
+node-exporter: nobody:nogroup
+nodeinfo: nobody:nogroup
+packet-headers: nobody:nogroup (CAP\_NET\_RAW: so that it can do packet captures)
+pusher: root:nobody (CAP\_DAC\_OVERRIDE: so that it can operate on files owned by other users)
+revtrvp nobody:nogroup (CAP\_CHOWN, CAP\_DAC\_OVERRIDE, CAP\_NET\_RAW, CAP\_SETGID, CAP\_SETUID, CAP\_SYS\_CHROOT: scamper requires all of these to operate)
+tcp-info: nobody:nogroup
+traceroute-caller: nobody:nogroup (CAP\_DAC\_OVERRIDE, CAP\_NET\_RAW, CAP\_SETGID, CAP\_SETUID, CAP\_SYS\_CHROOT: scamper requires these to operate)
+uuid-annotator: nobody:nogroup
+vector: root:root (CAP\_DAC\_READ\_SEARCH: so that it can read all the necessary log files)
+wehe: nobody:nogroup (CAP\_NET\_RAW: it needs to do packet captures)
+

--- a/README.md
+++ b/README.md
@@ -146,27 +146,27 @@ container image build process. These so called "file" capabilities are extended
 filesystem attributes that the kernel reads when a binary is executed.
 
 ```
-access: root:nobody (CAP\_NET\_ADMIN, CAP\_NET\_RAW: needs to manipulate iptables rules)
-cadvisor: root:root (CAP\_DAC\_READ\_SEARCH: allows it to read all the files it needs to gather data)
+access: root:nobody (CAP_NET_ADMIN, CAP_NET_RAW: needs to manipulate iptables rules)
+cadvisor: root:root (CAP_DAC_READ_SEARCH: allows it to read all the files it needs to gather data)
 dash: nobody:nogroup
 disco: nobody:nogroup
-flannel: root:root (CAP\_NET\_ADMIN, CAP\_NET\_RAW: flannel needs to do various privileged network operations)
+flannel: root:root (CAP_NET_ADMIN, CAP_NET_RAW: flannel needs to do various privileged network operations)
 heartbeat: nobody:nogroup
 jostler: nobody:nogroup
 kube-rbac-proxy: nobody:nogroup
-kured: root:root (privileged=true: [MLB-014: Kured container vulnerable to break out](https://github.com/m-lab/ops-tracker/issues/1653))
+kured: root:root (privileged=true: https://github.com/m-lab/ops-tracker/issues/1653)
 msak: nobody:nogroup
 ndt-server: nobody:nogroup
-ndt-server (virtual): root:nogroup (CAP\_NET\_BIND\_SERVICE: to bind to port 80)
+ndt-server (virtual): root:nogroup (CAP_NET_BIND_SERVICE: to bind to port 80)
 node-exporter: nobody:nogroup
 nodeinfo: nobody:nogroup
-packet-headers: nobody:nogroup (CAP\_NET\_RAW: so that it can do packet captures)
-pusher: root:nobody (CAP\_DAC\_OVERRIDE: so that it can operate on files owned by other users)
-revtrvp nobody:nogroup (CAP\_CHOWN, CAP\_DAC\_OVERRIDE, CAP\_NET\_RAW, CAP\_SETGID, CAP\_SETUID, CAP\_SYS\_CHROOT: scamper requires all of these to operate)
+packet-headers: nobody:nogroup (CAP_NET_RAW: so that it can do packet captures)
+pusher: root:nobody (CAP_DAC_OVERRIDE: so that it can operate on files owned by other users)
+revtrvp nobody:nogroup (CAP_CHOWN, CAP_DAC_OVERRIDE, CAP_NET_RAW, CAP_SETGID, CAP_SETUID, CAP_SYS_CHROOT: scamper requires all of these to operate)
 tcp-info: nobody:nogroup
-traceroute-caller: nobody:nogroup (CAP\_DAC\_OVERRIDE, CAP\_NET\_RAW, CAP\_SETGID, CAP\_SETUID, CAP\_SYS\_CHROOT: scamper requires these to operate)
+traceroute-caller: nobody:nogroup (CAP_DAC_OVERRIDE, CAP_NET_RAW, CAP_SETGID, CAP_SETUID, CAP_SYS_CHROOT: scamper requires these to operate)
 uuid-annotator: nobody:nogroup
-vector: root:root (CAP\_DAC\_READ\_SEARCH: so that it can read all the necessary log files)
-wehe: nobody:nogroup (CAP\_NET\_RAW: it needs to do packet captures)
+vector: root:root (CAP_DAC_READ_SEARCH: so that it can read all the necessary log files)
+wehe: nobody:nogroup (CAP_NET_RAW: it needs to do packet captures)
 ```
 

--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ capabilities are added to the binaries in the container, added as part of the
 container image build process. These so called "file" capabilities are extended
 filesystem attributes that the kernel reads when a binary is executed.
 
+```
 access: root:nobody (CAP\_NET\_ADMIN, CAP\_NET\_RAW: needs to manipulate iptables rules)
 cadvisor: root:root (CAP\_DAC\_READ\_SEARCH: allows it to read all the files it needs to gather data)
 dash: nobody:nogroup
@@ -167,4 +168,5 @@ traceroute-caller: nobody:nogroup (CAP\_DAC\_OVERRIDE, CAP\_NET\_RAW, CAP\_SETGI
 uuid-annotator: nobody:nogroup
 vector: root:root (CAP\_DAC\_READ\_SEARCH: so that it can read all the necessary log files)
 wehe: nobody:nogroup (CAP\_NET\_RAW: it needs to do packet captures)
+```
 

--- a/k8s/daemonsets/core/disco.jsonnet
+++ b/k8s/daemonsets/core/disco.jsonnet
@@ -89,6 +89,9 @@ local dataDir = exp.VolumeMount('utilization').mountPath;
         },
         [if std.extVar('PROJECT_ID') != 'mlab-sandbox' then 'terminationGracePeriodSeconds']: 120,
         securityContext: {
+          capabilities: {
+            drop: 'all',
+          },
           runAsUser: 65534,
           runAsGroup: 65534,
         },

--- a/k8s/daemonsets/core/disco.jsonnet
+++ b/k8s/daemonsets/core/disco.jsonnet
@@ -73,6 +73,13 @@ local dataDir = exp.VolumeMount('utilization').mountPath;
                 containerPort: 9990,
               },
             ],
+            securityContext: {
+              capabilities: {
+                drop: [
+                  'all',
+                ],
+              },
+            },
             volumeMounts: [
               exp.VolumeMount('utilization'),
               {
@@ -89,11 +96,6 @@ local dataDir = exp.VolumeMount('utilization').mountPath;
         },
         [if std.extVar('PROJECT_ID') != 'mlab-sandbox' then 'terminationGracePeriodSeconds']: 120,
         securityContext: {
-          capabilities: {
-            drop: [
-              'all',
-            ],
-          },
           runAsUser: 65534,
           runAsGroup: 65534,
         },

--- a/k8s/daemonsets/core/disco.jsonnet
+++ b/k8s/daemonsets/core/disco.jsonnet
@@ -90,7 +90,9 @@ local dataDir = exp.VolumeMount('utilization').mountPath;
         [if std.extVar('PROJECT_ID') != 'mlab-sandbox' then 'terminationGracePeriodSeconds']: 120,
         securityContext: {
           capabilities: {
-            drop: 'all',
+            drop: [
+              'all',
+            ],
           },
           runAsUser: 65534,
           runAsGroup: 65534,

--- a/k8s/daemonsets/core/flannel-physical.jsonnet
+++ b/k8s/daemonsets/core/flannel-physical.jsonnet
@@ -78,6 +78,9 @@
                   'NET_ADMIN',
                   'NET_RAW',
                 ],
+                drop: [
+                  'all',
+                ],
               },
             },
             volumeMounts: [

--- a/k8s/daemonsets/core/flannel-virtual.jsonnet
+++ b/k8s/daemonsets/core/flannel-virtual.jsonnet
@@ -81,6 +81,9 @@
                   'NET_ADMIN',
                   'NET_RAW',
                 ],
+                drop: [
+                  'all',
+                ],
               },
             },
             volumeMounts: [

--- a/k8s/daemonsets/core/host.jsonnet
+++ b/k8s/daemonsets/core/host.jsonnet
@@ -19,6 +19,13 @@ exp.ExperimentNoIndex(expName, 'pusher-' + std.extVar('PROJECT_ID'), "none", [],
               '-prometheusx.listen-address=127.0.0.1:9990',
               '-config=/etc/nodeinfo/config.json',
             ],
+            securityContext: {
+              capabilities: {
+                drop: [
+                  'all',
+                ],
+              },
+            },
             volumeMounts: [
               {
                 mountPath: '/etc/nodeinfo',

--- a/k8s/daemonsets/core/node-exporter.jsonnet
+++ b/k8s/daemonsets/core/node-exporter.jsonnet
@@ -59,6 +59,13 @@ local exp = import '../templates.jsonnet';
                 memory: '180Mi',
               },
             },
+            securityContext: {
+              capabilities: {
+                drop: [
+                  'all',
+                ],
+              },
+            },
             volumeMounts: [
               {
                 mountPath: '/host/proc',
@@ -121,17 +128,19 @@ local exp = import '../templates.jsonnet';
                 memory: '20Mi',
               },
             },
+            securityContext: {
+              capabilities: {
+                drop: [
+                  'all',
+                ],
+              },
+            },
           },
         ],
         hostNetwork: true,
         hostPID: true,
         serviceAccountName: 'kube-rbac-proxy',
         securityContext: {
-          capabilities: {
-            drop: [
-              'all',
-            ],
-          },
           runAsUser: 65534,
           runAsGroup: 65534,
         },

--- a/k8s/daemonsets/core/node-exporter.jsonnet
+++ b/k8s/daemonsets/core/node-exporter.jsonnet
@@ -127,6 +127,11 @@ local exp = import '../templates.jsonnet';
         hostPID: true,
         serviceAccountName: 'kube-rbac-proxy',
         securityContext: {
+          capabilities: {
+            drop: [
+              'all',
+            ],
+          },
           runAsUser: 65534,
           runAsGroup: 65534,
         },

--- a/k8s/daemonsets/experiments/msak.jsonnet
+++ b/k8s/daemonsets/experiments/msak.jsonnet
@@ -100,34 +100,6 @@ exp.Experiment(expName, 1, 'pusher-' + std.extVar('PROJECT_ID'), "none", [], dat
               },
             ],
           },
-          {
-            args: [
-              '-addr=:4443',
-              '-cert=/certs/tls.crt',
-              '-key=/certs/tls.key',
-              '-hostname=msak-$(NODE_NAME)',
-              '-www=/app/www',
-            ],
-            env: [
-              {
-                name: 'NODE_NAME',
-                valueFrom: {
-                  fieldRef: {
-                    fieldPath: 'spec.nodeName',
-                  },
-                },
-              },
-            ],
-            image: 'soltesz/speedtest-webtransport-go:v0.0.1',
-            name: 'speedtest-webtransport',
-            volumeMounts: [
-              {
-                mountPath: '/certs',
-                name: 'measurement-lab-org-tls',
-                readOnly: true,
-              },
-            ],
-          },
         ] + std.flattenArrays([
           exp.Heartbeat(expName, false, services),
         ]),


### PR DESCRIPTION
While I was doing a final review of which containers run as which user and with which capabilities, I discovered that disco, flannel, node-exporter and nodeinfo were all running as the correct user:group, but had far more capabilities than they should have. This was because the container specs did not explicitly drop all unneeded capabilities. The PR takes care of this. These services has been running since yesterday afternoon with all these capabilities dropped, and things still seem to WAI, which was expected.

Additionally, this PR adds a new section to the repo README talking a bit about running containers as non-root, and presenting a table (of sorts) which displays how everything is running, with which capabilities, and why.

Also, this PR removes the mask container `speedtest-webtransport`, which was not supposed to make it beyond sandbox, but accidentally made it to production.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/816)
<!-- Reviewable:end -->
