### PR TITLE
Filters 3rd-party experiment logs, and some logs from chatty sidecars

### DIFF
--- a/helm/vector-values-overrides.yaml.template
+++ b/helm/vector-values-overrides.yaml.template
@@ -7,8 +7,8 @@ customConfig:
       type: gcp_stackdriver_logs
       credentials_path: "/etc/vector/keys/vector.json"
       inputs:
-      - kernel_log
-      - kubernetes_logs
+      - kernel_log_filter
+      - kubernetes_logs_filter
       project_id: {{PROJECT}}
       log_id: "${VECTOR_SELF_NODE_NAME}"
       resource:

--- a/helm/vector-values-overrides.yaml.template
+++ b/helm/vector-values-overrides.yaml.template
@@ -29,6 +29,19 @@ customConfig:
       - journald
       # This catches anything with priority warning (4) to critical (0).
       condition: .SYSLOG_IDENTIFIER == "kernel" && includes(["0", "1", "2", "3", "4"], .PRIORITY)
+    kubernetes_logs:
+      type: filter
+      inputs:
+      - kubernetes_logs
+      # 3rd-party service logs
+      condition."kubernetes.container_name.regex" != "(revtrvp|wehe|dash)"
+      # tcp-info
+      condition."message.regex" != "saver\.go:[0-9]+:
+      (Cache|Closed|Closing|Missing|Starting)"
+      # traceroute-caller
+      condition."message.regex" != "command (finished|started|succeeded)
+      # packet-headers
+      condition."message.regex" != "tcp\.go:[0-9]+: (Context|Create|Successfully)"
 env:
 - name: VECTOR_LOG
   value: info

--- a/helm/vector-values-overrides.yaml.template
+++ b/helm/vector-values-overrides.yaml.template
@@ -35,10 +35,10 @@ customConfig:
       - kubernetes_logs
       # Filter logs from 3rd-party services and some logs from chatty sidecars
       condition: >-
-        ".kubernetes.container_name.regex" != "(revtrvp|wehe|dash)" ||
-        ".message.regex" != "saver\.go:[0-9]+: (Cache|Closed|Closing|Missing|Starting)" ||
-        ".message.regex" != "command (finished|started|succeeded) ||
-        ".message.regex" != "tcp\.go:[0-9]+: (Context|Create|Successfully)"
+        .kubernetes.container_name.regex != "(revtrvp|wehe|dash)" &&
+        .message.regex != "saver\.go:[0-9]+: (Cache|Closed|Closing|Missing|Starting)" &&
+        .message.regex != "command (finished|started|succeeded) &&
+        .message.regex != "tcp\.go:[0-9]+: (Context|Create|Successfully)"
 env:
 - name: VECTOR_LOG
   value: info

--- a/helm/vector-values-overrides.yaml.template
+++ b/helm/vector-values-overrides.yaml.template
@@ -36,7 +36,7 @@ customConfig:
       # Filter logs from 3rd-party services and some logs from chatty sidecars
       condition: >-
         !match(.kubernetes.container_name, r'(revtrvp|wehe|dash)') &&
