### PR TITLE
Updates kube-rbac-proxy in node-exporter pod

### DIFF
--- a/k8s/daemonsets/core/node-exporter.jsonnet
+++ b/k8s/daemonsets/core/node-exporter.jsonnet
@@ -48,7 +48,7 @@ local exp = import '../templates.jsonnet';
               '--path.sysfs=/host/sys',
               '--web.listen-address=127.0.0.1:9100',
             ],
-            image: 'prom/node-exporter:v1.6.0',
+            image: 'prom/node-exporter:v1.7.0',
             name: 'node-exporter',
             resources: {
               limits: {
@@ -111,7 +111,7 @@ local exp = import '../templates.jsonnet';
                 },
               },
             ],
-            image: 'quay.io/brancz/kube-rbac-proxy:v0.11.0',
+            image: 'quay.io/brancz/kube-rbac-proxy:v0.15.0',
             name: 'kube-rbac-proxy',
             ports: [
               {


### PR DESCRIPTION
We just had an issue where the node-exporter pod on mlab1-bom01 wasn't able to download the kube-rbac-proxy image from quay.io. The quay.io status page said that they were aware of an intermittent issue with downloading older images. The version of kube-rbac-proxy we were using in the node-exporter pod was more than 2 years old. This commit updates kube-rbac-proxy to the latest version, and while I was at it I bumped the version of node-exporter itself, which wasn't all that old... might as well keep everything up to date when touching something.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/858)
<!-- Reviewable:end -->
