### PR TITLE
Changes ndt-canary selector to mlab/run=ndt-canary

### DIFF
--- a/k8s/daemonsets/experiments/ndt-canary.jsonnet
+++ b/k8s/daemonsets/experiments/ndt-canary.jsonnet
@@ -30,7 +30,7 @@ exp.ExperimentNoIndex(expName, 'pusher-' + std.extVar('PROJECT_ID'), 'none', dat
         hostNetwork: true,
         nodeSelector: {
           'mlab/type': 'virtual',
-          'mlab/ndt-version': 'canary',
+          'mlab/run': 'ndt-canary',
         },
         serviceAccountName: 'heartbeat-experiment',
         containers+: [


### PR DESCRIPTION
Previously, the selector was `mlab/ndt-version=canary`, which is different from the node selector used for a normal ndt-virtual nodes. This brings their configuration more in line, and allow us the possibility to assign any VM a certain DaemonSet in the Terraform configs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/851)
<!-- Reviewable:end -->
