### PR TITLE
Pins multi-networkpolicy-iptables DaemonSet to sandbox and staging

### DIFF
--- a/system.jsonnet
+++ b/system.jsonnet
@@ -16,7 +16,6 @@
     import 'k8s/daemonsets/core/disco.jsonnet',
     import 'k8s/daemonsets/core/flannel.jsonnet',
     import 'k8s/daemonsets/core/host.jsonnet',
-    import 'k8s/daemonsets/core/multi-networkpolicy.jsonnet',
     import 'k8s/daemonsets/core/node-exporter.jsonnet',
   ] + std.flattenArrays([
     import 'k8s/daemonsets/experiments/msak.jsonnet',
@@ -41,6 +40,9 @@
       // A internal Google service we are experimenting with only in sandbox
       // and staging.
       import 'k8s/daemonsets/core/flooefi.jsonnet',
+      // Keep this back from production until we can do more extensive testing
+      // in staging.
+      import 'k8s/daemonsets/core/multi-networkpolicy.jsonnet',
     ] else []
   ) + [
     // Deployments


### PR DESCRIPTION
We need to test this configuration more in staging, and we don't want this to block releasing k8s-support for other things in the meantime.

The MultiNetworkPolicy CRD definition will still be deployed to production, along with the MultiNetworkPolicy instances for each experiment, as well as the rbac configs for the DaemonSet. This just holds back the DaemonSet. It should be perfectly find and safe for everything else to go to production. It will exist in the production cluster, but will be unused until the DaemonSet is there act on it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/912)
<!-- Reviewable:end -->
