### PR TITLE
Fix Vector and flannel container image tags

### DIFF
--- a/k8s/daemonsets/core/flannel-physical.jsonnet
+++ b/k8s/daemonsets/core/flannel-physical.jsonnet
@@ -106,7 +106,7 @@
             command: [
               'cp',
             ],
-            image: 'flannel/flannel:' + std.extVar('K8S_FLANNEL_VERSION') + '-amd64',
+            image: 'flannel/flannel:' + std.extVar('K8S_FLANNEL_VERSION'),
             name: 'install-cni',
             volumeMounts: [
               {

--- a/k8s/daemonsets/core/flannel-physical.jsonnet
+++ b/k8s/daemonsets/core/flannel-physical.jsonnet
@@ -59,7 +59,7 @@
                 },
               },
             ],
-            image: 'flannel/flannel:' + std.extVar('K8S_FLANNEL_VERSION') + '-amd64',
+            image: 'flannel/flannel:' + std.extVar('K8S_FLANNEL_VERSION'),
             name: 'flannel',
             resources: {
               limits: {

--- a/k8s/daemonsets/core/flannel-virtual.jsonnet
+++ b/k8s/daemonsets/core/flannel-virtual.jsonnet
@@ -56,7 +56,7 @@
                 },
               },
             ],
-            image: 'flannel/flannel:' + std.extVar('K8S_FLANNEL_VERSION') + '-amd64',
+            image: 'flannel/flannel:' + std.extVar('K8S_FLANNEL_VERSION'),
             name: 'flannel',
             resources: {
               limits: {

--- a/k8s/daemonsets/core/flannel-virtual.jsonnet
+++ b/k8s/daemonsets/core/flannel-virtual.jsonnet
@@ -103,7 +103,7 @@
             command: [
               'cp',
             ],
-            image: 'flannel/flannel:' + std.extVar('K8S_FLANNEL_VERSION') + '-amd64',
+            image: 'flannel/flannel:' + std.extVar('K8S_FLANNEL_VERSION'),
             name: 'install-cni',
             volumeMounts: [
               {

--- a/manage-cluster/k8s_deploy.conf
+++ b/manage-cluster/k8s_deploy.conf
@@ -42,7 +42,7 @@ K8S_TOOLING_VERSION="v0.16.7" # https://github.com/kubernetes/release/releases
 # https://github.com/kubernetes/kubernetes/blob/v1.26.11/cmd/kubeadm/app/constants/constants.go#L314
 ETCDCTL_VERSION="v3.5.12"
 K8S_HELM_VERSION="v3.14.3" # https://github.com/helm/helm/releases
-K8S_VECTOR_VERSION="0.37.0" # https://github.com/vectordotdev/vector/releases
+K8S_VECTOR_VERSION="0.37.0-debian" # https://github.com/vectordotdev/vector/releases
 K8S_VECTOR_CHART="0.32.0" # https://github.com/vectordotdev/helm-charts/releases
 K8S_KURED_VERSION="1.15.1" # https://github.com/kubereboot/kured/releases
 K8S_KURED_CHART="5.4.5" # https://github.com/kubereboot/charts/releases


### PR DESCRIPTION
In a [previous PR](https://github.com/m-lab/k8s-support/pull/874) the `-debian` suffix was accidentally removed from the version string for Vector. This PR adds that back.

Additionally, before, flannel released container image tags with an `-amd64` suffix, but it appears that they stopped doing this not long ago, so this PR removes that suffix.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/875)
<!-- Reviewable:end -->
