### PR TITLE
Adds flag --label=loadbalanced to both NDT DaemonSets

### DIFF
--- a/k8s/daemonsets/experiments/ndt-virtual.jsonnet
+++ b/k8s/daemonsets/experiments/ndt-virtual.jsonnet
@@ -73,6 +73,7 @@ exp.ExperimentNoIndex(expName, 'pusher-' + std.extVar('PROJECT_ID'), 'none', dat
               '-label=network-tier=@' + exp.Metadata.path + '/network-tier',
               '-label=zone=@' + exp.Metadata.path + '/zone',
               '-label=managed=@' + exp.Metadata.path + '/managed',
+              '-label=loadbalanced=@' + exp.Metadata.path + '/loadbalanced',
             ],
             env: [
               {

--- a/k8s/daemonsets/experiments/ndt.jsonnet
+++ b/k8s/daemonsets/experiments/ndt.jsonnet
@@ -46,6 +46,7 @@ exp.Experiment(expName, 2, 'pusher-' + std.extVar('PROJECT_ID'), "none", datatyp
               '-label=type=physical',
               '-label=deployment=stable',
               '-label=managed=@' + exp.Metadata.path + '/managed',
+              '-label=loadbalanced=@' + exp.Metadata.path + '/loadbalanced',
             ],
             env: [
               {


### PR DESCRIPTION
This will add a new server metadata field to all NDT measurements that will make it possible to query NDT data for measurements that were made to MIGs (i.e., load balanced).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/896)
<!-- Reviewable:end -->
