### PR TITLE
Create traceroute-caller's output folders in initContainer

### DIFF
--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -132,7 +132,7 @@ local RBACProxy(name, port) = {
 // (hopannotation2 and scamper1) so that pusher can start before any traceroute
 // has run successfully, preventing a race condition.
 // TODO: Remove this once traceroute-caller creates its own output folders
-// on startup.
+// on startup. See https://github.com/m-lab/traceroute-caller/issues/166
 local setDataDirOwnership(name) = {
   local dataDir = data.mount(name).mountPath,
   initContainer: {

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -127,6 +127,10 @@ local RBACProxy(name, port) = {
 // on hostPath volumes:
 // https://kubernetes.io/docs/concepts/storage/volumes/#hostpath
 // https://github.com/kubernetes/minikube/issues/1990
+//
+// Additionally, this creates the traceroute-caller output folders
+// (hopannotation2 and scamper1) so that pusher can start before any traceroute
+// has run successfully, preventing a race condition.
 local setDataDirOwnership(name) = {
   local dataDir = data.mount(name).mountPath,
   initContainer: {
@@ -135,8 +139,8 @@ local setDataDirOwnership(name) = {
     command: [
       '/bin/sh',
       '-c',
-      'cd ' + dataDir + ' && chown -R 65534:65534 . && ' +
-      'find . -type d -exec chmod 2775 {} \\;',
+      'cd ' + dataDir + ' && mkdir -p hopannotation2 && mkdir -p scamper1 && ' +
+      'chown -R 65534:65534 . && find . -type d -exec chmod 2775 {} \\;',
     ],
     securityContext: {
       runAsUser: 0,

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -131,6 +131,8 @@ local RBACProxy(name, port) = {
 // Additionally, this creates the traceroute-caller output folders
 // (hopannotation2 and scamper1) so that pusher can start before any traceroute
 // has run successfully, preventing a race condition.
+// TODO: Remove this once traceroute-caller creates its own output folders
+// on startup.
 local setDataDirOwnership(name) = {
   local dataDir = data.mount(name).mountPath,
   initContainer: {


### PR DESCRIPTION
This PR applies the same fix we added in staging/production to make sure that the `hopannotation2` and `scamper1` folders exist when pusher starts. This prevents the situation where:
1. pusher cannot start due to these two folders missing
2. the pod never gets to the `Running`  state
3. Locate does not send any traffic to it
4. traceroute-caller never writes an output file due to no incoming traffic
5. these folders are never created
6. GOTO 1

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/886)
<!-- Reviewable:end -->
