### PR TITLE
Add annotation2 to autoloaded datatypes

### DIFF
--- a/k8s/daemonsets/experiments/packet-test.jsonnet
+++ b/k8s/daemonsets/experiments/packet-test.jsonnet
@@ -45,6 +45,7 @@ exp.Experiment(expName, 6, 'pusher-' + std.extVar('PROJECT_ID'), "none", [], dat
               '-token.machine=$(NODE_NAME)',
               '-token.verify-key=/verify/jwk_sig_EdDSA_locate_20200409.pub',
               '-token.verify=true',
+              '-uuid-prefix-file=' + exp.uuid.prefixfile,
             ],
             env: [
               {

--- a/k8s/daemonsets/experiments/packet-test.jsonnet
+++ b/k8s/daemonsets/experiments/packet-test.jsonnet
@@ -1,4 +1,4 @@
-local datatypes = ['pair1','train1','ndt7'];
+local datatypes = ['pair1','train1','ndt7','annotation2'];
 local exp = import '../templates.jsonnet';
 local expName = 'pt';
 local expVersion = 'v0.1.2';

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -68,7 +68,7 @@ local uuidAnnotatorSchema = {
       "generate-schemas"
     ],
   },
-}
+};
 
 local data = {
   volume(name):: {

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -739,7 +739,7 @@ local Heartbeat(expName, tcpPort, hostNetwork, services) = [
 ;
 
 local ExperimentNoIndex(name, bucket, anonMode, datatypesArchived, datatypesAutoloaded, hostNetwork, siteType='physical') = {
-  local autoAnnotations = [x for x in datatypesAutoloaded == 'annotation2'],
+  local autoAnnotations = [x for x in datatypesAutoloaded if x == 'annotation2'],
   local allDatatypes =  ['tcpinfo', 'pcap', 'scamper1', 'hopannotation2'] + datatypesArchived + if std.length(autoAnnotations) == 0 then ["annotation2"] else [],
   local allVolumes = datatypesArchived + datatypesAutoloaded,
   apiVersion: 'apps/v1',

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -60,6 +60,16 @@ local uuid = {
   },
 };
 
+local uuidAnnotatorSchema = {
+  initContainer: {
+    name: 'uuid-annotator-schema',
+    image: 'measurementlab/uuid-annotator:v0.5.5',
+    command: [
+      "generate-schemas"
+    ],
+  },
+}
+
 local data = {
   volume(name):: {
     hostPath: {
@@ -591,7 +601,6 @@ local UUIDAnnotator(expName, tcpPort, hostNetwork) = [
     },
     volumeMounts: [
       data.mount(expName),
-      datatypes.mount('annotation2'),
       tcpinfoServiceVolume.volumemount,
       uuidannotatorServiceVolume.volumemount,
       {
@@ -779,6 +788,7 @@ local ExperimentNoIndex(name, bucket, anonMode, datatypesArchived, datatypesAuto
         [if hostNetwork then 'serviceAccountName']: 'kube-rbac-proxy',
         initContainers: [
           uuid.initContainer,
+          uuidAnnotatorSchema.initContainer,
           setDataDirOwnership(name).initContainer,
           setDatatypesDirOwnership(name).initContainer,
         ],

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -739,7 +739,7 @@ local Heartbeat(expName, tcpPort, hostNetwork, services) = [
 ;
 
 local ExperimentNoIndex(name, bucket, anonMode, datatypesArchived, datatypesAutoloaded, hostNetwork, siteType='physical') = {
-  local autoAnnotations = [x for x in datatypesAutoloaded == 'annotation2']
+  local autoAnnotations = [x for x in datatypesAutoloaded == 'annotation2'],
   local allDatatypes =  ['tcpinfo', 'pcap', 'scamper1', 'hopannotation2'] + datatypesArchived + if std.length(autoAnnotations) == 0 then ["annotation2"] else [],
   local allVolumes = datatypesArchived + datatypesAutoloaded,
   apiVersion: 'apps/v1',

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -67,6 +67,9 @@ local uuidAnnotatorSchema = {
     command: [
       "/generate-schemas"
     ],
+    volumeMounts: [
+      exp.VolumeMountDatatypes('annotation2'),
+    ],
   },
 };
 

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -60,19 +60,6 @@ local uuid = {
   },
 };
 
-local uuidAnnotatorSchema = {
-  initContainer: {
-    name: 'uuid-annotator-schema',
-    image: 'measurementlab/uuid-annotator:v0.5.5',
-    command: [
-      "/generate-schemas"
-    ],
-    volumeMounts: [
-      datatypes.mount('annotation2'),
-    ],
-  },
-};
-
 local data = {
   volume(name):: {
     hostPath: {
@@ -98,6 +85,19 @@ local datatypes = {
   mount(name):: {
     mountPath: '/var/spool/datatypes',
     name: std.asciiLower(std.strReplace(name, '/', '-')) + '-datatypes',
+  },
+};
+
+local uuidAnnotatorSchema = {
+  initContainer: {
+    name: 'uuid-annotator-schema',
+    image: 'measurementlab/uuid-annotator:v0.5.5',
+    command: [
+      "/generate-schemas"
+    ],
+    volumeMounts: [
+      datatypes.mount('annotation2'),
+    ],
   },
 };
 

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -591,6 +591,7 @@ local UUIDAnnotator(expName, tcpPort, hostNetwork) = [
     },
     volumeMounts: [
       data.mount(expName),
+      datatypes.mount(expName),
       tcpinfoServiceVolume.volumemount,
       uuidannotatorServiceVolume.volumemount,
       {

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -739,7 +739,8 @@ local Heartbeat(expName, tcpPort, hostNetwork, services) = [
 ;
 
 local ExperimentNoIndex(name, bucket, anonMode, datatypesArchived, datatypesAutoloaded, hostNetwork, siteType='physical') = {
-  local allDatatypes =  ['tcpinfo', 'pcap', 'scamper1', 'hopannotation2'] + datatypesArchived + if 'annotation2' !in datatypesAutoloaded then + ["annotation2"],
+  local autoAnnotations = [x for x in datatypesAutoloaded == 'annotation2']
+  local allDatatypes =  ['tcpinfo', 'pcap', 'scamper1', 'hopannotation2'] + datatypesArchived + if std.length(autoAnnotations) == 0 then ["annotation2"] else [],
   local allVolumes = datatypesArchived + datatypesAutoloaded,
   apiVersion: 'apps/v1',
   kind: 'DaemonSet',

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -739,8 +739,7 @@ local Heartbeat(expName, tcpPort, hostNetwork, services) = [
 ;
 
 local ExperimentNoIndex(name, bucket, anonMode, datatypesArchived, datatypesAutoloaded, hostNetwork, siteType='physical') = {
-  local allDatatypes =  ['tcpinfo', 'pcap', 'scamper1', 'hopannotation2'] + datatypesArchived,
-  if 'annotation2' !in datatypesAutoloaded then allDatatypes + ["annotation2"],
+  local allDatatypes =  ['tcpinfo', 'pcap', 'scamper1', 'hopannotation2'] + datatypesArchived + if 'annotation2' !in datatypesAutoloaded then + ["annotation2"],
   local allVolumes = datatypesArchived + datatypesAutoloaded,
   apiVersion: 'apps/v1',
   kind: 'DaemonSet',

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -757,7 +757,7 @@ local Heartbeat(expName, tcpPort, hostNetwork, services) = [
 ;
 
 local ExperimentNoIndex(name, bucket, anonMode, datatypesArchived, datatypesAutoloaded, hostNetwork, siteType='physical') = {
-  local autoAnnotations = contains(datatypesAutoloaded, "annotation2"),
+  local autoAnnotations = contains("annotation2", datatypesAutoloaded),
   local datatypesPushed =  ['tcpinfo', 'pcap', 'scamper1', 'hopannotation2'] + datatypesArchived + if autoAnnotations then ["annotation2"] else [],
   local allVolumes = datatypesArchived + datatypesAutoloaded,
   apiVersion: 'apps/v1',

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -68,7 +68,7 @@ local uuidAnnotatorSchema = {
       "/generate-schemas"
     ],
     volumeMounts: [
-      exp.VolumeMountDatatypes('annotation2'),
+      datatypes.mount('annotation2'),
     ],
   },
 };

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -591,7 +591,7 @@ local UUIDAnnotator(expName, tcpPort, hostNetwork) = [
     },
     volumeMounts: [
       data.mount(expName),
-      datatypes.mount(expName),
+      datatypes.mount('annotation2'),
       tcpinfoServiceVolume.volumemount,
       uuidannotatorServiceVolume.volumemount,
       {

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -739,7 +739,8 @@ local Heartbeat(expName, tcpPort, hostNetwork, services) = [
 ;
 
 local ExperimentNoIndex(name, bucket, anonMode, datatypesArchived, datatypesAutoloaded, hostNetwork, siteType='physical') = {
-  local allDatatypes =  ['tcpinfo', 'pcap', 'annotation2', 'scamper1', 'hopannotation2'] + datatypesArchived,
+  local allDatatypes =  ['tcpinfo', 'pcap', 'scamper1', 'hopannotation2'] + datatypesArchived,
+  if 'annotation2' !in datatypesAutoloaded then allDatatypes + ["annotation2"],
   local allVolumes = datatypesArchived + datatypesAutoloaded,
   apiVersion: 'apps/v1',
   kind: 'DaemonSet',

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -88,7 +88,7 @@ local datatypes = {
   },
 };
 
-local uuidAnnotatorSchema = {
+local uuidAnnotatorSchema(name) = {
   initContainer: {
     name: 'uuid-annotator-schema',
     image: 'measurementlab/uuid-annotator:v0.5.5',
@@ -96,7 +96,7 @@ local uuidAnnotatorSchema = {
       "/generate-schemas"
     ],
     volumeMounts: [
-      datatypes.mount('annotation2'),
+      datatypes.mount(name),
     ],
   },
 };
@@ -791,7 +791,7 @@ local ExperimentNoIndex(name, bucket, anonMode, datatypesArchived, datatypesAuto
         [if hostNetwork then 'serviceAccountName']: 'kube-rbac-proxy',
         initContainers: [
           uuid.initContainer,
-          uuidAnnotatorSchema.initContainer,
+          uuidAnnotatorSchema(name).initContainer,
           setDataDirOwnership(name).initContainer,
           setDatatypesDirOwnership(name).initContainer,
         ],

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -65,7 +65,7 @@ local uuidAnnotatorSchema = {
     name: 'uuid-annotator-schema',
     image: 'measurementlab/uuid-annotator:v0.5.5',
     command: [
-      "generate-schemas"
+      "/generate-schemas"
     ],
   },
 };


### PR DESCRIPTION
This PR adds an option to autoload "annotation2" data. If the "annotation2" datatype is in the `datatypesAutoloaded` array (jostler), it is skipped from the `allDatatypes` array (pusher).

The `annotation2` data for packet-test is being autoloaded under [`mlab-sandbox.raw_pt.annotation2`](https://pantheon.corp.google.com/bigquery/projects/mlab-sandbox/datasets/raw_pt/tables/annotation2?referrer=search&project=mlab-sandbox&ws=!1m5!1m4!4m3!1smlab-sandbox!2sraw_pt!3sannotation2).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/908)
<!-- Reviewable:end -->
