### PR TITLE
Update ndt-server versions

### DIFF
--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -1,7 +1,7 @@
-local ndtVersion = 'v0.20.19';
+local ndtVersion = 'v0.20.20';
 // The canary version is expected to be greater than or equal to
 // the current stable version.
-local ndtCanaryVersion = 'v0.20.19';
+local ndtCanaryVersion = 'v0.20.20';
 local PROJECT_ID = std.extVar('PROJECT_ID');
 
 // The default grace period after k8s sends SIGTERM is 30s. We


### PR DESCRIPTION
This change updates the ndt-server version to include changes to explicitly bind health_addr to localhost.

Part of:
* https://github.com/m-lab/ops-tracker/issues/1798

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/826)
<!-- Reviewable:end -->
