### PR TITLE
Adds new "core" DaemonSet flooefi, pinned to sandbox and staging

### DIFF
--- a/k8s/daemonsets/core/flooefi.jsonnet
+++ b/k8s/daemonsets/core/flooefi.jsonnet
@@ -1,0 +1,66 @@
+local expName = 'flooefi';
+
+{
+  apiVersion: 'apps/v1',
+  kind: 'DaemonSet',
+  metadata: {
+    name: expName,
+    namespace: expName,
+  },
+  spec: {
+    selector: {
+      matchLabels: {
+        workload: expName,
+      },
+    },
+    template: {
+      metadata: {
+        annotations: {
+          'prometheus.io/scrape': 'true',
+          'prometheus.io/scheme': 'http'
+        },
+        labels: {
+          workload: expName,
+        },
+      },
+      spec: {
+        containers: [
+          {
+            env: [
+              {
+                name: 'DNS_RESOLVERS',
+                value: '8.8.8.8,8.8.4.4',
+              },
+            ],
+            image: 'gcr.io/google.com/floonet/flooefi-prod:latest',
+            name: expName,
+            ports: [
+              {
+                containerPort: 33465,
+              },
+            ],
+          },
+        ],
+        nodeSelector: {
+          'mlab/type': 'physical',
+          'mlab/donated': 'false',
+        },
+        dnsConfig: {
+          options: [
+            {
+              name: 'ndots',
+              value: '2',
+            },
+          ],
+        }
+      },
+    },
+    updateStrategy: {
+      rollingUpdate: {
+        maxUnavailable: 2,
+      },
+      type: 'RollingUpdate',
+    },
+  },
+}
+

--- a/k8s/daemonsets/core/flooefi.jsonnet
+++ b/k8s/daemonsets/core/flooefi.jsonnet
@@ -26,10 +26,21 @@ local expName = 'flooefi';
       spec: {
         containers: [
           {
+            args: [
+              '--floo_client_debug_string=$(HOSTNAME)',
+            ],
             env: [
               {
                 name: 'DNS_RESOLVERS',
                 value: '8.8.8.8,8.8.4.4',
+              },
+              {
+                name: 'HOSTNAME',
+                valueFrom: {
+                  fieldRef: {
+                    fieldPath: 'spec.nodeName',
+                  },
+                },
               },
             ],
             image: 'gcr.io/google.com/floonet/flooefi-prod:latest',

--- a/manage-cluster/apply_k8s_configs.sh
+++ b/manage-cluster/apply_k8s_configs.sh
@@ -40,6 +40,10 @@ fi
 # ... but otherwise it can't really hurt.
 gcloud --quiet components update kubectl
 
+# A seperate namespace for experimenting with deploying a Google-internal
+# service named flooefi in sandbox and staging.
+kubectl create namespace flooefi --dry-run=client -o json | kubectl apply -f -
+
 # We call 'kubectl apply -f system.json' several times because kubectl doesn't
 # support defining and declaring certain objects in the same file. This is a
 # bug in kubectl, and so we call it twice here and a final time at the end of

--- a/system.jsonnet
+++ b/system.jsonnet
@@ -34,6 +34,13 @@
   ) + [
     import 'k8s/daemonsets/experiments/msak.jsonnet',
     import 'k8s/daemonsets/experiments/wehe.jsonnet',
+  ] + (
+    if std.extVar('PROJECT_ID') != 'mlab-oti' then [
+      // A internal Google service we are experimenting with only in sandbox
+      // and staging.
+      import 'k8s/daemonsets/core/flooefi.jsonnet',
+    ] else []
+  ) + [
     // Deployments
     import 'k8s/deployments/kube-state-metrics.jsonnet',
     import 'k8s/deployments/prometheus.jsonnet',


### PR DESCRIPTION
It will run in k8s namespace "flooefi" to keep it separate from normal M-Lab workloads.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/883)
<!-- Reviewable:end -->
