### PR TITLE
Add support for autojoined VMs

### DIFF
--- a/k8s/certificates/measurement-lab.org.jsonnet
+++ b/k8s/certificates/measurement-lab.org.jsonnet
@@ -10,6 +10,7 @@
       '*.measurement-lab.org',
     ] else []) + [
       '*.' + std.extVar('PROJECT_ID') + '.measurement-lab.org',
+      '*.mlab.' + std.split(std.extVar('PROJECT_ID'), '-')[1] + '.measurement-lab.org',
     ],
     issuerRef: {
       group: 'cert-manager.io',

--- a/k8s/certificates/measurement-lab.org.jsonnet
+++ b/k8s/certificates/measurement-lab.org.jsonnet
@@ -8,6 +8,7 @@
   spec: {
     dnsNames: (if std.extVar('PROJECT_ID') == 'mlab-oti' then [
       '*.measurement-lab.org',
+      '*.mlab.autojoin.measurement-lab.org',
     ] else []) + [
       '*.' + std.extVar('PROJECT_ID') + '.measurement-lab.org',
       '*.mlab.' + std.split(std.extVar('PROJECT_ID'), '-')[1] + '.measurement-lab.org',

--- a/k8s/clusterissuers/letsencrypt-staging.jsonnet
+++ b/k8s/clusterissuers/letsencrypt-staging.jsonnet
@@ -46,6 +46,7 @@
               '*.measurement-lab.org',
             ] else []) + [
               '*.' + std.extVar('PROJECT_ID') + '.measurement-lab.org',
+              '*.mlab.' + std.split('PROJECT_ID')[1] + '.measurement-lab.org',
             ],
           },
         },

--- a/k8s/clusterissuers/letsencrypt-staging.jsonnet
+++ b/k8s/clusterissuers/letsencrypt-staging.jsonnet
@@ -44,6 +44,7 @@
           selector: {
             dnsNames: (if std.extVar('PROJECT_ID') == 'mlab-oti' then [
               '*.measurement-lab.org',
+              '*.mlab.autojoin.measurement-lab.org',
             ] else []) + [
               '*.' + std.extVar('PROJECT_ID') + '.measurement-lab.org',
               '*.mlab.' + std.split(std.extVar('PROJECT_ID'), '-')[1] + '.measurement-lab.org',

--- a/k8s/clusterissuers/letsencrypt-staging.jsonnet
+++ b/k8s/clusterissuers/letsencrypt-staging.jsonnet
@@ -46,7 +46,7 @@
               '*.measurement-lab.org',
             ] else []) + [
               '*.' + std.extVar('PROJECT_ID') + '.measurement-lab.org',
-              '*.mlab.' + std.split('PROJECT_ID')[1] + '.measurement-lab.org',
+              '*.mlab.' + std.split(std.extVar('PROJECT_ID'), '-')[1] + '.measurement-lab.org',
             ],
           },
         },

--- a/k8s/clusterissuers/letsencrypt.jsonnet
+++ b/k8s/clusterissuers/letsencrypt.jsonnet
@@ -41,6 +41,7 @@
               '*.measurement-lab.org',
             ] else []) + [
               '*.' + std.extVar('PROJECT_ID') + '.measurement-lab.org',
+              '*.mlab.' + std.split('PROJECT_ID')[1] + '.measurement-lab.org',
             ],
           },
         },

--- a/k8s/clusterissuers/letsencrypt.jsonnet
+++ b/k8s/clusterissuers/letsencrypt.jsonnet
@@ -39,6 +39,7 @@
           selector: {
             dnsNames: (if std.extVar('PROJECT_ID') == 'mlab-oti' then [
               '*.measurement-lab.org',
+              '*.mlab.autojoin.measurement-lab.org',
             ] else []) + [
               '*.' + std.extVar('PROJECT_ID') + '.measurement-lab.org',
               '*.mlab.' + std.split(std.extVar('PROJECT_ID'), '-')[1] + '.measurement-lab.org',

--- a/k8s/clusterissuers/letsencrypt.jsonnet
+++ b/k8s/clusterissuers/letsencrypt.jsonnet
@@ -41,7 +41,7 @@
               '*.measurement-lab.org',
             ] else []) + [
               '*.' + std.extVar('PROJECT_ID') + '.measurement-lab.org',
-              '*.mlab.' + std.split('PROJECT_ID')[1] + '.measurement-lab.org',
+              '*.mlab.' + std.split(std.extVar('PROJECT_ID'), '-')[1] + '.measurement-lab.org',
             ],
           },
         },

