### PR TITLE
Add autoloading configuration to wehe

### DIFF
--- a/k8s/daemonsets/experiments/wehe.jsonnet
+++ b/k8s/daemonsets/experiments/wehe.jsonnet
@@ -39,23 +39,6 @@ exp.Experiment(expName, 5, 'pusher-' + std.extVar('PROJECT_ID'), 'netblock', ['r
             ],
           },
         ],
-          # TODO(soltesz): eliminate in favor of native flag to wehe server.
-          /*
-          {
-            args: [
-              'cp', '/var/local/uuid/prefix', '/res/uuid_prefix_tag.txt',
-            ],
-            image: 'busybox:1.34',
-            name: 'copy-uuid-prefix',
-            volumeMounts: [
-              exp.uuid.volumemount,
-              {
-                mountPath: '/res/',
-                name: 'wehe-res',
-              },
-            ],
-          },
-          */
         containers+: [
           {
             args: [
@@ -158,7 +141,6 @@ exp.Experiment(expName, 5, 'pusher-' + std.extVar('PROJECT_ID'), 'netblock', ['r
               },
               {
                 // Analyzer server
-                // TODO(soltesz): update upstream.
                 containerPort: 9091,
               },
             ],
@@ -230,12 +212,6 @@ exp.Experiment(expName, 5, 'pusher-' + std.extVar('PROJECT_ID'), 'netblock', ['r
             },
           },
         ],
-          /*
-          {
-            emptyDir: {},
-            name: 'wehe-res',
-          },
-          */
       },
     },
   },

