### PR TITLE
Fix order of annotation2 autoloading check

### DIFF
--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -758,7 +758,7 @@ local Heartbeat(expName, tcpPort, hostNetwork, services) = [
 
 local ExperimentNoIndex(name, bucket, anonMode, datatypesArchived, datatypesAutoloaded, hostNetwork, siteType='physical') = {
   local autoAnnotations = contains("annotation2", datatypesAutoloaded),
-  local datatypesPushed =  ['tcpinfo', 'pcap', 'scamper1', 'hopannotation2'] + datatypesArchived + if autoAnnotations then ["annotation2"] else [],
+  local datatypesPushed =  ['tcpinfo', 'pcap', 'scamper1', 'hopannotation2'] + datatypesArchived + if autoAnnotations then [] else ["annotation2"],
   local allVolumes = datatypesArchived + datatypesAutoloaded,
   apiVersion: 'apps/v1',
   kind: 'DaemonSet',


### PR DESCRIPTION
This PR fixes the order of the `annotation2` check for autoloading. If not autoloaded, it should be added to the pusher datatypes!

Apologies for missing this–just caught it when double-checking in staging.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/909)
<!-- Reviewable:end -->
