### PR TITLE
Change -flowtimeout to 5s

### DIFF
--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -361,6 +361,7 @@ local Pcap(expName, tcpPort, hostNetwork, siteType, anonMode) = [
       '-anonymize.ip=' + anonMode,
       '-maxidleram=1500MB',
       '-maxheap=2GB',
+      '-flowtimeout=5s',
     ] + if expName == 'host' then [
       // The "host" experiment is currently the only experiment where
       // packet-headers needs to listen explictly on interface eth0.


### PR DESCRIPTION
This changes the value of `-flowtimeout` from the default (30s) to 5s. As a result, a flow will be considered stopped, and its corresponding goroutine will be terminated and garbage-collected after 5 seconds of no new packets being observed.

See https://github.com/m-lab/dev-tracker/issues/800

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/915)
<!-- Reviewable:end -->
