### PR TITLE
Revert "Deploys MultiNetworkPolicy DaemonSet to all production machin…

### DIFF
--- a/k8s/daemonsets/core/multi-networkpolicy.jsonnet
+++ b/k8s/daemonsets/core/multi-networkpolicy.jsonnet
@@ -29,6 +29,7 @@
         hostNetwork: true,
         nodeSelector: {
           'kubernetes.io/arch': 'amd64',
+          [if std.extVar('PROJECT_ID') == 'mlab-oti' then 'mlab/run']: 'multi-networkpolicy-canary',
         },
         tolerations: [
           {


### PR DESCRIPTION
…es (#918)"

This reverts commit cdbfb698676e456e69d4cd7acac03e7264ba549e.

For unknown reasons the multi-networkpolicy DaemonSet caused memory exhaustion on all API machines, rending the API inoperable.