### PR TITLE
Removes conditional for packet-headers memory limit flags

### DIFF
--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -319,11 +319,8 @@ local Pcap(expName, tcpPort, hostNetwork, siteType, anonMode) = [
       '-tcpinfo.eventsocket=' + tcpinfoServiceVolume.socketFilename,
       '-stream=false',
       '-anonymize.ip=' + anonMode,
-    ] + if siteType == 'virtual' then [
-      // Only virtual nodes need to limit RAM beyond default values.
       '-maxidleram=1500MB',
       '-maxheap=2GB',
-    ] else [
     ] + if expName == 'host' then [
       // The "host" experiment is currently the only experiment where
       // packet-headers needs to listen explictly on interface eth0.


### PR DESCRIPTION
Previously, we restricted applying the flags `-maxidleram` and `-maxheap` to only VMs. This change applies those flags to all machine types, both VMs and physical. The expected outcome is that this shouldn't modify behavior of packet-headers on physical machines most all of the time, but may prevent packet-headers from eating up too much memory and invoking the oom-killer due to SYN floods or heavy traffic spikes. In either case packet-headers data is corrupted or non-existent, but with the flags it may not take the machine down or make it unresponsive.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/862)
<!-- Reviewable:end -->
