### PR TITLE
Fixes bug in ndt-server -token.machine flag value

### DIFF
--- a/k8s/daemonsets/experiments/ndt-virtual.jsonnet
+++ b/k8s/daemonsets/experiments/ndt-virtual.jsonnet
@@ -45,13 +45,7 @@ exp.ExperimentNoIndex(expName, 'pusher-' + std.extVar('PROJECT_ID'), 'none', dat
             command: [
               '/bin/sh',
               '-c',
-              // MIGs are currently only present in sandbox, so limit stripping
-              // anything from the node name to sandbox.
-              if std.extVar('PROJECT_ID') == 'mlab-sandbox' then 
-                '/ndt-server -token.machine=${NODE_NAME%-*} $@'
-              else
-                '/ndt-server -token.machine=${NODE_NAME} $@'
-              ,
+              '/ndt-server -token.machine=${NODE_NAME/org-*/org} $@',
               '--',
             ],
             args: [


### PR DESCRIPTION
Prior to this commit, the shell parameter substitution creating the value for the -token.machine flag would strip off "-lab.org" from VMs that were not part of a MIG. The original thinking had been that we would only be using MIGs for all VMs, but we decided that we have use cases for both MIGs and regular stand-alone VMs. This commit uses a parameter subtitution that should work in the case of MIG instances, and be a no-op on non-MIG instances.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/825)
<!-- Reviewable:end -->
