### PR TITLE
Enable autoloading for packet-test

### DIFF
--- a/k8s/daemonsets/experiments/packet-test.jsonnet
+++ b/k8s/daemonsets/experiments/packet-test.jsonnet
@@ -33,7 +33,7 @@ exp.Experiment(expName, 6, 'pusher-' + std.extVar('PROJECT_ID'), "none", [], dat
           {
             args: [
               '-datadir=/var/spool/' + expName,
-              '-hostname=$(MLAB_NODE_NAME)',
+              '-hostname=$(NODE_NAME)',
             ],
             env: [
               {

--- a/k8s/daemonsets/experiments/packet-test.jsonnet
+++ b/k8s/daemonsets/experiments/packet-test.jsonnet
@@ -82,6 +82,7 @@ exp.Experiment(expName, 6, 'pusher-' + std.extVar('PROJECT_ID'), "none", [], dat
                 name: 'locate-verify-keys',
                 readOnly: true,
               },
+              exp.uuid.volumemount,
             ] + [
               exp.VolumeMount(expName + '/' + d) for d in datatypes
             ],

--- a/k8s/daemonsets/experiments/packet-test.jsonnet
+++ b/k8s/daemonsets/experiments/packet-test.jsonnet
@@ -32,14 +32,7 @@ exp.Experiment(expName, 6, 'pusher-' + std.extVar('PROJECT_ID'), "none", [], dat
         containers+: [
           {
             args: [
-              '-ws_addr=:80',
-              '-wss_addr=:443',
-              '-cert=/certs/tls.crt',
-              '-key=/certs/tls.key',
               '-datadir=/var/spool/' + expName,
-              '-token.machine=$(NODE_NAME)',
-              '-token.verify=false',
-              '-debug=true',
             ],
             env: [
               {

--- a/k8s/daemonsets/experiments/packet-test.jsonnet
+++ b/k8s/daemonsets/experiments/packet-test.jsonnet
@@ -13,6 +13,22 @@ exp.Experiment(expName, 6, 'pusher-' + std.extVar('PROJECT_ID'), "none", [], dat
       },
       spec+: {
         serviceAccountName: 'heartbeat-experiment',
+        initContainers+: [
+          {
+            // Copy the JSON schema where jostler expects it to be.
+            name: 'copy-schema',
+            image: 'measurementlab/packet-test:latest',
+            command: [
+              '/bin/sh',
+              '-c',
+              'cp /packet-test/pair1.json /var/spool/datatypes/pair1.json && ' +
+              'cp /packet-test/train1.json /var/spool/datatypes/train1.json',
+            ],
+            volumeMounts: [
+              exp.VolumeMountDatatypes(expName),
+            ],
+          },
+        ],
         containers+: [
           {
             args: [

--- a/k8s/daemonsets/experiments/packet-test.jsonnet
+++ b/k8s/daemonsets/experiments/packet-test.jsonnet
@@ -3,7 +3,7 @@ local exp = import '../templates.jsonnet';
 local expName = 'pt';
 local services = [];
 
-exp.Experiment(expName, 6, 'pusher-' + std.extVar('PROJECT_ID'), "none", datatypes, []) + {
+exp.Experiment(expName, 6, 'pusher-' + std.extVar('PROJECT_ID'), "none", [], datatypes) + {
   spec+: {
     template+: {
       metadata+: {

--- a/k8s/daemonsets/experiments/packet-test.jsonnet
+++ b/k8s/daemonsets/experiments/packet-test.jsonnet
@@ -33,6 +33,7 @@ exp.Experiment(expName, 6, 'pusher-' + std.extVar('PROJECT_ID'), "none", [], dat
           {
             args: [
               '-datadir=/var/spool/' + expName,
+              '-hostname=$(MLAB_NODE_NAME)',
             ],
             env: [
               {


### PR DESCRIPTION
This PR enables autoloading for `pt` (packet-test).

Autoloaded data can be found under mlab-sandbox.raw_pt.train1.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/880)
<!-- Reviewable:end -->
