### PR TITLE
Raise pusher's open-file limit to survive containerd 2.x default

### DIFF
--- a/k8s/daemonsets/templates.jsonnet
+++ b/k8s/daemonsets/templates.jsonnet
@@ -457,6 +457,17 @@ local Pusher(expName, tcpPort, datatypes, hostNetwork, bucket) = [
     local version='v1.20.3',
     name: 'pusher',
     image: 'measurementlab/pusher:'+version,
+    // containerd 2.x defaults a container's soft RLIMIT_NOFILE to 1024 (hard
+    // limit 524288). Pusher exhausts a 1024 soft limit (inotify watches over
+    // the spool tree plus open file handles for tarring/uploading), which
+    // silently stalls uploads and loses data. Wrap the entrypoint in a shell
+    // that raises the soft limit to the hard limit before exec'ing pusher.
+    command: [
+      '/bin/sh',
+      '-c',
+      'ulimit -n "$(ulimit -Hn)"; exec /pusher "$@"',
+      '--',
+    ],
     args: [
       if hostNetwork then
         '-prometheusx.listen-address=127.0.0.1:' + tcpPort


### PR DESCRIPTION
Ubuntu's jammy-security update bumped containerd from 1.7.x to 2.x, whose packaged systemd unit no longer sets a high LimitNOFILE. Containers now inherit a soft RLIMIT_NOFILE of 1024. pusher does not raise its own soft limit and exhausts 1024 (one inotify watch per spool directory plus open file handles for tarring), which silently stalls uploads and loses data.

Wrap pusher's entrypoint in a shell that raises the soft limit to the hard limit before exec'ing /pusher.

Co-Authored-By: Claude Opus 4.8

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/k8s-support/947)
<!-- Reviewable:end -->
