### PR TITLE
Increase revtr rate to 10%

### DIFF
--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -592,7 +592,7 @@ local Revtr(expName, tcpPort) = [
       '-revtr.hostname=revtr.ccs.neu.edu',
       '-revtr.grpcPort=9999',
       '-prometheus.port='+tcpPort,
-      '-revtr.sampling=100', // 1%
+      '-revtr.sampling=10', // x/100 == 10%
       '-revtr.APIKey=$(REVTR_APIKEY)',
       '-loglevel=debug',
     ],


### PR DESCRIPTION
This change increases the rate of samples triggering the revtr sidecar to 10% (every 10th event).

FYI: @kvermeul

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/870)
<!-- Reviewable:end -->
