### PR TITLE
Add physical deployment of packet-test to staging/oti

### DIFF
--- a/k8s/daemonsets/experiments/packet-test.jsonnet
+++ b/k8s/daemonsets/experiments/packet-test.jsonnet
@@ -1,6 +1,7 @@
 local datatypes = ['pair1','train1','ndt7'];
 local exp = import '../templates.jsonnet';
 local expName = 'pt';
+local expVersion = 'v0.1.0'
 local services = [
   'pt/ndt7=ws:///v0/ndt7/download',
 ];
@@ -19,7 +20,7 @@ exp.Experiment(expName, 6, 'pusher-' + std.extVar('PROJECT_ID'), "none", [], dat
           {
             // Copy the JSON schema where jostler expects it to be.
             name: 'copy-schema',
-            image: 'measurementlab/packet-test:latest',
+            image: 'measurementlab/packet-test:' + expVersion,
             command: [
               '/bin/sh',
               '-c',
@@ -60,7 +61,7 @@ exp.Experiment(expName, 6, 'pusher-' + std.extVar('PROJECT_ID'), "none", [], dat
                 },
               },
             ],
-            image: 'measurementlab/packet-test:latest',
+            image: 'measurementlab/packet-test:' + expVersion,
             name: 'packet-test',
             command: [
               '/packet-test/server',

--- a/k8s/daemonsets/experiments/packet-test.jsonnet
+++ b/k8s/daemonsets/experiments/packet-test.jsonnet
@@ -1,7 +1,7 @@
 local datatypes = ['pair1','train1','ndt7'];
 local exp = import '../templates.jsonnet';
 local expName = 'pt';
-local expVersion = 'v0.1.0'
+local expVersion = 'v0.1.0';
 local services = [
   'pt/ndt7=ws:///v0/ndt7/download',
 ];

--- a/k8s/daemonsets/experiments/packet-test.jsonnet
+++ b/k8s/daemonsets/experiments/packet-test.jsonnet
@@ -1,7 +1,7 @@
 local datatypes = ['pair1','train1','ndt7'];
 local exp = import '../templates.jsonnet';
 local expName = 'pt';
-local expVersion = 'v0.1.0';
+local expVersion = 'v0.1.1';
 local services = [
   'pt/ndt7=ws:///v0/ndt7/download',
 ];

--- a/system.jsonnet
+++ b/system.jsonnet
@@ -21,6 +21,7 @@
     import 'k8s/daemonsets/experiments/ndt-canary.jsonnet',
     import 'k8s/daemonsets/experiments/neubot.jsonnet',
     import 'k8s/daemonsets/experiments/revtr.jsonnet',
+    import 'k8s/daemonsets/experiments/packet-test.jsonnet',
   ] + (
     if std.extVar('PROJECT_ID') == 'mlab-sandbox' then [
       // responsiveness commented out by Kinkade. It's stuck in sandbox and not
@@ -28,7 +29,6 @@
       // hostNetwork=true. If we want to resume the experiment we can just
       // uncomment the following line.
       //import 'k8s/daemonsets/experiments/responsiveness.jsonnet',
-      import 'k8s/daemonsets/experiments/packet-test.jsonnet',
       import 'k8s/daemonsets/experiments/packet-test-virtual.jsonnet',
     ] else []
   ) + [


### PR DESCRIPTION
This PR adds the physical deployment of the packet-test daemonset to the staging and oti projects, so it can be targeted from the measurement lab client. It updates the version to the last tagged version (rather than "latest").

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/895)
<!-- Reviewable:end -->
