### PR TITLE
Updates uuid-annotator container image to v0.5.5

### DIFF
--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -517,7 +517,7 @@ local Jostler(expName, tcpPort, datatypesAutoloaded, hostNetwork, bucket) = [
 local UUIDAnnotator(expName, tcpPort, hostNetwork) = [
   {
     name: 'uuid-annotator',
-    image: 'measurementlab/uuid-annotator:v0.5.3',
+    image: 'measurementlab/uuid-annotator:v0.5.5',
     args: [
       if hostNetwork then
         '-prometheusx.listen-address=127.0.0.1:' + tcpPort


### PR DESCRIPTION
This will hopefully resolve the "DataPipeline_GeoAnnotationRatioTooLowOrMissing" alerts in production, which we believe are related to uuid-annotator not currently recognizing the load balancer public IPv6 address, which this [new version of uuid-annotator should have resolved](https://github.com/m-lab/uuid-annotator/pull/63).

Prior to this new version, uuid-annotator on mlab1-chs0t nodes in sandbox were logging something like the following several times every 5 or 10 seconds:

```
2024/02/13 04:21:25 /go/src/github.com/m-lab/uuid-annotator/handler/handler.go:76: Can't annotate connection: Unknown direction for &{SPort:443 DPort:56882 SrcIP:2600:1900:4020:31cd:8000:: DstIP:2600:1901:8001:1e::1:6 Interface:0 Cookie:1304603}
```

With this new version of uuid-annotator, those log messages are gone.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/871)
<!-- Reviewable:end -->
