### PR TITLE
Adds new mlab/managed=switch-machine nodeSelector to Disco

### DIFF
--- a/k8s/daemonsets/core/disco.jsonnet
+++ b/k8s/daemonsets/core/disco.jsonnet
@@ -93,6 +93,7 @@ local dataDir = exp.VolumeMount('utilization').mountPath;
           ]),
         nodeSelector: {
           'mlab/type': 'physical',
+          'mlab/managed': 'switch-machine',
         },
         [if std.extVar('PROJECT_ID') != 'mlab-sandbox' then 'terminationGracePeriodSeconds']: 120,
         securityContext: {


### PR DESCRIPTION
Today, Disco is configured to run as a DaemonSet on all physical machines. With the advent of "minimal" physical sites which do not have a switch, we don't want Disco running there. This commit adds a new nodeSelector leveraging the new "[mlab/managed](https://github.com/m-lab/epoxy-images/pull/261)" node label such that Disco should only be deployed on physical machines where a switch is present.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/877)
<!-- Reviewable:end -->
