### PR TITLE
Places site-type pod label in right place

### DIFF
--- a/k8s/daemonsets/experiments/ndt-canary.jsonnet
+++ b/k8s/daemonsets/experiments/ndt-canary.jsonnet
@@ -14,7 +14,6 @@ exp.Experiment(expName, 2, 'pusher-' + std.extVar('PROJECT_ID'), "none", datatyp
     selector+: {
       matchLabels+: {
         workload: expName + '-canary',
-        'site-type': 'virtual',
       },
     },
     template+: {
@@ -24,6 +23,7 @@ exp.Experiment(expName, 2, 'pusher-' + std.extVar('PROJECT_ID'), "none", datatyp
         },
         labels+: {
           workload: expName + '-canary',
+          'site-type': 'virtual',
         },
       },
       spec+: {


### PR DESCRIPTION
The previous commit had it incorrectly in the pod selector labels, not where it should be in the pod labels.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/831)
<!-- Reviewable:end -->
