### PR TITLE
Add access token arguments to packet-test deployment

### DIFF
--- a/k8s/daemonsets/experiments/packet-test.jsonnet
+++ b/k8s/daemonsets/experiments/packet-test.jsonnet
@@ -35,6 +35,9 @@ exp.Experiment(expName, 6, 'pusher-' + std.extVar('PROJECT_ID'), "none", [], dat
             args: [
               '-datadir=/var/spool/' + expName,
               '-hostname=$(NODE_NAME)',
+              '-token.machine=$(NODE_NAME)',
+              '-token.verify-key=/verify/jwk_sig_EdDSA_locate_20200409.pub',
+              '-token.verify=true',
             ],
             env: [
               {

--- a/k8s/daemonsets/experiments/packet-test.jsonnet
+++ b/k8s/daemonsets/experiments/packet-test.jsonnet
@@ -1,7 +1,9 @@
 local datatypes = ['pair1','train1','ndt7'];
 local exp = import '../templates.jsonnet';
 local expName = 'pt';
-local services = [];
+local services = [
+  'pt/ndt7==ws:///v0/ndt7/download',
+];
 
 exp.Experiment(expName, 6, 'pusher-' + std.extVar('PROJECT_ID'), "none", [], datatypes) + {
   spec+: {
@@ -35,6 +37,7 @@ exp.Experiment(expName, 6, 'pusher-' + std.extVar('PROJECT_ID'), "none", [], dat
             args: [
               '-datadir=/var/spool/' + expName,
               '-hostname=$(NODE_NAME)',
+              '-address=:80',
               '-token.machine=$(NODE_NAME)',
               '-token.verify-key=/verify/jwk_sig_EdDSA_locate_20200409.pub',
               '-token.verify=true',


### PR DESCRIPTION
This PR adds the proper arguments to the packet-test deployment to enable access tokens. Clients now need to query the Locate to request a valid URL https://locate-dot-mlab-sandbox.appspot.com/v2/nearest/pt/ndt7.