### PR TITLE
Update tcp-info to v1.8.0 use -exclude-dstip

### DIFF
--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -208,7 +208,8 @@ local Tcpinfo(expName, tcpPort, hostNetwork, anonMode) = [
       '-uuid-prefix-file=' + uuid.prefixfile,
       '-tcpinfo.eventsocket=' + tcpinfoServiceVolume.socketFilename,
       '-exclude-srcport=9100,9090,9091,9989,9990,9991,9992,9993,9994,9995,9996,9997',
-      '-exclude-dstip=172.25.0.1',
+      // Exclude k8s api server, kube-ip static ips mlab-oti and mlab-staging.
+      '-exclude-dstip=172.25.0.1,35.202.153.90,35.188.150.110,35.185.54.7,35.243.193.167',
       '-anonymize.ip=' + anonMode,
     ],
     env: if hostNetwork then [] else [

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -197,7 +197,7 @@ local uuidannotatorServiceVolume = {
 local Tcpinfo(expName, tcpPort, hostNetwork, anonMode) = [
   {
     name: 'tcp-info',
-    image: 'measurementlab/tcp-info:v1.7.0',
+    image: 'measurementlab/tcp-info:v1.8.0',
     args: [
       if hostNetwork then
         '-prometheusx.listen-address=127.0.0.1:' + tcpPort
@@ -207,7 +207,8 @@ local Tcpinfo(expName, tcpPort, hostNetwork, anonMode) = [
       '-output=' + data.mount(expName).mountPath + '/tcpinfo',
       '-uuid-prefix-file=' + uuid.prefixfile,
       '-tcpinfo.eventsocket=' + tcpinfoServiceVolume.socketFilename,
-      '-exclude-srcport=9100,9989,9990,9991,9992,9993,9994,9995,9996,9997',
+      '-exclude-srcport=9100,9090,9091,9989,9990,9991,9992,9993,9994,9995,9996,9997',
+      '-exclude-dstip=172.25.0.1',
       '-anonymize.ip=' + anonMode,
     ],
     env: if hostNetwork then [] else [


### PR DESCRIPTION
This change updates the tcp-info version to v1.8.0 which includes the new flag to `-exclude-dstip=172.25.0.1` which is the same IP for the Kubernetes api servers in all projects. This destination accounts for ~68% of remaining unannotated rows. And, since these connections are only operational in origin, by eliminating them we will increase the net annotation ratio of the tcpinfo and scamper1 data and prevent unnecessary data collection of this data.

Part of:
* https://github.com/m-lab/dev-tracker/issues/760

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/829)
<!-- Reviewable:end -->
