### PR TITLE
Update ndtServer version to v0.20.19

### DIFF
--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -1,7 +1,7 @@
 local ndtVersion = 'v0.20.19';
 // The canary version is expected to be greater than or equal to
 // the current stable version.
-local ndtCanaryVersion = 'v0.20.17';
+local ndtCanaryVersion = 'v0.20.19';
 local PROJECT_ID = std.extVar('PROJECT_ID');
 
 // The default grace period after k8s sends SIGTERM is 30s. We

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -1,4 +1,4 @@
-local ndtVersion = 'v0.20.17';
+local ndtVersion = 'v0.20.19';
 // The canary version is expected to be greater than or equal to
 // the current stable version.
 local ndtCanaryVersion = 'v0.20.17';


### PR DESCRIPTION
Releases in this update:

- https://github.com/m-lab/ndt-server/releases/tag/v0.20.18
- https://github.com/m-lab/ndt-server/releases/tag/v0.20.19

Changes tested by sending requests to the sandbox nodes:

```
$ go run main.go -service-url "ws://ndt-mlab2-lga1t.mlab-sandbox.measurement-lab.org/ndt/v7/download?access_token=eyJhbGciOiJFZERTQSIsImtpZCI6ImxvY2F0ZV8yMDIwMDQwOSJ9.eyJhdWQiOlsibWxhYjItbGdhMXQubWxhYi1zYW5kYm94Lm1lYXN1cmVtZW50LWxhYi5vcmciXSwiZXhwIjoxNjg3ODg4MjIwLCJpc3MiOiJsb2NhdGUiLCJqdGkiOiJmNDFiMDE5OS0zYzQzLTQ1OTItYjBlYi1lZTMxMDUxNDMzNmMiLCJzdWIiOiJuZHQifQ.TDj1bDlE2OiZYCgMovuQb5aF8_WpnHC4y5CUYcd_RconsgZf1baqR8IvNuF3PvbBXf4jBNPE-jFKIoOTuHx_Dw&early_exit=250"
download in progress with ndt-mlab2-lga1t.mlab-sandbox.measurement-lab.org
Avg. speed  :   894.0 Mbit/s
download: complete
         Server: ndt-mlab2-lga1t.mlab-sandbox.measurement-lab.org
         Client: 104.196.36.241
        Latency:    17.6 ms
       Download:   894.0
         Upload:     0.0
 Retransmission:    0.00 %

$ go run main.go -service-url "ws://ndt-mlab2-lga1t.mlab-sandbox.measurement-lab.org/ndt/v7/download?access_token=eyJhbGciOiJFZERTQSIsImtpZCI6ImxvY2F0ZV8yMDIwMDQwOSJ9.eyJhdWQiOlsibWxhYjItbGdhMXQubWxhYi1zYW5kYm94Lm1lYXN1cmVtZW50LWxhYi5vcmciXSwiZXhwIjoxNjg3ODg4MjIwLCJpc3MiOiJsb2NhdGUiLCJqdGkiOiJmNDFiMDE5OS0zYzQzLTQ1OTItYjBlYi1lZTMxMDUxNDMzNmMiLCJzdWIiOiJuZHQifQ.TDj1bDlE2OiZYCgMovuQb5aF8_WpnHC4y5CUYcd_RconsgZf1baqR8IvNuF3PvbBXf4jBNPE-jFKIoOTuHx_Dw&early_exit=200"
download failed: websocket: bad handshake

download: complete
         Server: ndt-mlab2-lga1t.mlab-sandbox.measurement-lab.org
         Client:
        Latency:     0.0
       Download:     0.0
         Upload:     0.0
 Retransmission:    0.00
exit status 1

$ go run main.go -service-url "ws://ndt-mlab2-lga1t.mlab-sandbox.measurement-lab.org/ndt/v7/download?access_token=eyJhbGciOiJFZERTQSIsImtpZCI6ImxvY2F0ZV8yMDIwMDQwOSJ9.eyJhdWQiOlsibWxhYjItbGdhMXQubWxhYi1zYW5kYm94Lm1lYXN1cmVtZW50LWxhYi5vcmciXSwiZXhwIjoxNjg3ODg4MjIwLCJpc3MiOiJsb2NhdGUiLCJqdGkiOiJmNDFiMDE5OS0zYzQzLTQ1OTItYjBlYi1lZTMxMDUxNDMzNmMiLCJzdWIiOiJuZHQifQ.TDj1bDlE2OiZYCgMovuQb5aF8_WpnHC4y5CUYcd_RconsgZf1baqR8IvNuF3PvbBXf4jBNPE-jFKIoOTuHx_Dw"
download in progress with ndt-mlab2-lga1t.mlab-sandbox.measurement-lab.org
Avg. speed  :   928.1 Mbit/s
download: complete
         Server: ndt-mlab2-lga1t.mlab-sandbox.measurement-lab.org
         Client: 34.74.99.68
        Latency:    17.3 ms
       Download:   928.1
         Upload:     0.0
 Retransmission:    0.00 %
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/819)
<!-- Reviewable:end -->
