### PR TITLE
Adds netstat collector to node_exporter

### DIFF
--- a/k8s/daemonsets/core/node-exporter.jsonnet
+++ b/k8s/daemonsets/core/node-exporter.jsonnet
@@ -37,6 +37,7 @@ local exp = import '../templates.jsonnet';
               '--collector.hwmon',
               '--collector.loadavg',
               '--collector.meminfo',
+              '--collector.netstat',
               '--collector.netdev',
               '--collector.processes',
               '--collector.stat',


### PR DESCRIPTION
The metrics provided by this collector could be useful, especially the ones related to SYN cookies, which may help us detect SYN floods.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/863)
<!-- Reviewable:end -->