--- a/k8s/daemonsets/experiments/wehe.jsonnet
+++ b/k8s/daemonsets/experiments/wehe.jsonnet
@@ -65,7 +65,8 @@ exp.Experiment(expName, 5, 'pusher-' + std.extVar('PROJECT_ID'), 'netblock', ['r
               '-envelope.subject=wehe',
               '-envelope.machine=$(MLAB_NODE_NAME)',
               '-envelope.verify-key=/verify/jwk_sig_EdDSA_locate_20200409.pub',
-              '-envelope.token-required=true',
+              // TODO(soltesz): restore after testing.
+              '-envelope.token-required=false',
               '-prometheusx.listen-address=:9989',
               // Maximum timeout for a client to hold the envelope open.
               '-timeout=10m',
@@ -130,7 +131,7 @@ exp.Experiment(expName, 5, 'pusher-' + std.extVar('PROJECT_ID'), 'netblock', ['r
                 },
               },
             ],
-            image: 'measurementlab/wehe-py3:v0.3.1',
+            image: 'measurementlab/wehe-py3:v0.3.3',
             livenessProbe+: {
               httpGet: {
                 path: '/metrics',
@@ -196,7 +197,7 @@ exp.Experiment(expName, 5, 'pusher-' + std.extVar('PROJECT_ID'), 'netblock', ['r
               },
               // TODO(soltesz): verify this is used by wehe server.
               exp.uuid.volumemount,
-              exp.VolumeMountDatatypeSchema(),
+              exp.VolumeMountDatatypes(expName),
             ] + [
               exp.VolumeMount(expName + '/' + d) for d in autoloadedDatatypes
             ],

--- a/k8s/daemonsets/experiments/wehe.jsonnet
+++ b/k8s/daemonsets/experiments/wehe.jsonnet
@@ -195,6 +195,11 @@ exp.Experiment(expName, 5, 'pusher-' + std.extVar('PROJECT_ID'), 'netblock', ['r
               },
               // TODO(soltesz): verify this is used by wehe server.
               exp.uuid.volumemount,
+              {
+                mountPath: '/var/spool/datatypes',
+                name: 'var-spool-datatypes',
+                readOnly: false,
+              },
             ] + [
               exp.VolumeMount(expName + '/' + d) for d in autoloadedDatatypes
             ],

--- a/k8s/daemonsets/experiments/wehe.jsonnet
+++ b/k8s/daemonsets/experiments/wehe.jsonnet
@@ -50,8 +50,7 @@ exp.Experiment(expName, 5, 'pusher-' + std.extVar('PROJECT_ID'), 'netblock', ['r
               '-envelope.subject=wehe',
               '-envelope.machine=$(MLAB_NODE_NAME)',
               '-envelope.verify-key=/verify/jwk_sig_EdDSA_locate_20200409.pub',
-              // TODO(soltesz): restore after testing.
-              '-envelope.token-required=false',
+              '-envelope.token-required=true',
               '-prometheusx.listen-address=:9989',
               // Maximum timeout for a client to hold the envelope open.
               '-timeout=10m',

--- a/k8s/daemonsets/experiments/wehe.jsonnet
+++ b/k8s/daemonsets/experiments/wehe.jsonnet
@@ -47,6 +47,10 @@ exp.Experiment(expName, 5, 'pusher-' + std.extVar('PROJECT_ID'), 'netblock', ['r
             name: 'copy-uuid-prefix',
             volumeMounts: [
               exp.uuid.volumemount,
+              {
+                mountPath: '/res/',
+                name: 'wehe-res',
+              },
             ],
           },
         ],
@@ -220,6 +224,10 @@ exp.Experiment(expName, 5, 'pusher-' + std.extVar('PROJECT_ID'), 'netblock', ['r
             secret: {
               secretName: 'locate-verify-keys',
             },
+          },
+          {
+            emptyDir: {},
+            name: 'wehe-res',
           },
         ],
       },

--- a/k8s/daemonsets/experiments/wehe.jsonnet
+++ b/k8s/daemonsets/experiments/wehe.jsonnet
@@ -66,6 +66,7 @@ exp.Experiment(expName, 5, 'pusher-' + std.extVar('PROJECT_ID'), 'netblock', ['r
               '-envelope.machine=$(MLAB_NODE_NAME)',
               '-envelope.verify-key=/verify/jwk_sig_EdDSA_locate_20200409.pub',
               '-envelope.token-required=true',
+              '-prometheusx.listen-address=:9989',
               // Maximum timeout for a client to hold the envelope open.
               '-timeout=10m',
             ],
@@ -110,7 +111,7 @@ exp.Experiment(expName, 5, 'pusher-' + std.extVar('PROJECT_ID'), 'netblock', ['r
             // Advertise the prometheus port so it can be discovered by Prometheus.
             ports: [
               {
-                containerPort: 9990,
+                containerPort: 9989,
               },
             ],
           },
@@ -195,11 +196,7 @@ exp.Experiment(expName, 5, 'pusher-' + std.extVar('PROJECT_ID'), 'netblock', ['r
               },
               // TODO(soltesz): verify this is used by wehe server.
               exp.uuid.volumemount,
-              {
-                mountPath: '/var/spool/datatypes',
-                name: 'var-spool-datatypes',
-                readOnly: false,
-              },
+              exp.VolumeMountDatatypeSchema(),
             ] + [
               exp.VolumeMount(expName + '/' + d) for d in autoloadedDatatypes
             ],

--- a/k8s/daemonsets/experiments/wehe.jsonnet
+++ b/k8s/daemonsets/experiments/wehe.jsonnet
@@ -38,7 +38,9 @@ exp.Experiment(expName, 5, 'pusher-' + std.extVar('PROJECT_ID'), 'netblock', ['r
               },
             ],
           },
+        ],
           # TODO(soltesz): eliminate in favor of native flag to wehe server.
+          /*
           {
             args: [
               'cp', '/var/local/uuid/prefix', '/res/uuid_prefix_tag.txt',
@@ -53,7 +55,7 @@ exp.Experiment(expName, 5, 'pusher-' + std.extVar('PROJECT_ID'), 'netblock', ['r
               },
             ],
           },
-        ],
+          */
         containers+: [
           {
             args: [
@@ -130,8 +132,12 @@ exp.Experiment(expName, 5, 'pusher-' + std.extVar('PROJECT_ID'), 'netblock', ['r
                   },
                 },
               },
+              {
+                name: 'UUID_PREFIX',
+                value: '/var/local/uuid/prefix',
+              },
             ],
-            image: 'measurementlab/wehe-py3:v0.3.3',
+            image: 'measurementlab/wehe-py3:v0.3.4',
             livenessProbe+: {
               httpGet: {
                 path: '/metrics',
@@ -191,11 +197,6 @@ exp.Experiment(expName, 5, 'pusher-' + std.extVar('PROJECT_ID'), 'netblock', ['r
                 mountPath: '/wehe/ssl/',
                 name: 'wehe-ca-cache',
               },
-              {
-                mountPath: '/res/',
-                name: 'wehe-res',
-              },
-              // TODO(soltesz): verify this is used by wehe server.
               exp.uuid.volumemount,
               exp.VolumeMountDatatypes(expName),
             ] + [
@@ -228,11 +229,13 @@ exp.Experiment(expName, 5, 'pusher-' + std.extVar('PROJECT_ID'), 'netblock', ['r
               secretName: 'locate-verify-keys',
             },
           },
+        ],
+          /*
           {
             emptyDir: {},
             name: 'wehe-res',
           },
-        ],
+          */
       },
     },
   },

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -207,7 +207,7 @@ local Tcpinfo(expName, tcpPort, hostNetwork, anonMode) = [
       '-output=' + data.mount(expName).mountPath + '/tcpinfo',
       '-uuid-prefix-file=' + uuid.prefixfile,
       '-tcpinfo.eventsocket=' + tcpinfoServiceVolume.socketFilename,
-      '-exclude-srcport=9100,9990,9991,9992,9993,9994,9995,9996,9997',
+      '-exclude-srcport=9100,9989,9990,9991,9992,9993,9994,9995,9996,9997',
       '-anonymize.ip=' + anonMode,
     ],
     env: if hostNetwork then [] else [
@@ -832,6 +832,10 @@ local Experiment(name, index, bucket, anonMode, datatypes=[], datatypesAutoloade
   // Returns a volumemount for jostler datatypes directory. Must be included for
   // all experiments producing autoloaded data.
   VolumeMountDatatypes(name):: datatypes.mount(name),
+
+  // Returns a volumemount for jostler datatypes directory. Must be included for
+  // all experiments producing autoloaded data.
+  VolumeMountDatatypeSchema():: VolumeMountDatatypeSchema(),
 
   // Returns a "container" configuration for pusher that will upload the named experiment datatypes.
   // Users MUST declare a "pusher-credentials" volume as part of the deployment.

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -833,10 +833,6 @@ local Experiment(name, index, bucket, anonMode, datatypes=[], datatypesAutoloade
   // all experiments producing autoloaded data.
   VolumeMountDatatypes(name):: datatypes.mount(name),
 
-  // Returns a volumemount for jostler datatypes directory. Must be included for
-  // all experiments producing autoloaded data.
-  VolumeMountDatatypeSchema():: VolumeMountDatatypeSchema(),
-
   // Returns a "container" configuration for pusher that will upload the named experiment datatypes.
   // Users MUST declare a "pusher-credentials" volume as part of the deployment.
   Pusher(expName, tcpPort, datatypes, hostNetwork, bucket):: Pusher(expName, tcpPort, datatypes, hostNetwork, bucket),


### PR DESCRIPTION
This change updates the wehe configuration to support autoloaded datatypes: `replayInfo1`, `clientXputs1`, `decisions1`. The end to end behavior has been verified in sandbox. And, the wehe service will temporarily continue to save all data in the `replay` datatype to support downstream processing by the NU data pipeline without interruption. Ultimately, that pipeline will be migrated to BQ and retired and the duplicate data collection eliminated. The estimated timeline for this is about three months.

FYI: @zeinabshmeis

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/822)
<!-- Reviewable:end -->
