### PR TITLE
Upgrade to k8s v1.26.12

### DIFF
--- a/manage-cluster/k8s_deploy.conf
+++ b/manage-cluster/k8s_deploy.conf
@@ -28,25 +28,25 @@ PROM_BASE_NAME="prometheus-${GCE_BASE_NAME}"
 # we learn more.
 GCE_API_SCOPES="cloud-platform"
 
-K8S_VERSION="v1.25.13" # https://github.com/kubernetes/kubernetes/releases
-K8S_CNI_VERSION="v1.3.0" # https://github.com/containernetworking/plugins/releases
-K8S_CRICTL_VERSION="v1.25.0" # https://github.com/kubernetes-sigs/cri-tools/releases
+K8S_VERSION="v1.26.11" # https://github.com/kubernetes/kubernetes/releases
+K8S_CNI_VERSION="v1.4.0" # https://github.com/containernetworking/plugins/releases
+K8S_CRICTL_VERSION="v1.26.1" # https://github.com/kubernetes-sigs/cri-tools/releases
 # FLANNEL is for the flannel DaemonSet, whereas FLANNELCNI is for the CNI
 # plugin located at /opt/cni/bin (used by the kubelet).
-K8S_FLANNEL_VERSION="v0.22.2" # https://github.com/flannel-io/flannel/releases
+K8S_FLANNEL_VERSION="v0.24.0" # https://github.com/flannel-io/flannel/releases
 K8S_FLANNELCNI_VERSION=v1.2.0 # https://github.com/flannel-io/cni-plugin/releases
-K8S_TOOLING_VERSION="v0.15.1" # https://github.com/kubernetes/release/releases
+K8S_TOOLING_VERSION="v0.16.4" # https://github.com/kubernetes/release/releases
 # kubeadm installs and managed etcd automatically. Try to keep this version of
 # etcdctl more or less in line with the default etcd version that kubeadm uses
 # for any given release of k8s. For example, see this:
-# https://github.com/kubernetes/kubernetes/blob/v1.23.16/cmd/kubeadm/app/constants/constants.go#L304
-ETCDCTL_VERSION="v3.5.6"
+# https://github.com/kubernetes/kubernetes/blob/v1.26.11/cmd/kubeadm/app/constants/constants.go#L314
+ETCDCTL_VERSION="v3.5.9"
 K8S_HELM_VERSION="v3.12.3" # https://github.com/helm/helm/releases
-K8S_VECTOR_VERSION="0.32.1-debian" # https://github.com/vectordotdev/vector/releases
-K8S_VECTOR_CHART="0.24.1" # https://github.com/vectordotdev/helm-charts/releases
-K8S_KURED_VERSION="1.13.2" # https://github.com/kubereboot/kured/releases
-K8S_KURED_CHART="5.1.0" # https://github.com/kubereboot/charts/releases
-K8S_CERTMANAGER_VERSION="v1.12.4" # https://github.com/cert-manager/cert-manager/releases
+K8S_VECTOR_VERSION="0.34.1-debian" # https://github.com/vectordotdev/vector/releases
+K8S_VECTOR_CHART="0.29.0" # https://github.com/vectordotdev/helm-charts/releases
+K8S_KURED_VERSION="1.14.2" # https://github.com/kubereboot/kured/releases
+K8S_KURED_CHART="5.3.2" # https://github.com/kubereboot/charts/releases
+K8S_CERTMANAGER_VERSION="v1.13.1" # https://github.com/cert-manager/cert-manager/releases
 K8S_CERTMANAGER_DNS01_SA="cert-manager-dns01-solver"
 K8S_CERTMANAGER_SA_KEY="cert-manager-credentials.json"
 K8S_CA_FILES="ca.crt ca.key sa.key sa.pub front-proxy-ca.crt front-proxy-ca.key etcd/ca.crt etcd/ca.key"

--- a/manage-cluster/k8s_deploy.conf
+++ b/manage-cluster/k8s_deploy.conf
@@ -28,7 +28,7 @@ PROM_BASE_NAME="prometheus-${GCE_BASE_NAME}"
 # we learn more.
 GCE_API_SCOPES="cloud-platform"
 
-K8S_VERSION="v1.26.11" # https://github.com/kubernetes/kubernetes/releases
+K8S_VERSION="v1.26.12" # https://github.com/kubernetes/kubernetes/releases
 K8S_CNI_VERSION="v1.4.0" # https://github.com/containernetworking/plugins/releases
 K8S_CRICTL_VERSION="v1.26.1" # https://github.com/kubernetes-sigs/cri-tools/releases
 # FLANNEL is for the flannel DaemonSet, whereas FLANNELCNI is for the CNI


### PR DESCRIPTION
Along with upgrading k8s to v1.26.12, as usual, this PR takes the opportunity to upgrade other cluster services and related components.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/864)
<!-- Reviewable:end -->
