### PR TITLE
Adds new ndt-server -label flag for "managed"

### DIFF
--- a/k8s/daemonsets/experiments/ndt-canary.jsonnet
+++ b/k8s/daemonsets/experiments/ndt-canary.jsonnet
@@ -72,6 +72,7 @@ exp.ExperimentNoIndex(expName, 'pusher-' + std.extVar('PROJECT_ID'), 'none', dat
               '-label=machine-type=@' + exp.Metadata.path + '/machine-type',
               '-label=network-tier=@' + exp.Metadata.path + '/network-tier',
               '-label=zone=@' + exp.Metadata.path + '/zone',
+              '-label=managed=@' + exp.Metadata.path + '/managed',
             ],
             env: [
               {

--- a/k8s/daemonsets/experiments/ndt-virtual.jsonnet
+++ b/k8s/daemonsets/experiments/ndt-virtual.jsonnet
@@ -72,6 +72,7 @@ exp.ExperimentNoIndex(expName, 'pusher-' + std.extVar('PROJECT_ID'), 'none', dat
               '-label=machine-type=@' + exp.Metadata.path + '/machine-type',
               '-label=network-tier=@' + exp.Metadata.path + '/network-tier',
               '-label=zone=@' + exp.Metadata.path + '/zone',
+              '-label=managed=@' + exp.Metadata.path + '/managed',
             ],
             env: [
               {

--- a/k8s/daemonsets/experiments/ndt.jsonnet
+++ b/k8s/daemonsets/experiments/ndt.jsonnet
@@ -45,6 +45,7 @@ exp.Experiment(expName, 2, 'pusher-' + std.extVar('PROJECT_ID'), "none", datatyp
               '-ndt7.token.required=true',
               '-label=type=physical',
               '-label=deployment=stable',
+              '-label=managed=@' + exp.Metadata.path + '/managed',
             ],
             env: [
               {


### PR DESCRIPTION
There is a new metadata file at /var/local/metadata/managed, which contains different values depending on the deployment environment. For "full" physical sites it will be "switch,machine", for "minimal" sites it will be "machine" and for BYOS it will be "none". This will allow data users to filter based on the environment.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/873)
<!-- Reviewable:end -->
