### PR TITLE
Adds new alert to detect excessive clock drift

### DIFF
--- a/config/prometheus/alerts.yml
+++ b/config/prometheus/alerts.yml
@@ -239,14 +239,14 @@ groups:
       dashboard: https://grafana.mlab-oti.measurementlab.net/d/_fugwnWZk/ops-tactical-and-sre-overview
 
   - alert: PlatformCluster_TooMuchClockDrift
-    expr: abs(timestamp(node_time_seconds) - node_time_seconds) > 15
+    expr: abs(timestamp(node_time_seconds) - node_time_seconds) > 30
     for: 1h
     labels:
       repo: ops-tracker
       severity: ticket
       cluster: platform
     annotations:
-      summary: A machine's clock has drifted by more than 15s
+      summary: A machine's clock has drifted by more than 30s
       description: https://github.com/m-lab/ops-tracker/wiki/Alerts-&-Troubleshooting#platformcluster_toomuchclockdrift
 
   # Too many OS releases on the platform for too long. This could happen, for

--- a/config/prometheus/alerts.yml
+++ b/config/prometheus/alerts.yml
@@ -238,6 +238,17 @@ groups:
       description: https://github.com/m-lab/ops-tracker/wiki/Alerts-&-Troubleshooting#platformhardware_machineuptoolong
       dashboard: https://grafana.mlab-oti.measurementlab.net/d/_fugwnWZk/ops-tactical-and-sre-overview
 
+  - alert: PlatformCluster_TooMuchClockDrift
+    expr: abs(timestamp(node_time_seconds) - node_time_seconds) > 15
+    for: 1h
+    labels:
+      repo: ops-tracker
+      severity: ticket
+      cluster: platform
+    annotations:
+      summary: A machine's clock has drifted by more than 15s
+      description: https://github.com/m-lab/ops-tracker/wiki/Alerts-&-Troubleshooting#platformcluster_toomuchclockdrift
+
   # Too many OS releases on the platform for too long. This could happen, for
   # example, if a new epoxy-images version was only partially deployed to the
   # platform.

--- a/k8s/daemonsets/core/node-exporter.jsonnet
+++ b/k8s/daemonsets/core/node-exporter.jsonnet
@@ -42,12 +42,13 @@ local exp = import '../templates.jsonnet';
               '--collector.stat',
               '--collector.textfile',
               '--collector.textfile.directory=/var/spool/node-exporter',
+              '--collector.time',
               '--path.procfs=/host/proc',
               '--path.rootfs=/host/root',
               '--path.sysfs=/host/sys',
               '--web.listen-address=127.0.0.1:9100',
             ],
-            image: 'prom/node-exporter:v1.3.1',
+            image: 'prom/node-exporter:v1.6.0',
             name: 'node-exporter',
             resources: {
               limits: {


### PR DESCRIPTION
This PR enables the `time` collector in node_exporter and uses its single metric to help [detect clock drift on machines](https://www.robustperception.io/time-metric-from-the-node-exporter/). It also adds a new alert for when the remote system's clock has drifted more than 15s in either direction from the Prometheus server's clock.

While I was touching the node_exporter manifest, I went ahead took the opportunity to upgrade node_exporter to the latest version.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/835)
<!-- Reviewable:end -->
