### PR TITLE
Use different revtrvp config in sandbox and staging 

### DIFF
--- a/k8s/daemonsets/experiments/revtr.jsonnet
+++ b/k8s/daemonsets/experiments/revtr.jsonnet
@@ -1,4 +1,8 @@
 local exp = import '../templates.jsonnet';
+local plvp_config = if std.extVar('PROJECT_ID') == 'mlab-oti' then
+    '/plvp_mlab.config.production'
+  else
+    '/plvp_mlab.config.sandbox';
 
 [
   exp.Experiment('revtr', 3, 'pusher-' + std.extVar('PROJECT_ID'), 'none', [], []) + {
@@ -11,7 +15,7 @@ local exp = import '../templates.jsonnet';
               image: 'measurementlab/revtrvp:v0.3.2',
               args: [
                 '/server.crt',
-                '/plvp.config',
+                plvp_config
               ],
               securityContext: {
                 capabilities: {
@@ -47,4 +51,3 @@ local exp = import '../templates.jsonnet';
     }
   },
 ]
-

--- a/k8s/daemonsets/experiments/revtr.jsonnet
+++ b/k8s/daemonsets/experiments/revtr.jsonnet
@@ -12,7 +12,7 @@ local plvp_config = if std.extVar('PROJECT_ID') == 'mlab-oti' then
           containers+: [
             {
               name: 'revtrvp',
-              image: 'measurementlab/revtrvp:v0.3.2',
+              image: 'measurementlab/revtrvp:v0.4.0',
               args: [
                 '/server.crt',
                 plvp_config


### PR DESCRIPTION
Sandbox and staging will use a config with debugging enabled, while production will have it disabled.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/927)
<!-- Reviewable:end -->
