### PR TITLE
Revert to upstream prometheus version

### DIFF
--- a/k8s/deployments/prometheus.jsonnet
+++ b/k8s/deployments/prometheus.jsonnet
@@ -41,7 +41,7 @@ local prometheusConfig = import '../../config/prometheus.jsonnet';
               '--storage.tsdb.retention.time=120d',
               '--enable-feature=memory-snapshot-on-shutdown',
             ],
-            image: 'measurementlab/prometheus:v2.32.1-idle30k',
+            image: 'prom/prometheus:v2.32.1',
             name: 'prometheus',
             ports: [
               {


### PR DESCRIPTION
This change reverts our use of the custom-build prometheus image that allowed up to 30k idle connections to prevent excess operational connections visible to tcpinfo.

Since the addition of https://github.com/m-lab/k8s-support/pull/815 tcp-info will unconditionally ignore the most common operational ports for measurement services.

Unfortunately, the combination of prometheus with lower idle connection limit and this tcpinfo configuration cannot be evaluated at scale until in production.

Part of:
* https://github.com/m-lab/dev-tracker/issues/760

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/817)
<!-- Reviewable:end -->
