### PR TITLE
Removes the "processes" collector from node_exporter

### DIFF
--- a/k8s/daemonsets/core/node-exporter.jsonnet
+++ b/k8s/daemonsets/core/node-exporter.jsonnet
@@ -38,7 +38,6 @@ local exp = import '../templates.jsonnet';
               '--collector.loadavg',
               '--collector.meminfo',
               '--collector.netdev',
-              '--collector.processes',
               '--collector.stat',
               '--collector.textfile',
               '--collector.textfile.directory=/var/spool/node-exporter',


### PR DESCRIPTION
For a long time, logs on platform machines have been completely swamped/filled with AppArmor error messages related to node_exporter for containerd's default AppArmor profile, of the form:

```
audit: type=1400 audit(1724098386.963:188383): apparmor="DENIED" operation="ptrace" profile="cri-containerd.apparmor.d" pid=2159 comm="node_exporter" requested_mask="read" denied_mask="read" peer="unconfined
```
This makes it harder to debug on a machine when the logs are so full of useless messages. This commit removes the processes collector from node_exporter, which is only used by two dashboards and isn't really used.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/900)
<!-- Reviewable:end -->
