### PR TITLE
Adds experimental deployment of CAIDA Ark, pinned to sanbox

### DIFF
--- a/k8s/daemonsets/core/ark.jsonnet
+++ b/k8s/daemonsets/core/ark.jsonnet
@@ -1,0 +1,85 @@
+local expName = 'ark';
+
+{
+  apiVersion: 'apps/v1',
+  kind: 'DaemonSet',
+  metadata: {
+    name: expName,
+    namespace: expName,
+  },
+  spec: {
+    selector: {
+      matchLabels: {
+        workload: expName,
+      },
+    },
+    template: {
+      metadata: {
+        annotations: {
+          'prometheus.io/scrape': 'true',
+          'prometheus.io/scheme': 'http'
+        },
+        labels: {
+          workload: expName,
+        },
+      },
+      spec: {
+        containers: [
+          {
+            env: [
+              {
+                name: 'ARK_AUTH_TOKEN',
+                value: 'replaceme',
+              },
+              {
+                name: 'ARK_PROMETHEUS_EXPORTER',
+                value: '1',
+              },
+              {
+                name: 'DISABLE_ARK_ACTIVITY_TEAM',
+                value: '1'
+              },
+              {
+                name: 'DISABLE_ARK_ACTIVITY_v6',
+                value: '1'
+              },
+              {
+                name: 'SCAMPER_REMOTE',
+                value: ''
+              },
+            ],
+            image: 'caida/ark:latest',
+            name: expName,
+            ports: [
+              {
+                containerPort: 8000,
+              },
+            ],
+            volumeMounts: [
+              {
+                mountPath: '/etc/ark',
+                name: 'ark',
+              },
+            ],
+          },
+        ],
+        nodeSelector: {
+          'mlab/type': 'physical',
+        },
+        volumes: [
+          {
+            emptyDir: {},
+            name: 'ark',
+          },
+        ]
+      },
+    },
+    updateStrategy: {
+      rollingUpdate: {
+        maxUnavailable: 2,
+      },
+      type: 'RollingUpdate',
+    },
+  },
+}
+

--- a/k8s/daemonsets/core/ark.jsonnet
+++ b/k8s/daemonsets/core/ark.jsonnet
@@ -45,7 +45,7 @@ local expName = 'ark';
                 value: '1'
               },
               {
-                name: 'DISABLE_ARK_ACTIVITY_v6',
+                name: 'DISABLE_ARK_ACTIVITY_V6',
                 value: '1'
               },
               {

--- a/k8s/daemonsets/core/ark.jsonnet
+++ b/k8s/daemonsets/core/ark.jsonnet
@@ -5,7 +5,6 @@ local expName = 'ark';
   kind: 'DaemonSet',
   metadata: {
     name: expName,
-    namespace: expName,
   },
   spec: {
     selector: {

--- a/k8s/daemonsets/core/ark.jsonnet
+++ b/k8s/daemonsets/core/ark.jsonnet
@@ -15,11 +15,7 @@ local expName = 'ark';
     template: {
       metadata: {
         annotations: {
-          'k8s.v1.cni.cncf.io/networks': [
-            {
-              name: 'index2ip-index-4-conf',
-            },
-          ],
+          'k8s.v1.cni.cncf.io/networks': '[{ "name": "index2ip-index-4-conf" }]',
           'prometheus.io/scrape': 'true',
           'prometheus.io/scheme': 'http',
         },

--- a/k8s/daemonsets/core/ark.jsonnet
+++ b/k8s/daemonsets/core/ark.jsonnet
@@ -16,8 +16,13 @@ local expName = 'ark';
     template: {
       metadata: {
         annotations: {
+          'k8s.v1.cni.cncf.io/networks': [
+            {
+              name: 'index2ip-index-4-conf',
+            },
+          ],
           'prometheus.io/scrape': 'true',
-          'prometheus.io/scheme': 'http'
+          'prometheus.io/scheme': 'http',
         },
         labels: {
           workload: expName,

--- a/k8s/daemonsets/core/ark.jsonnet
+++ b/k8s/daemonsets/core/ark.jsonnet
@@ -67,6 +67,10 @@ local expName = 'ark';
             ],
           },
         ],
+        dnsPolicy: 'None',
+        dnsConfig: {
+          nameservers: ['8.8.8.8', '8.8.4.4'],
+        },
         nodeSelector: {
           'mlab/type': 'physical',
         },

--- a/system.jsonnet
+++ b/system.jsonnet
@@ -31,6 +31,9 @@
   ] + (
     if std.extVar('PROJECT_ID') == 'mlab-sandbox' then [
       import 'k8s/daemonsets/experiments/ndt-virtual-autojoin.jsonnet',
+      // We are experimenting with the idea of hosting CAIDA Ark instances on
+      // the platform.
+      import 'k8s/daemonsets/core/ark.jsonnet',
       // responsiveness commented out by Kinkade. It's stuck in sandbox and not
       // really being used, and must be run as root because is has
       // hostNetwork=true. If we want to resume the experiment we can just


### PR DESCRIPTION
This is so far just an experiment to see what it looks like to run CAIDA Ark software on the M-Lab platform.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/921)
<!-- Reviewable:end -->
