### PR TITLE
Deploys MultiNetworkPolicy DaemonSet to all production machines

### DIFF
--- a/k8s/daemonsets/core/multi-networkpolicy.jsonnet
+++ b/k8s/daemonsets/core/multi-networkpolicy.jsonnet
@@ -29,7 +29,6 @@
         hostNetwork: true,
         nodeSelector: {
           'kubernetes.io/arch': 'amd64',
-          [if std.extVar('PROJECT_ID') == 'mlab-oti' then 'mlab/run']: 'multi-networkpolicy-canary',
         },
         tolerations: [
           {


### PR DESCRIPTION
The canary was determined to be a success by myself, @stephen-soltesz  and @mattmathis.

https://github.com/m-lab/ops-tracker/issues/2025

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/918)
<!-- Reviewable:end -->
