### PR TITLE
Update packet-headers to v0.7.6 and add -maxflows

### DIFF
--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -349,7 +349,7 @@ local Traceroute(expName, tcpPort, hostNetwork, anonMode) = [
 local Pcap(expName, tcpPort, hostNetwork, siteType, anonMode) = [
   {
     name: 'packet-headers',
-    image: 'measurementlab/packet-headers:v0.7.5',
+    image: 'measurementlab/packet-headers:v0.7.6',
     args: [
       if hostNetwork then
         '-prometheusx.listen-address=127.0.0.1:' + tcpPort
@@ -362,6 +362,7 @@ local Pcap(expName, tcpPort, hostNetwork, siteType, anonMode) = [
       '-maxidleram=1500MB',
       '-maxheap=2GB',
       '-flowtimeout=5s',
+      '-maxflows=150',
     ] + if expName == 'host' then [
       // The "host" experiment is currently the only experiment where
       // packet-headers needs to listen explictly on interface eth0.


### PR DESCRIPTION
Updates packet-headers to v0.7.6, which includes a `-maxflows` flag. See https://github.com/m-lab/packet-headers/pull/58.

The limit of 150 is pretty conservative, since the machines with the most traffic on the platform seem to have 50-60 "current" flows at most at any given time. See for example [DEL02](https://grafana.mlab-sandbox.measurementlab.net/d/de36ddo095tz4c/k8s3a-site-overview-packet-headers-filter?orgId=1&var-datasource=WW1Jk2sGk&var-gkedatasource=OSuRJ_YMz&var-type=physical&var-type=virtual&var-site=del02&var-node=All&var-pod=ndt&from=now-7d&to=now)