### PR TITLE
Updates configs to k8s v1.24.15

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 This repo contains all of the scripts and configs required to set up the
 world-spanning M-Lab kubernetes (k8s) cluster.  The organization is as follows:
 - [manage-cluster/](manager-cluster/) contains all the scripts necessary to set
-  up and configure the cloud master node(s) as well as new nodes in Google cloud
-  for monitoring services and the like.
+  up and configure the cloud control plane node(s) as well as new nodes in
+  Google cloud for monitoring services and the like.
 - [config/](config/) contains service configuration files.
 - [k8s/](k8s/) contains Kubernetes config files.
 - [node/](node/) DEPRECATED. The files in this directory will eventually move to
@@ -110,7 +110,7 @@ API cluster nodes report the correct version, and that all pods in the cluster
 are running normally. You can do this with something like:
 
 ```
-$ kubectl --context <project> get nodes | grep master-platform-cluster
+$ kubectl --context <project> get nodes | grep api-platform-cluster
 $ kubectl --context <project> get pods --all-namespaces | grep -v Running
 ```
 
@@ -129,7 +129,7 @@ or for someone to notice something is amiss.
 a project is updated, then you will still need to upgrade all the cluster
 nodes. This is done in the [epoxy-images
 repository](https://github.com/m-lab/epoxy-images) by [editing the same version
-strings](https://github.com/m-lab/epoxy-images/blob/master/config.sh#L6) you
+strings](https://github.com/m-lab/epoxy-images/blob/main/config.sh#L6) you
 did for this repository, and then pushing to the epoxy-images repository.
 Pushing to the repository (or tagging, for production) will cause all boot
 images to be rebuilt, after which a rolling reboot of the cluster nodes should

--- a/k8s/daemonsets/core/flannel-virtual.jsonnet
+++ b/k8s/daemonsets/core/flannel-virtual.jsonnet
@@ -4,12 +4,6 @@
 // label mlab/type=virtual. If a node tries to join without an mlab/type, its
 // network will likely not work. Pods running on virtual nodes only get an
 // internal IP address.
-//
-// The toleration "key: node-role.kubernetes.io/master" was removed because of
-// this issue: https://github.com/coreos/flannel/issues/1044. This was needed
-// because flannel pods were not getting scheduled on the master nodes due to a
-// new taint being added to the master because of this issue:
-// https://github.com/kubernetes/kubernetes/issues/44254
 
 {
   apiVersion: 'apps/v1',

--- a/k8s/daemonsets/core/node-exporter.jsonnet
+++ b/k8s/daemonsets/core/node-exporter.jsonnet
@@ -138,10 +138,6 @@ local exp = import '../templates.jsonnet';
           },
           {
             effect: 'NoSchedule',
-            key: 'node-role.kubernetes.io/master',
-          },
-          {
-            effect: 'NoSchedule',
             key: 'node-role.kubernetes.io/control-plane',
           },
         ],

--- a/manage-cluster/PROMETHEUS.md
+++ b/manage-cluster/PROMETHEUS.md
@@ -21,4 +21,4 @@ documentation](https://cloud.google.com/compute/docs/disks/add-persistent-disk#r
 for how to do this is quite detailed and clear (i.e., resize2fs). All of this
 can be done without interrupting the VM or any running processes. When done,
 be sure to update the default disk size in the [Prometheus bootstrap
-script](https://github.com/m-lab/k8s-support/blob/master/manage-cluster/bootstrap_prometheus.sh#L49)
+script](https://github.com/m-lab/k8s-support/blob/main/manage-cluster/bootstrap_prometheus.sh#L49)

--- a/manage-cluster/k8s_deploy.conf
+++ b/manage-cluster/k8s_deploy.conf
@@ -28,25 +28,25 @@ PROM_BASE_NAME="prometheus-${GCE_BASE_NAME}"
 # we learn more.
 GCE_API_SCOPES="cloud-platform"
 
-K8S_VERSION="v1.23.16" # https://github.com/kubernetes/kubernetes/releases
-K8S_CNI_VERSION="v1.2.0" # https://github.com/containernetworking/plugins/releases
-K8S_CRICTL_VERSION="v1.23.0" # https://github.com/kubernetes-sigs/cri-tools/releases
+K8S_VERSION="v1.24.15" # https://github.com/kubernetes/kubernetes/releases
+K8S_CNI_VERSION="v1.3.0" # https://github.com/containernetworking/plugins/releases
+K8S_CRICTL_VERSION="v1.24.2" # https://github.com/kubernetes-sigs/cri-tools/releases
 # FLANNEL is for the flannel DaemonSet, whereas FLANNELCNI is for the CNI
 # plugin located at /opt/cni/bin (used by the kubelet).
-K8S_FLANNEL_VERSION="v0.21.2" # https://github.com/flannel-io/flannel/releases
+K8S_FLANNEL_VERSION="v0.22.0" # https://github.com/flannel-io/flannel/releases
 K8S_FLANNELCNI_VERSION=v1.1.2 # https://github.com/flannel-io/cni-plugin/releases
-K8S_TOOLING_VERSION="v0.15.0" # https://github.com/kubernetes/release/releases
+K8S_TOOLING_VERSION="v0.15.1" # https://github.com/kubernetes/release/releases
 # kubeadm installs and managed etcd automatically. Try to keep this version of
 # etcdctl more or less in line with the default etcd version that kubeadm uses
 # for any given release of k8s. For example, see this:
 # https://github.com/kubernetes/kubernetes/blob/v1.23.16/cmd/kubeadm/app/constants/constants.go#L304
 ETCDCTL_VERSION="v3.5.6"
-K8S_HELM_VERSION="v3.11.1" # https://github.com/helm/helm/releases
-K8S_VECTOR_VERSION="0.30.0-debian"
-K8S_VECTOR_CHART="0.22.0"
-K8S_KURED_VERSION="1.10.2"
-K8S_KURED_CHART="4.4.1"
-K8S_CERTMANAGER_VERSION="v1.11.0"
+K8S_HELM_VERSION="v3.12.1" # https://github.com/helm/helm/releases
+K8S_VECTOR_VERSION="0.30.0-debian" # https://github.com/vectordotdev/vector/releases
+K8S_VECTOR_CHART="0.22.1" # https://github.com/vectordotdev/helm-charts/releases
+K8S_KURED_VERSION="1.12.2" # https://github.com/kubereboot/kured/releases
+K8S_KURED_CHART="4.6.0" # https://github.com/kubereboot/charts/releases
+K8S_CERTMANAGER_VERSION="v1.12.2" # https://github.com/cert-manager/cert-manager/releases
 K8S_CERTMANAGER_DNS01_SA="cert-manager-dns01-solver"
 K8S_CERTMANAGER_SA_KEY="cert-manager-credentials.json"
 K8S_CA_FILES="ca.crt ca.key sa.key sa.pub front-proxy-ca.crt front-proxy-ca.key etcd/ca.crt etcd/ca.key"


### PR DESCRIPTION
The major change in this commit is upgrading config varibles to deploy k8s v1.24.15. Some changes were also necessary to the upgrade script to support the new Terraform-deployed control plane VMs. Additionally, I updated some READMEs to have more correct information.