### PR TITLE
Removes -ports flag from ndt-virtual-autojoin register container

### DIFF
--- a/k8s/daemonsets/experiments/ndt-virtual-autojoin.jsonnet
+++ b/k8s/daemonsets/experiments/ndt-virtual-autojoin.jsonnet
@@ -48,7 +48,6 @@ exp.ExperimentNoIndex(expName, 'pusher-' + std.extVar('PROJECT_ID'), 'none', dat
               '-service=ndt',
               '-organization=mlab',
               '-output=/autonode',
-              '-ports=9990,9991,9992,9993',
               '-probability=@/metadata/probability',
               '-type=virtual',
               '-uplink=7g',


### PR DESCRIPTION
We don't want the Autojoin system to emit monitoring targets for M-Lab-managed VMs. M-Lab VMs already have all the monitoring they need.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/924)
<!-- Reviewable:end -->
