### PR TITLE
Update msak to v0.3.1

### DIFF
--- a/k8s/daemonsets/experiments/msak.jsonnet
+++ b/k8s/daemonsets/experiments/msak.jsonnet
@@ -4,7 +4,7 @@ local expName = 'msak';
 local expVersion = 'v0.3.1';
 local services = [
   'msak/throughput1=ws:///throughput/v1/download,ws:///throughput/v1/upload,wss:///throughput/v1/download,wss:///throughput/v1/upload',
-  'msak/latency1=http:///latency/v1/authorize,https:///latency/v1/authorize',
+  'msak/latency1=http:///latency/v1/authorize,https:///latency/v1/authorize,http:///latency/v1/result,https:///latency/v1/result',
 ];
 
 exp.Experiment(expName, 1, 'pusher-' + std.extVar('PROJECT_ID'), "none", [], datatypes) + {


### PR DESCRIPTION
This PR updates the deployed version of msak to [v0.3.1](https://github.com/m-lab/msak/releases/tag/v0.3.1) and adds the `msak/latency1` service.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/842)
<!-- Reviewable:end -->
