### PR TITLE
Rename packet-test experiment to pt

### DIFF
--- a/k8s/daemonsets/experiments/packet-test.jsonnet
+++ b/k8s/daemonsets/experiments/packet-test.jsonnet
@@ -1,8 +1,9 @@
+local datatypes = ['pair1','train1'];
 local exp = import '../templates.jsonnet';
 local expName = 'pt';
 local services = [];
 
-exp.Experiment(expName, 6, 'pusher-' + std.extVar('PROJECT_ID'), "none", [], []) + {
+exp.Experiment(expName, 6, 'pusher-' + std.extVar('PROJECT_ID'), "none", datatypes, []) + {
   spec+: {
     template+: {
       metadata+: {

--- a/k8s/daemonsets/experiments/packet-test.jsonnet
+++ b/k8s/daemonsets/experiments/packet-test.jsonnet
@@ -1,9 +1,8 @@
-local datatypes = ['packet-test'];
 local exp = import '../templates.jsonnet';
-local expName = 'packet-test';
+local expName = 'pt';
 local services = [];
 
-exp.Experiment(expName, 6, 'pusher-' + std.extVar('PROJECT_ID'), "none", datatypes, []) + {
+exp.Experiment(expName, 6, 'pusher-' + std.extVar('PROJECT_ID'), "none", [], []) + {
   spec+: {
     template+: {
       metadata+: {


### PR DESCRIPTION
This PR renames the packet-test experiment to "pt" to avoid pusher error regarding invalid naming conventions. The pt daemonset is running in sandbox.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/879)
<!-- Reviewable:end -->
