### PR TITLE
Add packet-test deployment back to mlab-oti project

### DIFF
--- a/system.jsonnet
+++ b/system.jsonnet
@@ -21,6 +21,7 @@
     import 'k8s/daemonsets/experiments/ndt-canary.jsonnet',
     import 'k8s/daemonsets/experiments/neubot.jsonnet',
     import 'k8s/daemonsets/experiments/revtr.jsonnet',
+    import 'k8s/daemonsets/experiments/packet-test.jsonnet',
   ] + (
     if std.extVar('PROJECT_ID') == 'mlab-sandbox' then [
       // responsiveness commented out by Kinkade. It's stuck in sandbox and not
@@ -28,10 +29,7 @@
       // hostNetwork=true. If we want to resume the experiment we can just
       // uncomment the following line.
       //import 'k8s/daemonsets/experiments/responsiveness.jsonnet',
-      import 'k8s/daemonsets/experiments/packet-test.jsonnet',
       import 'k8s/daemonsets/experiments/packet-test-virtual.jsonnet',
-    ] else if std.extVar('PROJECT_ID') == 'mlab-staging' then [
-      import 'k8s/daemonsets/experiments/packet-test.jsonnet',
     ] else []
   ) + [
     import 'k8s/daemonsets/experiments/msak.jsonnet',


### PR DESCRIPTION
Following the policy implemented at the M-Lab staff call on August 15th, this PR adds the packet-test deployment back to mlab-oti.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/899)
<!-- Reviewable:end -->
