### PR TITLE
Mount metadata volume to heartbeat

### DIFF
--- a/k8s/daemonsets/experiments/msak.jsonnet
+++ b/k8s/daemonsets/experiments/msak.jsonnet
@@ -114,6 +114,7 @@ exp.Experiment(expName, 1, 'pusher-' + std.extVar('PROJECT_ID'), "none", [], dat
               secretName: 'locate-verify-keys',
             },
           },
+          exp.Metadata.volume,
         ],
       },
     },

--- a/k8s/daemonsets/experiments/neubot.jsonnet
+++ b/k8s/daemonsets/experiments/neubot.jsonnet
@@ -77,6 +77,7 @@ exp.Experiment(expName, 10, 'pusher-' + std.extVar('PROJECT_ID'), "none", dataty
               secretName: 'measurement-lab-org-tls',
             },
           },
+          exp.Metadata.volume,
         ],
       },
     },

--- a/k8s/daemonsets/experiments/wehe.jsonnet
+++ b/k8s/daemonsets/experiments/wehe.jsonnet
@@ -210,6 +210,7 @@ exp.Experiment(expName, 5, 'pusher-' + std.extVar('PROJECT_ID'), 'netblock', ['r
               secretName: 'locate-verify-keys',
             },
           },
+          exp.Metadata.volume,
         ],
       },
     },

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -703,7 +703,7 @@ local Heartbeat(expName, tcpPort, hostNetwork, services) = [
         name: 'locate-heartbeat-key',
         readOnly: true,
       },
-      exp.Metadata.volumemount,
+      Metadata.volumemount,
     ],
   }] +
   if hostNetwork then

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -620,6 +620,22 @@ local Revtr(expName, tcpPort) = [
 ]
 ;
 
+local Metadata = {
+  path: '/metadata',
+  volumemount: {
+    mountPath: Metadata.path,
+    name: 'metadata',
+    readOnly: true,
+  },
+  volume: {
+    hostPath: {
+      path: '/var/local/metadata',
+      type: 'Directory',
+    },
+    name: 'metadata',
+  },
+};
+
 local Heartbeat(expName, tcpPort, hostNetwork, services) = [
   {
     name: 'heartbeat',
@@ -710,22 +726,6 @@ local Heartbeat(expName, tcpPort, hostNetwork, services) = [
     [RBACProxy('heartbeat', tcpPort)]
   else []
 ;
-
-local Metadata = {
-  path: '/metadata',
-  volumemount: {
-    mountPath: Metadata.path,
-    name: 'metadata',
-    readOnly: true,
-  },
-  volume: {
-    hostPath: {
-      path: '/var/local/metadata',
-      type: 'Directory',
-    },
-    name: 'metadata',
-  },
-};
 
 local ExperimentNoIndex(name, bucket, anonMode, datatypesArchived, datatypesAutoloaded, hostNetwork, siteType='physical') = {
   local allDatatypes =  ['tcpinfo', 'pcap', 'annotation2', 'scamper1', 'hopannotation2'] + datatypesArchived,

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -703,6 +703,7 @@ local Heartbeat(expName, tcpPort, hostNetwork, services) = [
         name: 'locate-heartbeat-key',
         readOnly: true,
       },
+      exp.Metadata.volumemount,
     ],
   }] +
   if hostNetwork then


### PR DESCRIPTION
This PR mounts the metadata volume to the heartbeat.

```
$ kubectl --context mlab-sandbox exec -it ndt-virtual-9pf4q -c heartbeat -- sh
~ $ cd metadata
/metadata $ cat loadbalanced
true/metadata $
```

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/860)
<!-- Reviewable:end -->
