### PR TITLE
Remove annotation2 from packet-test autoloaded datatypes

### DIFF
--- a/k8s/daemonsets/experiments/packet-test.jsonnet
+++ b/k8s/daemonsets/experiments/packet-test.jsonnet
@@ -1,4 +1,4 @@
-local datatypes = ['pair1','train1','ndt7','annotation2'];
+local datatypes = ['pair1','train1','ndt7'];
 local exp = import '../templates.jsonnet';
 local expName = 'pt';
 local expVersion = 'v0.1.3';


### PR DESCRIPTION
Some pods are failing to read the schema file. Stop `annotation2` autoloading for packet-test while this is fixed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/917)
<!-- Reviewable:end -->
