### PR TITLE
Update references to msak/ndt8 to throughput1

### DIFF
--- a/k8s/daemonsets/experiments/msak.jsonnet
+++ b/k8s/daemonsets/experiments/msak.jsonnet
@@ -1,7 +1,7 @@
 local datatypes = ['throughput1'];
 local exp = import '../templates.jsonnet';
 local expName = 'msak';
-local expVersion = 'v0.1.0';
+local expVersion = 'v0.2.0';
 local services = [
   'msak/throughput1=ws:///throughput/v1/download,ws:///throughput/v1/upload,wss:///throughput/v1/download,wss:///throughput/v1/upload',
 ];

--- a/k8s/daemonsets/experiments/msak.jsonnet
+++ b/k8s/daemonsets/experiments/msak.jsonnet
@@ -1,9 +1,9 @@
-local datatypes = ['ndt8'];
+local datatypes = ['throughput1'];
 local exp = import '../templates.jsonnet';
 local expName = 'msak';
 local expVersion = 'v0.1.0';
 local services = [
-  'msak/ndt8=ws:///ndt/v8/download,ws:///ndt/v8/upload,wss:///ndt/v8/download,wss:///ndt/v8/upload',
+  'msak/throughput1=ws:///throughput/v1/download,ws:///throughput/v1/upload,wss:///throughput/v1/download,wss:///throughput/v1/upload',
 ];
 
 exp.Experiment(expName, 1, 'pusher-' + std.extVar('PROJECT_ID'), "none", [], datatypes) + {
@@ -24,7 +24,7 @@ exp.Experiment(expName, 1, 'pusher-' + std.extVar('PROJECT_ID'), "none", [], dat
             command: [
               '/bin/sh',
               '-c',
-              'cp /msak/ndt8.json /var/spool/datatypes/ndt8.json',
+              'cp /msak/throughput1.json /var/spool/datatypes/throughput1.json',
             ],
             volumeMounts: [
               {


### PR DESCRIPTION
This change follows updates from https://github.com/m-lab/msak/pull/15 that makes "throughput1" the canonical protocol and archival datatype name, and msak references to use msak/throughput1 and corresponding resource paths as well.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/818)
<!-- Reviewable:end -->
