### PR TITLE
Changes ndt-canary DS to deploy on virtual machines

### DIFF
--- a/k8s/daemonsets/experiments/ndt-canary.jsonnet
+++ b/k8s/daemonsets/experiments/ndt-canary.jsonnet
@@ -28,6 +28,7 @@ exp.Experiment(expName, 2, 'pusher-' + std.extVar('PROJECT_ID'), "none", datatyp
       spec+: {
         nodeSelector+: {
           'mlab/ndt-version': 'canary',
+          'mlab/type': 'virtual',
         },
         serviceAccountName: 'heartbeat-experiment',
         containers+: [
@@ -53,7 +54,7 @@ exp.Experiment(expName, 2, 'pusher-' + std.extVar('PROJECT_ID'), "none", datatyp
               '-token.machine=$(NODE_NAME)',
               '-token.verify-key=/verify/jwk_sig_EdDSA_locate_20200409.pub',
               '-ndt7.token.required=true',
-              '-label=type=physical',
+              '-label=type=virtual',
               '-label=deployment=canary',
             ],
             env: [

--- a/k8s/daemonsets/experiments/ndt-canary.jsonnet
+++ b/k8s/daemonsets/experiments/ndt-canary.jsonnet
@@ -47,7 +47,7 @@ exp.Experiment(expName, 2, 'pusher-' + std.extVar('PROJECT_ID'), "none", datatyp
               '-uuid-prefix-file=' + exp.uuid.prefixfile,
               '-prometheusx.listen-address=$(PRIVATE_IP):9990',
               '-datadir=/var/spool/' + expName,
-              '-txcontroller.device=net1',
+              '-txcontroller.device=bond0',
               '-htmldir=html/mlab',
               '-key=/certs/tls.key',
               '-cert=/certs/tls.crt',
@@ -56,6 +56,9 @@ exp.Experiment(expName, 2, 'pusher-' + std.extVar('PROJECT_ID'), "none", datatyp
               '-ndt7.token.required=true',
               '-label=type=virtual',
               '-label=deployment=canary',
+              '-ndt5_addr=127.0.0.1:3002', // any non-public port.
+              '-ndt5_ws_addr=:3001', // default, public ndt5 port.
+              '-ndt5.token.required=true',
             ],
             env: [
               {


### PR DESCRIPTION
This change is for testing one of the Equinix machines in production, but as a canary, which will pass the appropriate labels to ndt-server so that data from this machine can be easily identified.

Part of:
* https://github.com/m-lab/ops-tracker/issues/1798

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/828)
<!-- Reviewable:end -->
