### PR TITLE
Enables exporting of internal Vector metrics 

### DIFF
--- a/helm/vector-values-overrides.yaml.template
+++ b/helm/vector-values-overrides.yaml.template
@@ -7,6 +7,7 @@ customConfig:
       type: prometheus_exporter
       inputs:
       - vector_metrics
+	  address: 0.0.0.0:9090
     stackdriver:
       type: gcp_stackdriver_logs
       credentials_path: "/etc/vector/keys/vector.json"
@@ -37,8 +38,8 @@ customConfig:
 env:
 - name: VECTOR_LOG
   value: info
-extraContainerPorts:
-- 9598
+extraContainersPorts:
+- 9090
 extraVolumes:
 - name: credentials
   secret:

--- a/helm/vector-values-overrides.yaml.template
+++ b/helm/vector-values-overrides.yaml.template
@@ -25,8 +25,8 @@ customConfig:
       type: journald
     kubernetes_logs:
       type: kubernetes_logs
-	vector_metrics:
-	  type: vector_metrics
+    vector_metrics:
+      type: vector_metrics
   transforms:
     kernel_log_filter:
       type: filter

--- a/helm/vector-values-overrides.yaml.template
+++ b/helm/vector-values-overrides.yaml.template
@@ -26,7 +26,7 @@ customConfig:
     kubernetes_logs:
       type: kubernetes_logs
     vector_metrics:
-      type: vector_metrics
+      type: internal_metrics
   transforms:
     kernel_log_filter:
       type: filter

--- a/helm/vector-values-overrides.yaml.template
+++ b/helm/vector-values-overrides.yaml.template
@@ -7,7 +7,7 @@ customConfig:
       type: prometheus_exporter
       inputs:
       - vector_metrics
-	  address: 0.0.0.0:9090
+      address: 0.0.0.0:9090
     stackdriver:
       type: gcp_stackdriver_logs
       credentials_path: "/etc/vector/keys/vector.json"

--- a/helm/vector-values-overrides.yaml.template
+++ b/helm/vector-values-overrides.yaml.template
@@ -3,6 +3,10 @@ customConfig:
     enabled: false
   data_dir: /tmp
   sinks:
+    prometheus:
+      type: prometheus_exporter
+      inputs:
+      - vector_metrics
     stackdriver:
       type: gcp_stackdriver_logs
       credentials_path: "/etc/vector/keys/vector.json"
@@ -21,6 +25,8 @@ customConfig:
       type: journald
     kubernetes_logs:
       type: kubernetes_logs
+	vector_metrics:
+	  type: vector_metrics
   transforms:
     kernel_log_filter:
       type: filter
@@ -31,6 +37,8 @@ customConfig:
 env:
 - name: VECTOR_LOG
   value: info
+extraContainerPorts:
+- 9598
 extraVolumes:
 - name: credentials
   secret:


### PR DESCRIPTION
We recently [stopped pushing experiment container logs to GCP](https://github.com/m-lab/k8s-support/pull/849), and as part of that [we removed the alert `ContainerLogsMissingIngInStackdriver`](https://github.com/m-lab/prometheus-support/pull/1007). However, we have consistently found that Vector containers can get into a broken state with no visible symptom other than it stops pushing container logs successfully. Vector still does push kernel logs and _some_ low  volume container logs (e.g., cAdvisor, node-exporter, kube-state-metrics, etc). We still need some sort of alert for when Vector is broken, yet the container doesn't crash (which itself would cause an alert over time). 

This PR enables the `internal_metrics` data source and pushes it the `prometheus_exporter` sink on port 9090. Vector exports [a ridiculous number of metrics](https://vector.dev/docs/reference/configuration/sources/internal_metrics/#output-metrics), and we are likely only concerned with a few. However, until we can discover a broken container and find out which metric(s) are relevant, we collect all metrics exported by Vector. At some point we can either use Vector itself to filter some metric or we can filter on the Prometheus side.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/850)
<!-- Reviewable:end -->