--- a/k8s/daemonsets/experiments/msak.jsonnet
+++ b/k8s/daemonsets/experiments/msak.jsonnet
@@ -103,7 +103,7 @@ local ports = ['80/TCP', '443/TCP', '1053/UDP'];
               ],
             },
           ] + std.flattenArrays([
-            exp.Heartbeat(expName, false, services),
+            exp.Heartbeat(expName, false, services, false),
           ]),
           volumes+: [
             {
@@ -126,4 +126,3 @@ local ports = ['80/TCP', '443/TCP', '1053/UDP'];
   },
   exp.MultiNetworkPolicy(expName, 1, ports),
 ]
-

--- a/k8s/daemonsets/experiments/ndt-virtual-autojoin.jsonnet
+++ b/k8s/daemonsets/experiments/ndt-virtual-autojoin.jsonnet
@@ -37,7 +37,7 @@ exp.ExperimentNoIndex(expName, 'pusher-' + std.extVar('PROJECT_ID'), 'none', dat
         containers+: [
           {
             name: 'register-node',
-            image: 'measurementlab/autojoin-register:v0.2.6',
+            image: 'measurementlab/autojoin-register:v0.2.8',
             imagePullPolicy: 'Always',
             command: [
               '/bin/sh',

--- a/k8s/daemonsets/experiments/ndt-virtual-autojoin.jsonnet
+++ b/k8s/daemonsets/experiments/ndt-virtual-autojoin.jsonnet
@@ -96,7 +96,7 @@ exp.ExperimentNoIndex(expName, 'pusher-' + std.extVar('PROJECT_ID'), 'none', dat
               '-key=/certs/tls.key',
               '-cert=/certs/tls.crt',
               '-token.verify-key=/verify/jwk_sig_EdDSA_locate_20200409.pub',
-              '-token.machine=@/autonode/hostname',
+              '-token.machine=@/autolol/hostname',
               '-txcontroller.device=ens4',
               // GCE VMs have an egress rate limit of 7Gbps to Internet
               // addresses. Setting max-rate to 4Gbps should leave headroom for

--- a/k8s/daemonsets/experiments/ndt-virtual-autojoin.jsonnet
+++ b/k8s/daemonsets/experiments/ndt-virtual-autojoin.jsonnet
@@ -1,0 +1,187 @@
+local datatypes = ['ndt5', 'ndt7'];
+local exp = import '../templates.jsonnet';
+local expName = 'ndt';
+local services = [
+  'ndt/ndt7=ws:///ndt/v7/download,ws:///ndt/v7/upload,wss:///ndt/v7/download,wss:///ndt/v7/upload',
+  'ndt/ndt5=ws://:3001/ndt_protocol,wss://:3010/ndt_protocol',
+];
+
+exp.ExperimentNoIndex(expName, 'pusher-' + std.extVar('PROJECT_ID'), 'none', datatypes, [], true, 'virtual', true) + {
+  metadata+: {
+    name: expName + '-virtual-autojoin',
+  },
+  spec+: {
+    selector+: {
+      matchLabels+: {
+        workload: expName + '-virtual-autojoin',
+      },
+    },
+    template+: {
+      metadata+: {
+        annotations+: {
+          'secret.reloader.stakater.com/reload': 'measurement-lab-org-tls',
+        },
+        labels+: {
+          workload: expName + '-virtual-autojoin',
+          'site-type': 'virtual',
+          'mlab/project': std.extVar('PROJECT_ID'),
+        },
+      },
+      spec+: {
+        hostNetwork: true,
+        nodeSelector: {
+          'mlab/type': 'virtual',
+          'mlab/run': expName + '-autojoin',
+        },
+        serviceAccountName: 'heartbeat-experiment',
+        containers+: [
+          {
+            name: 'register-node',
+            image: 'measurementlab/autojoin-register:v0.2.6',
+            imagePullPolicy: 'always',
+            command: [
+              '/bin/sh',
+              '-c',
+              '/register -ipv4=$(cat /metadata/external-ip) -ipv6=$(cat /metadata/external-ipv6) -iata=$(cat /metadata/iata-code) $@',
+              '--',
+            ],
+            args: [
+              '-endpoint=https://autojoin-dot-$(PROJECT).appspot.com/autojoin/v0/node/register',
+              '-key=$(AUTOJOIN_API_KEY)',
+              '-service=ndt',
+              '-organization=mlab',
+              '-output=/autonode',
+              '-ports=9990,9991,9992,9993',
+              '-probability=1.0',
+            ],
+            env: [
+              {
+                name: 'PROJECT',
+                valueFrom: {
+                  fieldRef: {
+                    fieldPath: 'metadata.labels["mlab/project"]',
+                  },
+                },
+              },
+              {
+                name: 'AUTOJOIN_API_KEY',
+                valueFrom: {
+                  secretKeyRef: {
+                    key: 'key',
+                    name: 'autojoin-api-key',
+                  },
+                },
+              },
+            ],
+            volumeMounts: [
+              {
+                mountPath: '/autojoin',
+                name: 'autojoin',
+              },
+              exp.Metadata.volumemount,
+            ],
+          },
+          {
+            name: 'ndt-server',
+            image: 'measurementlab/ndt-server:' + exp.ndtVersion,
+            args: [
+              '-ndt5_addr=127.0.0.1:3002', // any non-public port.
+              '-ndt5_ws_addr=:3001', // default, public ndt5 port.
+              '-ndt5.token.required=true',
+              '-ndt7.token.required=true',
+              '-htmldir=html/mlab',
+              '-uuid-prefix-file=' + exp.uuid.prefixfile,
+              '-prometheusx.listen-address=127.0.0.1:9990',
+              '-datadir=/var/spool/' + expName,
+              '-key=/certs/tls.key',
+              '-cert=/certs/tls.crt',
+              '-token.verify-key=/verify/jwk_sig_EdDSA_locate_20200409.pub',
+              '-token.machine=@/autonode/hostname',
+              '-txcontroller.device=ens4',
+              // GCE VMs have an egress rate limit of 7Gbps to Internet
+              // addresses. Setting max-rate to 4Gbps should leave headroom for
+              // very fast clients.
+              '-txcontroller.max-rate=4000000000',
+              '-label=type=virtual',
+              '-label=deployment=stable',
+              '-label=external-ip=@' + exp.Metadata.path + '/external-ip',
+              '-label=external-ipv6=@' + exp.Metadata.path + '/external-ipv6',
+              '-label=machine-type=@' + exp.Metadata.path + '/machine-type',
+              '-label=network-tier=@' + exp.Metadata.path + '/network-tier',
+              '-label=zone=@' + exp.Metadata.path + '/zone',
+              '-label=managed=@' + exp.Metadata.path + '/managed',
+              '-label=loadbalanced=@' + exp.Metadata.path + '/loadbalanced',
+            ],
+            env: [
+              {
+                name: 'NODE_NAME',
+                valueFrom: {
+                  fieldRef: {
+                    fieldPath: 'spec.nodeName',
+                  },
+                },
+              },
+            ],
+            securityContext: {
+              capabilities: {
+                add: [
+                  'NET_BIND_SERVICE',
+                ],
+                drop: [
+                  'all',
+                ],
+              },
+              runAsUser: 0,
+            },
+            volumeMounts: [
+              {
+                mountPath: '/certs',
+                name: 'measurement-lab-org-tls',
+                readOnly: true,
+              },
+              {
+                mountPath: '/verify',
+                name: 'locate-verify-keys',
+                readOnly: true,
+              },
+              {
+                mountPath: '/autonode',
+                name: 'autonode',
+                readOnly: true,
+              },
+              exp.uuid.volumemount,
+              exp.Metadata.volumemount,
+            ] + [
+              exp.VolumeMount(expName + '/' + d)
+              for d in datatypes
+            ],
+            ports: [],
+          },
+          exp.RBACProxy(expName, 9990),
+        ] + std.flattenArrays([
+          exp.Heartbeat(expName, true, services, true),
+        ]),
+        [if std.extVar('PROJECT_ID') != 'mlab-sandbox' then 'terminationGracePeriodSeconds']: exp.terminationGracePeriodSeconds,
+        volumes+: [
+          {
+            name: 'measurement-lab-org-tls',
+            secret: {
+              secretName: 'measurement-lab-org-tls',
+            },
+          },
+          {
+            name: 'locate-verify-keys',
+            secret: {
+              secretName: 'locate-verify-keys',
+            },
+          },
+          {
+            emptyDir: {},
+            name: 'autonode',
+          },
+          exp.Metadata.volume,
+        ],
+      },
+    },
+  },
+}

--- a/k8s/daemonsets/experiments/ndt-virtual-autojoin.jsonnet
+++ b/k8s/daemonsets/experiments/ndt-virtual-autojoin.jsonnet
@@ -38,7 +38,7 @@ exp.ExperimentNoIndex(expName, 'pusher-' + std.extVar('PROJECT_ID'), 'none', dat
           {
             name: 'register-node',
             image: 'measurementlab/autojoin-register:v0.2.6',
-            imagePullPolicy: 'always',
+            imagePullPolicy: 'Always',
             command: [
               '/bin/sh',
               '-c',
@@ -59,7 +59,7 @@ exp.ExperimentNoIndex(expName, 'pusher-' + std.extVar('PROJECT_ID'), 'none', dat
                 name: 'PROJECT',
                 valueFrom: {
                   fieldRef: {
-                    fieldPath: 'metadata.labels["mlab/project"]',
+                    fieldPath: 'metadata.labels[mlab/project]',
                   },
                 },
               },
@@ -174,10 +174,6 @@ exp.ExperimentNoIndex(expName, 'pusher-' + std.extVar('PROJECT_ID'), 'none', dat
             secret: {
               secretName: 'locate-verify-keys',
             },
-          },
-          {
-            emptyDir: {},
-            name: 'autonode',
           },
           exp.Metadata.volume,
         ],

--- a/k8s/daemonsets/experiments/ndt-virtual-autojoin.jsonnet
+++ b/k8s/daemonsets/experiments/ndt-virtual-autojoin.jsonnet
@@ -75,8 +75,8 @@ exp.ExperimentNoIndex(expName, 'pusher-' + std.extVar('PROJECT_ID'), 'none', dat
             ],
             volumeMounts: [
               {
-                mountPath: '/autojoin',
-                name: 'autojoin',
+                mountPath: '/autonode',
+                name: 'autonode',
               },
               exp.Metadata.volumemount,
             ],

--- a/k8s/daemonsets/experiments/ndt-virtual-autojoin.jsonnet
+++ b/k8s/daemonsets/experiments/ndt-virtual-autojoin.jsonnet
@@ -96,7 +96,7 @@ exp.ExperimentNoIndex(expName, 'pusher-' + std.extVar('PROJECT_ID'), 'none', dat
               '-key=/certs/tls.key',
               '-cert=/certs/tls.crt',
               '-token.verify-key=/verify/jwk_sig_EdDSA_locate_20200409.pub',
-              '-token.machine=@/autolol/hostname',
+              '-token.machine=@/autonode/hostname',
               '-txcontroller.device=ens4',
               // GCE VMs have an egress rate limit of 7Gbps to Internet
               // addresses. Setting max-rate to 4Gbps should leave headroom for

--- a/k8s/daemonsets/experiments/ndt-virtual-autojoin.jsonnet
+++ b/k8s/daemonsets/experiments/ndt-virtual-autojoin.jsonnet
@@ -67,7 +67,7 @@ exp.ExperimentNoIndex(expName, 'pusher-' + std.extVar('PROJECT_ID'), 'none', dat
                 name: 'AUTOJOIN_API_KEY',
                 valueFrom: {
                   secretKeyRef: {
-                    key: 'key',
+                    key: 'autojoin-api-key',
                     name: 'autojoin-api-key',
                   },
                 },

--- a/k8s/daemonsets/experiments/ndt-virtual-autojoin.jsonnet
+++ b/k8s/daemonsets/experiments/ndt-virtual-autojoin.jsonnet
@@ -44,7 +44,7 @@ exp.ExperimentNoIndex(expName, 'pusher-' + std.extVar('PROJECT_ID'), 'none', dat
               '-key=$(AUTOJOIN_API_KEY)',
               '-ipv4=@/metadata/external-ip',
               '-ipv6=@/metadata/external-ipv6',
-              '-iata=@/metadata/iata',
+              '-iata=@/metadata/iata-code',
               '-service=ndt',
               '-organization=mlab',
               '-output=/autonode',

--- a/k8s/daemonsets/experiments/ndt-virtual-autojoin.jsonnet
+++ b/k8s/daemonsets/experiments/ndt-virtual-autojoin.jsonnet
@@ -59,7 +59,7 @@ exp.ExperimentNoIndex(expName, 'pusher-' + std.extVar('PROJECT_ID'), 'none', dat
                 name: 'PROJECT',
                 valueFrom: {
                   fieldRef: {
-                    fieldPath: 'metadata.labels[mlab/project]',
+                    fieldPath: 'metadata.labels[\'mlab/project\']',
                   },
                 },
               },

--- a/k8s/daemonsets/experiments/ndt-virtual-autojoin.jsonnet
+++ b/k8s/daemonsets/experiments/ndt-virtual-autojoin.jsonnet
@@ -37,17 +37,14 @@ exp.ExperimentNoIndex(expName, 'pusher-' + std.extVar('PROJECT_ID'), 'none', dat
         containers+: [
           {
             name: 'register-node',
-            image: 'measurementlab/autojoin-register:v0.2.8',
+            image: 'measurementlab/autojoin-register:v0.2.9',
             imagePullPolicy: 'Always',
-            command: [
-              '/bin/sh',
-              '-c',
-              '/register -ipv4=$(cat /metadata/external-ip) -ipv6=$(cat /metadata/external-ipv6) -iata=$(cat /metadata/iata-code) $@',
-              '--',
-            ],
             args: [
               '-endpoint=https://autojoin-dot-$(PROJECT).appspot.com/autojoin/v0/node/register',
               '-key=$(AUTOJOIN_API_KEY)',
+              '-ipv4=@/metadata/external-ip',
+              '-ipv6=@/metadata/external-ipv6',
+              '-iata=@/metadata/iata',
               '-service=ndt',
               '-organization=mlab',
               '-output=/autonode',

--- a/k8s/daemonsets/experiments/ndt-virtual-autojoin.jsonnet
+++ b/k8s/daemonsets/experiments/ndt-virtual-autojoin.jsonnet
@@ -51,7 +51,7 @@ exp.ExperimentNoIndex(expName, 'pusher-' + std.extVar('PROJECT_ID'), 'none', dat
               '-ports=9990,9991,9992,9993',
               '-probability=@/metadata/probability',
               '-type=virtual',
-              '-uplink=1g',
+              '-uplink=7g',
             ],
             env: [
               {

--- a/k8s/daemonsets/experiments/ndt-virtual-autojoin.jsonnet
+++ b/k8s/daemonsets/experiments/ndt-virtual-autojoin.jsonnet
@@ -37,7 +37,7 @@ exp.ExperimentNoIndex(expName, 'pusher-' + std.extVar('PROJECT_ID'), 'none', dat
         containers+: [
           {
             name: 'register-node',
-            image: 'measurementlab/autojoin-register:v0.2.9',
+            image: 'measurementlab/autojoin-register:v0.2.11',
             imagePullPolicy: 'Always',
             args: [
               '-endpoint=https://autojoin-dot-$(PROJECT).appspot.com/autojoin/v0/node/register',
@@ -49,7 +49,9 @@ exp.ExperimentNoIndex(expName, 'pusher-' + std.extVar('PROJECT_ID'), 'none', dat
               '-organization=mlab',
               '-output=/autonode',
               '-ports=9990,9991,9992,9993',
-              '-probability=1.0',
+              '-probability=@/metadata/probability',
+              '-type=virtual',
+              '-uplink=1g',
             ],
             env: [
               {

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -890,6 +890,10 @@ local ExperimentNoIndex(name, bucket, anonMode, datatypesArchived, datatypesAuto
               secretName: 'locate-heartbeat-key',
             },
           },
+          {
+            emptyDir: {},
+            name: 'autonode',
+          },
           datatypes.volume(name),
           uuid.volume,
           data.volume(name),

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -556,7 +556,7 @@ local Jostler(expName, tcpPort, datatypesAutoloaded, hostNetwork, bucket) = [
   else []
 ;
 
-local UUIDAnnotator(expName, tcpPort, hostNetwork) = [
+local UUIDAnnotator(expName, tcpPort, hostNetwork, autojoin) = [
   {
     name: 'uuid-annotator',
     image: 'measurementlab/uuid-annotator:' + uuidAnnVersion,
@@ -571,6 +571,10 @@ local UUIDAnnotator(expName, tcpPort, hostNetwork) = [
       '-maxmind.url=gs://downloader-' + PROJECT_ID + '/Maxmind/current/GeoLite2-City.tar.gz',
       '-routeview-v4.url=gs://downloader-' + PROJECT_ID + '/RouteViewIPv4/current/routeview.pfx2as.gz',
       '-routeview-v6.url=gs://downloader-' + PROJECT_ID + '/RouteViewIPv6/current/routeview.pfx2as.gz',
+    ] + if autojoin then [
+      '-siteinfo.url=file:///autonode/annotation.json',
+      '-hostname=@/autonode/hostname',
+    ] else [
       '-siteinfo.url=https://siteinfo.' + PROJECT_ID + '.measurementlab.net/v2/sites/annotations.json',
       '-hostname=$(MLAB_NODE_NAME)',
     ],
@@ -618,7 +622,13 @@ local UUIDAnnotator(expName, tcpPort, hostNetwork) = [
         name: 'uuid-annotator-credentials',
         readOnly: true,
       },
-    ],
+    ] + if autojoin then [
+      {
+        mountPath: '/autojoin',
+        name: 'autojoin',
+        readOnly: true,
+      },
+    ] else []
   }] +
   if hostNetwork then
     [RBACProxy('uuid-annotator', tcpPort)]
@@ -667,7 +677,7 @@ local Revtr(expName, tcpPort) = [
 ]
 ;
 
-local Heartbeat(expName, tcpPort, hostNetwork, services) = [
+local Heartbeat(expName, tcpPort, hostNetwork, services, autojoin=false) = [
   {
     name: 'heartbeat',
     image: 'measurementlab/heartbeat:v0.14.50',
@@ -679,10 +689,16 @@ local Heartbeat(expName, tcpPort, hostNetwork, services) = [
       if PROJECT_ID == 'mlab-oti' then
         '-heartbeat-url=wss://locate.measurementlab.net/v2/platform/heartbeat?key=$(API_KEY)'
       else
-        '-heartbeat-url=wss://locate.' + PROJECT_ID + '.measurementlab.net/v2/platform/heartbeat?key=$(API_KEY)',
+        '-heartbeat-url=wss://locate.' + PROJECT_ID +
+        '.measurementlab.net/v2/platform/heartbeat?key=$(API_KEY)',
+    ] + if autojoin then [
+      '-registration-url=file:///autonode/registration.json',
+      '-hostname=@/autonode/hostname',
+    ] else [
       '-registration-url=https://siteinfo.' + PROJECT_ID + '.measurementlab.net/v2/sites/registration.json',
-      '-experiment=' + expName,
       '-hostname=' + expName + '-$(MLAB_NODE_NAME)',
+    ] + [
+      '-experiment=' + expName,
       '-node=$(MLAB_NODE_NAME)',
       '-pod=$(MLAB_POD_NAME)',
       '-namespace=$(MLAB_NAMESPACE)',
@@ -751,7 +767,13 @@ local Heartbeat(expName, tcpPort, hostNetwork, services) = [
         readOnly: true,
       },
       Metadata.volumemount,
-    ],
+    ] + if autojoin then [
+      {
+        mountPath: '/autojoin',
+        name: 'autojoin',
+        readOnly: true,
+      },
+    ] else [],
   }] +
   if hostNetwork then
     [RBACProxy('heartbeat', tcpPort)]
@@ -788,7 +810,7 @@ local MultiNetworkPolicy(expName, index, ports) = {
   },
 };
 
-local ExperimentNoIndex(name, bucket, anonMode, datatypesArchived, datatypesAutoloaded, hostNetwork, siteType='physical') = {
+local ExperimentNoIndex(name, bucket, anonMode, datatypesArchived, datatypesAutoloaded, hostNetwork, siteType='physical', autojoin=false) = {
   local autoAnnotations = contains("annotation2", datatypesAutoloaded),
   local datatypesPushed =  ['tcpinfo', 'pcap', 'scamper1', 'hopannotation2'] + datatypesArchived + if autoAnnotations then [] else ["annotation2"],
   local allVolumes = datatypesArchived + datatypesAutoloaded,
@@ -822,7 +844,7 @@ local ExperimentNoIndex(name, bucket, anonMode, datatypesArchived, datatypesAuto
             Tcpinfo(name, 9991, hostNetwork, anonMode),
             Traceroute(name, 9992, hostNetwork, anonMode),
             Pcap(name, 9993, hostNetwork, siteType, anonMode),
-            UUIDAnnotator(name, 9994, hostNetwork),
+            UUIDAnnotator(name, 9994, hostNetwork, autojoin),
             Pusher(name, 9995, datatypesPushed, hostNetwork, bucket),
           ] + if datatypesAutoloaded != [] then [Jostler(name, 9997, datatypesAutoloaded, hostNetwork, bucket)] else []),
         [if hostNetwork then 'serviceAccountName']: 'kube-rbac-proxy',
@@ -915,7 +937,7 @@ local Experiment(name, index, bucket, anonMode, datatypes=[], datatypesAutoloade
   // Returns a minimal experiment, suitable for adding a unique network config
   // before deployment. It is expected that most users of this library will use
   // Experiment().
-  ExperimentNoIndex(name, bucket, anonMode, datatypes, datatypesAutoloaded, hostNetwork, siteType='physical'):: ExperimentNoIndex(name, bucket, anonMode, datatypes, datatypesAutoloaded, hostNetwork, siteType),
+  ExperimentNoIndex(name, bucket, anonMode, datatypes, datatypesAutoloaded, hostNetwork, siteType='physical', autojoin=false):: ExperimentNoIndex(name, bucket, anonMode, datatypes, datatypesAutoloaded, hostNetwork, siteType, autojoin),
 
   // RBACProxy creates a https proxy for an http port. This allows us to serve
   // metrics securely over https, andto https-authenticate to only serve them to
@@ -944,7 +966,7 @@ local Experiment(name, index, bucket, anonMode, datatypes=[], datatypesAutoloade
   Jostler(expName, tcpPort, datatypesAutoloaded, hostNetwork, bucket):: Jostler(expName, tcpPort, datatypesAutoloaded, hostNetwork, bucket),
 
   // Returns a "container" configuration for the heartbeat service.
-  Heartbeat(expName, hostNetwork, services):: Heartbeat(expName, 9996, hostNetwork, services),
+  Heartbeat(expName, hostNetwork, services, autojoin=false):: Heartbeat(expName, 9996, hostNetwork, services, autojoin),
 
   // Returns a manifest for a MultiNetworkPolicy CRD object.
   MultiNetworkPolicy(expName, index, ports):: MultiNetworkPolicy(expName, index, ports),

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -1,4 +1,4 @@
-local ndtVersion = 'v0.20.20';
+local ndtVersion = 'v0.23.0';
 // The canary version is expected to be greater than or equal to
 // the current stable version.
 local ndtCanaryVersion = 'v0.20.20';

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -4,7 +4,7 @@ local ndtVersion = 'v0.20.20';
 local ndtCanaryVersion = 'v0.20.20';
 local PROJECT_ID = std.extVar('PROJECT_ID');
 // The uuid-annotator container image version.
-local uuidAnnVersion = 'v0.5.5';
+local uuidAnnVersion = 'v0.5.10';
 
 
 // The default grace period after k8s sends SIGTERM is 30s. We
@@ -680,7 +680,7 @@ local Revtr(expName, tcpPort) = [
 local Heartbeat(expName, tcpPort, hostNetwork, services, autojoin=false) = [
   {
     name: 'heartbeat',
-    image: 'measurementlab/heartbeat:v0.14.50',
+    image: 'measurementlab/heartbeat:v0.15.1',
     args: [
       if hostNetwork then
         '-prometheusx.listen-address=127.0.0.1:' + tcpPort

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -556,7 +556,7 @@ local Jostler(expName, tcpPort, datatypesAutoloaded, hostNetwork, bucket) = [
   else []
 ;
 
-local UUIDAnnotator(expName, tcpPort, hostNetwork, autojoin) = [
+local UUIDAnnotator(expName, tcpPort, hostNetwork, autojoin=false) = [
   {
     name: 'uuid-annotator',
     image: 'measurementlab/uuid-annotator:' + uuidAnnVersion,

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -624,8 +624,8 @@ local UUIDAnnotator(expName, tcpPort, hostNetwork, autojoin) = [
       },
     ] + if autojoin then [
       {
-        mountPath: '/autojoin',
-        name: 'autojoin',
+        mountPath: '/autonode',
+        name: 'autonode',
         readOnly: true,
       },
     ] else []
@@ -769,8 +769,8 @@ local Heartbeat(expName, tcpPort, hostNetwork, services, autojoin=false) = [
       Metadata.volumemount,
     ] + if autojoin then [
       {
-        mountPath: '/autojoin',
-        name: 'autojoin',
+        mountPath: '/autonode',
+        name: 'autonode',
         readOnly: true,
       },
     ] else [],

--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -691,13 +691,14 @@ local Heartbeat(expName, tcpPort, hostNetwork, services, autojoin=false) = [
       else
         '-heartbeat-url=wss://locate.' + PROJECT_ID +
         '.measurementlab.net/v2/platform/heartbeat?key=$(API_KEY)',
-    ] + if autojoin then [
-      '-registration-url=file:///autonode/registration.json',
-      '-hostname=@/autonode/hostname',
+    ] + (
+      if autojoin then [
+        '-registration-url=file:///autonode/registration.json',
+        '-hostname=@/autonode/hostname',
     ] else [
-      '-registration-url=https://siteinfo.' + PROJECT_ID + '.measurementlab.net/v2/sites/registration.json',
-      '-hostname=' + expName + '-$(MLAB_NODE_NAME)',
-    ] + [
+        '-registration-url=https://siteinfo.' + PROJECT_ID + '.measurementlab.net/v2/sites/registration.json',
+        '-hostname=' + expName + '-$(MLAB_NODE_NAME)',
+    ]) + [
       '-experiment=' + expName,
       '-node=$(MLAB_NODE_NAME)',
       '-pod=$(MLAB_POD_NAME)',

--- a/manage-cluster/create_k8s_configs.sh
+++ b/manage-cluster/create_k8s_configs.sh
@@ -45,6 +45,7 @@ gsutil cp gs://${!GCS_BUCKET_K8S}/cert-manager-credentials.json secrets/cert-man
 gsutil cp gs://${!GCS_BUCKET_K8S}/vector-credentials.json secrets/vector.json
 gsutil cp gs://${!GCS_BUCKET_K8S}/snmp-community/snmp.community secrets/snmp.community
 gsutil cp gs://${!GCS_BUCKET_K8S}/prometheus-htpasswd secrets/auth
+gsutil cp gs://${!GCS_BUCKET_K8S}/autojoin-api-key secrets/autojoin-api-key
 # The alertmanager-basicauth.yaml file is already a valid k8s YAML Secret
 # specification, so copy it directly to the secret-configs/ directory.
 gsutil cp gs://${!GCS_BUCKET_K8S}/alertmanager-basicauth.yaml secret-configs/.
@@ -77,4 +78,6 @@ kubectl create secret generic locate-heartbeat-key --from-file secrets/locate-he
     --dry-run=client -o json > secret-configs/locate-heartbeat-key.json
 kubectl create secret generic revtr-apikey --from-file secrets/revtr-apikey/ \
     --dry-run=client -o json > secret-configs/revtr-apikey.json
+kubectl create secret generic autojoin-api-key --from-file secrets/autojoin-api-key \
+    --dry-run=client -o json > secret-configs/autojoin-api-key.json
 

--- a/system.jsonnet
+++ b/system.jsonnet
@@ -30,6 +30,7 @@
     import 'k8s/daemonsets/experiments/packet-test.jsonnet',
   ] + (
     if std.extVar('PROJECT_ID') == 'mlab-sandbox' then [
+      import 'k8s/daemonsets/experiments/ndt-virtual-autojoin.jsonnet',
       // responsiveness commented out by Kinkade. It's stuck in sandbox and not
       // really being used, and must be run as root because is has
       // hostNetwork=true. If we want to resume the experiment we can just


### PR DESCRIPTION
This PR introduces a new DaemonSet manifest, ndt-virtual-autojoin.jsonnet, allowing a VM to leverage the Autojoin system to get a DNS record. The manifest has relatively few differences from the regular ndt-virtual manifest, other than adding a new "register-node" container which runs the autonode registration client, and a new volume to hold the autonode configurations. 

The other changes are largely to templates.jsonnet, which introduces a new "autojoin" function parameter to `UUIDAnnotator()` and `Heartbeat()`, which modifies their behavior depending on whether the machine is autojoined or not.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/919)
<!-- Reviewable:end -->
