### PR TITLE
Updates ingress-nginx controller configs to work with v1.12.0

### DIFF
--- a/helm/ingress-nginx-values-overrides.yaml
+++ b/helm/ingress-nginx-values-overrides.yaml
@@ -1,3 +1,5 @@
+configAnnotations:
+  annotations-risk-level: Critical
 controller:
   admissionWebhooks:
     enabled: false

--- a/helm/ingress-nginx-values-overrides.yaml
+++ b/helm/ingress-nginx-values-overrides.yaml
@@ -1,8 +1,8 @@
-configAnnotations:
-  annotations-risk-level: Critical
 controller:
   admissionWebhooks:
     enabled: false
+  configAnnotations:
+    annotations-risk-level: Critical
   hostNetwork: true
   nodeSelector:
     run: prometheus-server

--- a/helm/ingress-nginx-values-overrides.yaml
+++ b/helm/ingress-nginx-values-overrides.yaml
@@ -1,7 +1,8 @@
 controller:
   admissionWebhooks:
     enabled: false
-  configAnnotations:
+  config:
+    allow-snippet-annotations: "true"
     annotations-risk-level: Critical
   hostNetwork: true
   nodeSelector:


### PR DESCRIPTION
v1.12.0 was a pretty big release, and they modified some of the default security settings, which broke TLS for us. We should probably reconsider our configuration to work with the default settings, but for now these changes seem to mitigate the issue.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/925)
<!-- Reviewable:end -->
