### PR TITLE
Upgrades k8s to v1.29.15

### DIFF
--- a/k8s/certificates/measurement-lab.org.jsonnet
+++ b/k8s/certificates/measurement-lab.org.jsonnet
@@ -8,10 +8,8 @@
   spec: {
     dnsNames: (if std.extVar('PROJECT_ID') == 'mlab-oti' then [
       '*.measurement-lab.org',
-      '*.mlab.autojoin.measurement-lab.org',
     ] else []) + [
       '*.' + std.extVar('PROJECT_ID') + '.measurement-lab.org',
-      '*.mlab.' + std.split(std.extVar('PROJECT_ID'), '-')[1] + '.measurement-lab.org',
     ],
     issuerRef: {
       group: 'cert-manager.io',

--- a/k8s/clusterissuers/letsencrypt-staging.jsonnet
+++ b/k8s/clusterissuers/letsencrypt-staging.jsonnet
@@ -44,10 +44,8 @@
           selector: {
             dnsNames: (if std.extVar('PROJECT_ID') == 'mlab-oti' then [
               '*.measurement-lab.org',
-              '*.mlab.autojoin.measurement-lab.org',
             ] else []) + [
               '*.' + std.extVar('PROJECT_ID') + '.measurement-lab.org',
-              '*.mlab.' + std.split(std.extVar('PROJECT_ID'), '-')[1] + '.measurement-lab.org',
             ],
           },
         },

--- a/k8s/clusterissuers/letsencrypt.jsonnet
+++ b/k8s/clusterissuers/letsencrypt.jsonnet
@@ -39,10 +39,8 @@
           selector: {
             dnsNames: (if std.extVar('PROJECT_ID') == 'mlab-oti' then [
               '*.measurement-lab.org',
-              '*.mlab.autojoin.measurement-lab.org',
             ] else []) + [
               '*.' + std.extVar('PROJECT_ID') + '.measurement-lab.org',
-              '*.mlab.' + std.split(std.extVar('PROJECT_ID'), '-')[1] + '.measurement-lab.org',
             ],
           },
         },

--- a/manage-cluster/k8s_deploy.conf
+++ b/manage-cluster/k8s_deploy.conf
@@ -28,25 +28,25 @@ PROM_BASE_NAME="prometheus-${GCE_BASE_NAME}"
 # we learn more.
 GCE_API_SCOPES="cloud-platform"
 
-K8S_VERSION="v1.28.14" # https://github.com/kubernetes/kubernetes/releases
-K8S_CNI_VERSION="v1.5.1" # https://github.com/containernetworking/plugins/releases
-K8S_CRICTL_VERSION="v1.28.0" # https://github.com/kubernetes-sigs/cri-tools/releases
+K8S_VERSION="v1.29.15" # https://github.com/kubernetes/kubernetes/releases
+K8S_CNI_VERSION="v1.8.0" # https://github.com/containernetworking/plugins/releases
+K8S_CRICTL_VERSION="v1.29.0" # https://github.com/kubernetes-sigs/cri-tools/releases
 # FLANNEL is for the flannel DaemonSet, whereas FLANNELCNI is for the CNI
 # plugin located at /opt/cni/bin (used by the kubelet).
-K8S_FLANNEL_VERSION="v0.25.6" # https://github.com/flannel-io/flannel/releases
-K8S_FLANNELCNI_VERSION="v1.5.1-flannel3" # https://github.com/flannel-io/cni-plugin/releases
-K8S_TOOLING_VERSION="v0.17.7" # https://github.com/kubernetes/release/releases
+K8S_FLANNEL_VERSION="v0.27.3" # https://github.com/flannel-io/flannel/releases
+K8S_FLANNELCNI_VERSION="v1.7.1-flannel2" # https://github.com/flannel-io/cni-plugin/releases
+K8S_TOOLING_VERSION="v0.18.0" # https://github.com/kubernetes/release/releases
 # kubeadm installs and managed etcd automatically. Try to keep this version of
 # etcdctl more or less in line with the default etcd version that kubeadm uses
 # for any given release of k8s. For example, see this:
 # https://github.com/kubernetes/kubernetes/blob/v1.28.14/cmd/kubeadm/app/constants/constants.go#L308
-ETCDCTL_VERSION="v3.5.15"
-K8S_HELM_VERSION="v3.16.1" # https://github.com/helm/helm/releases
-K8S_VECTOR_VERSION="0.41.1-debian" # https://github.com/vectordotdev/vector/releases
-K8S_VECTOR_CHART="0.36.1" # https://github.com/vectordotdev/helm-charts/releases
-K8S_KURED_VERSION="1.16.0" # https://github.com/kubereboot/kured/releases
-K8S_KURED_CHART="5.5.0" # https://github.com/kubereboot/charts/releases
-K8S_CERTMANAGER_VERSION="v1.15.3" # https://github.com/cert-manager/cert-manager/releases
+ETCDCTL_VERSION="v3.5.16"
+K8S_HELM_VERSION="v3.18.6" # https://github.com/helm/helm/releases
+K8S_VECTOR_VERSION="0.49.0-debian" # https://github.com/vectordotdev/vector/releases
+K8S_VECTOR_CHART="0.45.0" # https://github.com/vectordotdev/helm-charts/releases
+K8S_KURED_VERSION="1.19.0" # https://github.com/kubereboot/kured/releases
+K8S_KURED_CHART="5.10.0" # https://github.com/kubereboot/charts/releases
+K8S_CERTMANAGER_VERSION="v1.18.2" # https://github.com/cert-manager/cert-manager/releases
 K8S_CERTMANAGER_DNS01_SA="cert-manager-dns01-solver"
 K8S_CERTMANAGER_SA_KEY="cert-manager-credentials.json"
 K8S_CA_FILES="ca.crt ca.key sa.key sa.pub front-proxy-ca.crt front-proxy-ca.key etcd/ca.crt etcd/ca.key"


### PR DESCRIPTION
In addition to upgrading k8s, these changes also upgrade various other related services e.g., Helm, Certmanager, Flannel, etc.

Also, this PR removes the Autojoin wildcard domain names from the cert-manager configurations. We are not using them, and they break cert-manager because the Autojoin domains are hosted in Cloud DNS in the mlab-autojoin project, but the cert-manager service account only has permission to up update DNS records in the mlab-oti project. cert-manager needs to be able to update DNS records to support the dns01 ACME validation scheme.

All nodes and workloads running as expected in mlab-sandbox.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/932)
<!-- Reviewable:end -->
