### PR TITLE
Make Prometheus in revtr-sidecar listen on a cluster-local address

### DIFF
--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -608,12 +608,12 @@ local UUIDAnnotator(expName, tcpPort, hostNetwork) = [
 local Revtr(expName, tcpPort) = [
   {
     name: 'revtr-sidecar',
-    image: 'measurementlab/revtr-sidecar:v1.4.1',
+    image: 'measurementlab/revtr-sidecar:v1.4.2',
     args: [
       '-tcpinfo.eventsocket=' + tcpinfoServiceVolume.socketFilename,
       '-revtr.hostname=revtr.ccs.neu.edu',
       '-revtr.grpcPort=9999',
-      '-prometheus.port='+tcpPort,
+      '-prometheus.addr=$(PRIVATE_IP):'+tcpPort,
       '-revtr.sampling=4', // 100/x == 25%
       '-revtr.APIKey=$(REVTR_APIKEY)',
       '-loglevel=debug',

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -613,7 +613,7 @@ local Revtr(expName, tcpPort) = [
       '-tcpinfo.eventsocket=' + tcpinfoServiceVolume.socketFilename,
       '-revtr.hostname=revtr.ccs.neu.edu',
       '-revtr.grpcPort=9999',
-      '-prometheus.port=$(PRIVATE_IP):'+tcpPort,
+      '-prometheus.port='+tcpPort,
       '-revtr.sampling=4', // 100/x == 25%
       '-revtr.APIKey=$(REVTR_APIKEY)',
       '-loglevel=debug',

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -613,12 +613,20 @@ local Revtr(expName, tcpPort) = [
       '-tcpinfo.eventsocket=' + tcpinfoServiceVolume.socketFilename,
       '-revtr.hostname=revtr.ccs.neu.edu',
       '-revtr.grpcPort=9999',
-      '-prometheus.port='+tcpPort,
+      '-prometheus.port=$(PRIVATE_IP):'+tcpPort,
       '-revtr.sampling=4', // 100/x == 25%
       '-revtr.APIKey=$(REVTR_APIKEY)',
       '-loglevel=debug',
     ],
     env: [
+      {
+        name: 'PRIVATE_IP',
+        valueFrom: {
+          fieldRef: {
+            fieldPath: 'status.podIP',
+          },
+        },
+      },
       {
         name: 'REVTR_APIKEY',
         valueFrom: {


### PR DESCRIPTION
Currently, Prometheus in revtr-sidecar listens on all interfaces. This PR causes it to listen only on the cluster-local pod address. It takes advantage of a new version of revtr-sidecar which enables this:

https://github.com/NEU-SNS/revtr-sidecar/pull/8

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/906)
<!-- Reviewable:end -->
