### PR TITLE
Increase revtr-sidecar testing percentage from 25% to 50%

### DIFF
--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -686,7 +686,7 @@ local Revtr(expName, tcpPort) = [
       '-revtr.hostname=revtr.ccs.neu.edu',
       '-revtr.grpcPort=9999',
       '-prometheus.addr=$(PRIVATE_IP):'+tcpPort,
-      '-revtr.sampling=4', // 100/x == 25%
+      '-revtr.sampling=2', // 100/x == 50%
       '-revtr.APIKey=$(REVTR_APIKEY)',
       '-loglevel=debug',
     ],


### PR DESCRIPTION
Kevin Vermeulen asked me to increase the revtr-sidecar test rate in the #mlab-revtr-shared Slack channel.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/946)
<!-- Reviewable:end -->