-        !match_any(string(.message), [
+        !match_any(string!(.message), [
           r'saver\.go:[0-9]+: (Cache|Closed|Closing|Missing|Starting)',
           r'command (finished|started|succeeded)',
           r'tcp\.go:[0-9]+: (Context|Create|Successfully)'

--- a/helm/vector-values-overrides.yaml.template
+++ b/helm/vector-values-overrides.yaml.template
@@ -34,11 +34,11 @@ customConfig:
       inputs:
       - kubernetes_logs
       # Filter logs from 3rd-party services and some logs from chatty sidecars
-      condition: >
-        ."kubernetes.container_name.regex" != "(revtrvp|wehe|dash)" ||
-        ."message.regex" != "saver\.go:[0-9]+: (Cache|Closed|Closing|Missing|Starting)" ||
-        ."message.regex" != "command (finished|started|succeeded) ||
-        ."message.regex" != "tcp\.go:[0-9]+: (Context|Create|Successfully)"
+      condition: >-
+        ".kubernetes.container_name.regex" != "(revtrvp|wehe|dash)" ||
+        ".message.regex" != "saver\.go:[0-9]+: (Cache|Closed|Closing|Missing|Starting)" ||
+        ".message.regex" != "command (finished|started|succeeded) ||
+        ".message.regex" != "tcp\.go:[0-9]+: (Context|Create|Successfully)"
 env:
 - name: VECTOR_LOG
   value: info

--- a/helm/vector-values-overrides.yaml.template
+++ b/helm/vector-values-overrides.yaml.template
@@ -35,7 +35,7 @@ customConfig:
       - kubernetes_logs
       # Filter logs from 3rd-party services and some logs from chatty sidecars
       condition: >-
-        !match(.kubernetes.container_name, r'(revtrvp|wehe|dash)') &&
+        !match(string!(.kubernetes.container_name), r'(revtrvp|wehe|dash)') &&
         !match_any(string!(.message), [
           r'saver\.go:[0-9]+: (Cache|Closed|Closing|Missing|Starting)',
           r'command (finished|started|succeeded)',

--- a/helm/vector-values-overrides.yaml.template
+++ b/helm/vector-values-overrides.yaml.template
@@ -33,15 +33,12 @@ customConfig:
       type: filter
       inputs:
       - kubernetes_logs
-      # 3rd-party service logs
-      condition."kubernetes.container_name.regex" != "(revtrvp|wehe|dash)"
-      # tcp-info
-      condition."message.regex" != "saver\.go:[0-9]+:
-      (Cache|Closed|Closing|Missing|Starting)"
-      # traceroute-caller
-      condition."message.regex" != "command (finished|started|succeeded)
-      # packet-headers
-      condition."message.regex" != "tcp\.go:[0-9]+: (Context|Create|Successfully)"
+      # Filter logs from 3rd-party services and some logs from chatty sidecars
+      condition: >
+        ."kubernetes.container_name.regex" != "(revtrvp|wehe|dash)" ||
+        ."message.regex" != "saver\.go:[0-9]+: (Cache|Closed|Closing|Missing|Starting)" ||
+        ."message.regex" != "command (finished|started|succeeded) ||
+        ."message.regex" != "tcp\.go:[0-9]+: (Context|Create|Successfully)"
 env:
 - name: VECTOR_LOG
   value: info

--- a/helm/vector-values-overrides.yaml.template
+++ b/helm/vector-values-overrides.yaml.template
@@ -23,13 +23,13 @@ customConfig:
     kubernetes_logs:
       type: kubernetes_logs
   transforms:
-    kernel_log:
+    kernel_log_filter:
       type: filter
       inputs:
       - journald
       # This catches anything with priority warning (4) to critical (0).
       condition: .SYSLOG_IDENTIFIER == "kernel" && includes(["0", "1", "2", "3", "4"], .PRIORITY)
-    kubernetes_logs:
+    kubernetes_logs_filter:
       type: filter
       inputs:
       - kubernetes_logs

--- a/helm/vector-values-overrides.yaml.template
+++ b/helm/vector-values-overrides.yaml.template
@@ -36,7 +36,7 @@ customConfig:
       # Filter logs from 3rd-party services and some logs from chatty sidecars
       condition: >-
         !match(.kubernetes.container_name, r'(revtrvp|wehe|dash)') &&
-        !match_any(.message, [
+        !match_any(string(.message), [
           r'saver\.go:[0-9]+: (Cache|Closed|Closing|Missing|Starting)',
           r'command (finished|started|succeeded)',
           r'tcp\.go:[0-9]+: (Context|Create|Successfully)'

--- a/helm/vector-values-overrides.yaml.template
+++ b/helm/vector-values-overrides.yaml.template
@@ -35,10 +35,12 @@ customConfig:
       - kubernetes_logs
       # Filter logs from 3rd-party services and some logs from chatty sidecars
       condition: >-
-        .kubernetes.container_name.regex != "(revtrvp|wehe|dash)" &&
-        .message.regex != "saver\.go:[0-9]+: (Cache|Closed|Closing|Missing|Starting)" &&
-        .message.regex != "command (finished|started|succeeded) &&
-        .message.regex != "tcp\.go:[0-9]+: (Context|Create|Successfully)"
+        !match(.kubernetes.container_name, r'(revtrvp|wehe|dash)') &&
+        !match_any(.message, [
+          r'saver\.go:[0-9]+: (Cache|Closed|Closing|Missing|Starting)',
+          r'command (finished|started|succeeded)',
+          r'tcp\.go:[0-9]+: (Context|Create|Successfully)'
+        ])
 env:
 - name: VECTOR_LOG
   value: info


### PR DESCRIPTION
This PR is a first shot at reducing the amount of container logs we store in GCP Logging:

https://github.com/m-lab/k8s-support/issues/847

It does two main things:

* Eliminates all container logs from 3rd-party experiments (i.e., dash, revtr, wehe). Logs for these services will still remain in the cluster, but just won't be pushed to GCP for longer storage (30d).
* Eliminates some of the less helpful, but plentiful, logs messages from our sidecars services... specifically packet-headers, tcp-info and traceroute-caller.

We may find there are other log message we would like to filter, but this should be a good start.

The change took place at about 3:45PM MDT. Looking at the Logs Explorer in sandbox this [seems to be working 3rd-party experiments](https://console.cloud.google.com/logs/query;query=resource.type%3D%22generic_node%22%0Aresource.labels.location%3D%22mlab-sandbox%22%0AjsonPayload.kubernetes.container_name%3D~%22%2528revtrvp%7Cwehe%7Cdash%2529%22;cursorTimestamp=2023-08-25T21:44:09.287095963Z;startTime=2023-08-25T20:51:00.000Z;endTime=2023-08-25T22:40:00.000Z?serviceId=locate&project=mlab-sandbox), [as well as sidecars](https://console.cloud.google.com/logs/query;query=resource.type%3D%22generic_node%22%0Aresource.labels.location%3D%22mlab-sandbox%22%0AjsonPayload.kubernetes.container_name%3D~%22%2528tcp-info%7Cpacket-headers%7Ctraceroute-caller%2529%22;cursorTimestamp=2023-08-25T21:45:38.576774019Z;startTime=2023-08-25T21:40:45.000Z;endTime=2023-08-25T21:47:00.000Z?serviceId=locate&project=mlab-sandbox).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/848)
<!-- Reviewable:end -->
