### PR TITLE
Allow multi-networkpolicy to deploy to mlab-oti with canary nodeSelector

### DIFF
--- a/k8s/daemonsets/core/multi-networkpolicy.jsonnet
+++ b/k8s/daemonsets/core/multi-networkpolicy.jsonnet
@@ -41,7 +41,7 @@
         containers: [
           {
             name: 'multi-networkpolicy',
-            image: 'measurementlab/multi-networkpolicy-iptables:latest',
+            image: 'measurementlab/multi-networkpolicy-iptables:v1.0.0',
             imagePullPolicy: 'Always',
             command: [
               '/usr/bin/multi-networkpolicy-iptables',

--- a/k8s/daemonsets/core/multi-networkpolicy.jsonnet
+++ b/k8s/daemonsets/core/multi-networkpolicy.jsonnet
@@ -6,14 +6,13 @@
     namespace: 'kube-system',
     labels: {
       tier: 'node',
-      app: 'multi-networkpolicy',
       name: 'multi-networkpolicy',
     },
   },
   spec: {
     selector: {
       matchLabels: {
-        name: 'multi-networkpolicy',
+        workload: 'multi-networkpolicy',
       },
     },
     updateStrategy: {
@@ -23,8 +22,7 @@
       metadata: {
         labels: {
           tier: 'node',
-          app: 'multi-networkpolicy',
-          name: 'multi-networkpolicy',
+          workload: 'multi-networkpolicy'
         },
       },
       spec: {
@@ -66,11 +64,11 @@
             resources: {
               requests: {
                 cpu: '100m',
-                memory: '80Mi',
+                memory: '150Mi',
               },
               limits: {
                 cpu: '100m',
-                memory: '150Mi',
+                memory: '250Mi',
               },
             },
             securityContext: {

--- a/k8s/daemonsets/core/multi-networkpolicy.jsonnet
+++ b/k8s/daemonsets/core/multi-networkpolicy.jsonnet
@@ -29,6 +29,7 @@
         hostNetwork: true,
         nodeSelector: {
           'kubernetes.io/arch': 'amd64',
+          [if std.extVar('PROJECT_ID') == 'mlab-oti' then 'mlab/run']: 'multi-networkpolicy-canary',
         },
         tolerations: [
           {
@@ -68,7 +69,7 @@
               },
               limits: {
                 cpu: '100m',
-                memory: '250Mi',
+                memory: '500Mi',
               },
             },
             securityContext: {

--- a/system.jsonnet
+++ b/system.jsonnet
@@ -17,6 +17,7 @@
     import 'k8s/daemonsets/core/flannel.jsonnet',
     import 'k8s/daemonsets/core/host.jsonnet',
     import 'k8s/daemonsets/core/node-exporter.jsonnet',
+    import 'k8s/daemonsets/core/multi-networkpolicy.jsonnet',
   ] + std.flattenArrays([
     import 'k8s/daemonsets/experiments/msak.jsonnet',
     import 'k8s/daemonsets/experiments/ndt.jsonnet',
@@ -40,9 +41,6 @@
       // A internal Google service we are experimenting with only in sandbox
       // and staging.
       import 'k8s/daemonsets/core/flooefi.jsonnet',
-      // Keep this back from production until we can do more extensive testing
-      // in staging.
-      import 'k8s/daemonsets/core/multi-networkpolicy.jsonnet',
     ] else []
   ) + [
     // Deployments


### PR DESCRIPTION
The primary intent of this PR is to allow the multi-networkpolicy DaemonSet to deploy to production, but only to nodes with the special label `mlab/run: multi-networkpolicy-canary`. The plan is to manually label a subset of nodes, perhaps 10 in various metros, to be sure that it works as intended and does not for any reason impact performance.

Additionally, the PR modifies modifies the memory limits for the container. I discovered that for some reason the containers in sandbox only use around 30MB of memory, but in staging they use around 120MB, sometimes spiking higher and causing the container to be killed for going over the old memory limit of 150Mi.

I also made some small modifications to the pod labels to be more in line with how we label other pods.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/913)
<!-- Reviewable:end -->
