### PR TITLE
Update jostler to v1.1.2

### DIFF
--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -450,7 +450,7 @@ local Pusher(expName, tcpPort, datatypes, hostNetwork, bucket) = [
 local Jostler(expName, tcpPort, datatypesAutoloaded, hostNetwork, bucket) = [
   {
     name: 'jostler',
-    image: 'measurementlab/jostler:v1.0.9',
+    image: 'measurementlab/jostler:v1.1.2',
     args: [
       if hostNetwork then
         '-prometheusx.listen-address=127.0.0.1:' + tcpPort


### PR DESCRIPTION
This change updates jostler to v1.1.2. While this includes a minor update, most recent changes (https://github.com/m-lab/jostler/compare/v1.0.9...v1.1.2) are not material to use on the M-Lab platform. However, this version does include fixes to populate the archiver.Version and archiver.GitCommit values identified in https://github.com/m-lab/jostler/issues/54

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/859)
<!-- Reviewable:end -->
