### PR TITLE
Use measurementlab's revtr-sidecar image

### DIFF
--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -589,7 +589,7 @@ local UUIDAnnotator(expName, tcpPort, hostNetwork) = [
 local Revtr(expName, tcpPort) = [
   {
     name: 'revtr-sidecar',
-    image: 'kvermeul/revtr-sidecar:v1.3.0',
+    image: 'measurementlab/revtr-sidecar:v1.3.0',
     args: [
       '-tcpinfo.eventsocket=' + tcpinfoServiceVolume.socketFilename,
       '-revtr.hostname=revtr.ccs.neu.edu',


### PR DESCRIPTION
This PR updates the revtr-sidecar image to the one in the `measurementlab` namespace.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/856)
<!-- Reviewable:end -->
