### PR TITLE
Adds site-type=virtual pod label

### DIFF
--- a/k8s/daemonsets/experiments/ndt-canary.jsonnet
+++ b/k8s/daemonsets/experiments/ndt-canary.jsonnet
@@ -14,6 +14,7 @@ exp.Experiment(expName, 2, 'pusher-' + std.extVar('PROJECT_ID'), "none", datatyp
     selector+: {
       matchLabels+: {
         workload: expName + '-canary',
+        'site-type': 'virtual',
       },
     },
     template+: {


### PR DESCRIPTION
I noticed in the staging ndt-canary DaemonSet that this was set to physical.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/830)
<!-- Reviewable:end -->
