### PR TITLE
Update msak to v0.4.6.

### DIFF
--- a/k8s/daemonsets/experiments/msak.jsonnet
+++ b/k8s/daemonsets/experiments/msak.jsonnet
@@ -1,7 +1,7 @@
 local datatypes = ['throughput1','latency1'];
 local exp = import '../templates.jsonnet';
 local expName = 'msak';
-local expVersion = 'v0.4.3';
+local expVersion = 'v0.4.6';
 local services = [
   'msak/throughput1=ws:///throughput/v1/download,ws:///throughput/v1/upload,wss:///throughput/v1/download,wss:///throughput/v1/upload',
   'msak/latency1=http:///latency/v1/authorize,https:///latency/v1/authorize,http:///latency/v1/result,https:///latency/v1/result',


### PR DESCRIPTION
[Releases](https://github.com/m-lab/msak/releases) v0.4.4 and v0.4.5 only contained client-side changes. v0.4.6 changes some Prometheus metrics.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/868)
<!-- Reviewable:end -->
