### PR TITLE
Add ndt7 to autoloadable datatypes for "pt" daemonset

### DIFF
--- a/k8s/daemonsets/experiments/packet-test-virtual.jsonnet
+++ b/k8s/daemonsets/experiments/packet-test-virtual.jsonnet
@@ -43,7 +43,7 @@ local services = [];
               '/bin/sh',
               '-c',
               'cp /packet-test/pair1.json /var/spool/datatypes/pair1.json && ' +
-              'cp /packet-test/train1.json /var/spool/datatypes/train1.json && ', +
+              'cp /packet-test/train1.json /var/spool/datatypes/train1.json && ' +
               'cp /packet-test/ndt7.json /var/spool/datatypes/ndt7.json',
             ],
             volumeMounts: [

--- a/k8s/daemonsets/experiments/packet-test-virtual.jsonnet
+++ b/k8s/daemonsets/experiments/packet-test-virtual.jsonnet
@@ -144,6 +144,13 @@ local services = [];
               type: 'DirectoryOrCreate',
             },
           },
+          {
+            name: expName + '-ndt7-data',
+            hostPath: {
+              path: '/cache/data/' + expName + '/ndt7',
+              type: 'DirectoryOrCreate',
+            },
+          },
           exp.Metadata.volume,
         ],
       },

--- a/k8s/daemonsets/experiments/packet-test-virtual.jsonnet
+++ b/k8s/daemonsets/experiments/packet-test-virtual.jsonnet
@@ -1,4 +1,4 @@
-local datatypes = ['pair1','train1'];
+local datatypes = ['pair1','train1','ndt7'];
 local exp = import '../templates.jsonnet';
 local expName = 'pt';
 local services = [];

--- a/k8s/daemonsets/experiments/packet-test-virtual.jsonnet
+++ b/k8s/daemonsets/experiments/packet-test-virtual.jsonnet
@@ -43,7 +43,8 @@ local services = [];
               '/bin/sh',
               '-c',
               'cp /packet-test/pair1.json /var/spool/datatypes/pair1.json && ' +
-              'cp /packet-test/train1.json /var/spool/datatypes/train1.json',
+              'cp /packet-test/train1.json /var/spool/datatypes/train1.json && ', +
+              'cp /packet-test/ndt7.json /var/spool/datatypes/ndt7.json',
             ],
             volumeMounts: [
               exp.VolumeMountDatatypes(expName),

--- a/k8s/daemonsets/experiments/packet-test.jsonnet
+++ b/k8s/daemonsets/experiments/packet-test.jsonnet
@@ -22,7 +22,8 @@ exp.Experiment(expName, 6, 'pusher-' + std.extVar('PROJECT_ID'), "none", [], dat
               '/bin/sh',
               '-c',
               'cp /packet-test/pair1.json /var/spool/datatypes/pair1.json && ' +
-              'cp /packet-test/train1.json /var/spool/datatypes/train1.json',
+              'cp /packet-test/train1.json /var/spool/datatypes/train1.json && ' +
+              'cp /packet-test/ndt7.json /var/spool/datatypes/ndt7.json',
             ],
             volumeMounts: [
               exp.VolumeMountDatatypes(expName),

--- a/k8s/daemonsets/experiments/packet-test.jsonnet
+++ b/k8s/daemonsets/experiments/packet-test.jsonnet
@@ -1,4 +1,4 @@
-local datatypes = ['pair1','train1'];
+local datatypes = ['pair1','train1','ndt7'];
 local exp = import '../templates.jsonnet';
 local expName = 'pt';
 local services = [];


### PR DESCRIPTION
This PR adds the ndt7 datatype to the list of autoloadable datatypes for the "pt" and "pt-virtual" daemonsets.

Sample autoloaded data can be found under `mlab-sandbox.raw_pt.ndt7`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/882)
<!-- Reviewable:end -->
