### PR TITLE
Adds an "fyi_project=mlab-oti" to NDT test volume doubled FYI alert

### DIFF
--- a/manage-cluster/k8s_deploy.conf
+++ b/manage-cluster/k8s_deploy.conf
@@ -28,9 +28,9 @@ PROM_BASE_NAME="prometheus-${GCE_BASE_NAME}"
 # we learn more.
 GCE_API_SCOPES="cloud-platform"
 
-K8S_VERSION="v1.31.13" # https://github.com/kubernetes/kubernetes/releases
+K8S_VERSION="v1.30.14" # https://github.com/kubernetes/kubernetes/releases
 K8S_CNI_VERSION="v1.8.0" # https://github.com/containernetworking/plugins/releases
-K8S_CRICTL_VERSION="v1.31.1" # https://github.com/kubernetes-sigs/cri-tools/releases
+K8S_CRICTL_VERSION="v1.30.1" # https://github.com/kubernetes-sigs/cri-tools/releases
 # FLANNEL is for the flannel DaemonSet, whereas FLANNELCNI is for the CNI
 # plugin located at /opt/cni/bin (used by the kubelet).
 K8S_FLANNEL_VERSION="v0.27.3" # https://github.com/flannel-io/flannel/releases


### PR DESCRIPTION
Testing volume is far too variable in sandbox and staging, causing the FYI
alert for when NDT testing volume more than doubled to fire. This commit adds a
new fyi_project=mlab-oti label to this FYI alert, and the Alertmanage will
only match this label when it is the version running in mlab-oti.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/938)
<!-- Reviewable:end -->
