### PR TITLE
Update revtr sample probability to 1% (for production deployment)

### DIFF
--- a/k8s/daemonsets/experiments/ndt.jsonnet
+++ b/k8s/daemonsets/experiments/ndt.jsonnet
@@ -99,7 +99,7 @@ exp.Experiment(expName, 2, 'pusher-' + std.extVar('PROJECT_ID'), "none", datatyp
         ]) + std.flattenArrays([
           // NOTE: exclude from production until design doc is approved, service
           // is monitored and scales to millions of requests/day.
-          if PROJECT_ID != 'mlab-oti' then exp.Revtr(expName) else []
+          exp.Revtr(expName)
         ]),
         volumes+: [
           {

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -595,7 +595,7 @@ local Revtr(expName, tcpPort) = [
       '-revtr.hostname=revtr.ccs.neu.edu',
       '-revtr.grpcPort=9999',
       '-prometheus.port='+tcpPort,
-      '-revtr.sampling=10', // 1%
+      '-revtr.sampling=100', // 1%
       '-revtr.APIKey=$(REVTR_APIKEY)',
       '-loglevel=debug',
     ],

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -595,7 +595,7 @@ local Revtr(expName, tcpPort) = [
       '-revtr.hostname=revtr.ccs.neu.edu',
       '-revtr.grpcPort=9999',
       '-prometheus.port='+tcpPort,
-      '-revtr.sampling=100',
+      '-revtr.sampling=10', // 1%
       '-revtr.APIKey=$(REVTR_APIKEY)',
       '-loglevel=debug',
     ],


### PR DESCRIPTION
This change prepares the revtr sidecar for production deployment.
* The sample probability is kept at 1%, with plans for staged increase to 10%, then 50%, with review at each step.
* The inclusion of the Revtr sidecar configuration is no longer conditional on project.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/857)
<!-- Reviewable:end -->
